### PR TITLE
Release Platty agent plugin v0.0.3 build 202606300812

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,132 +1,58 @@
-# Platty Agent Plugin
+# Platty
 
-This repository contains the public Platty agent plugin and skills for Codex and Claude Code.
+Platty is a codebase reverse-engineering engine: it reads your repository,
+extracts a source-of-truth (SOT) of what the code actually does — routes, data
+models, database access, API calls, events, jobs, external services — and turns
+it into technical and business documentation you can search and trust.
 
-Platty helps agents operate the Platty CLI for repository analysis, target review, generated documentation/business-output workflows, synchronization, retrieval, and human-recorded memory workflows.
+**Proprietary (not open source) · local-first · this repo is the public Platty agent-plugin distribution surface.**
 
-## What This Repository Contains
+## Start here
 
-- A Codex-compatible plugin manifest.
-- A Claude Code-compatible plugin manifest.
-- Platty agent skills under `plugins/platty/skills/`.
-- Claude Code session-start hooks that load the Platty entry skill. Codex uses native skill loading without plugin hooks.
-- Marketplace metadata for installing the plugin from this repository.
+- New to Platty? **[GETTING_STARTED.md](GETTING_STARTED.md)** — CLI install, agent-plugin install, and your first project.
+- Full usage manual: **[guide/en/usage-guide.md](guide/en/usage-guide.md)** · 한국어 **[guide/ko/usage-guide.md](guide/ko/usage-guide.md)**
 
-## What This Repository Does Not Contain
+## What Platty does
 
-This repository does not include the Platty engine, CLI implementation, backend, SaaS service, release build pipeline, internal test suite, or private product planning documents.
+- **Analyzes your code locally** — static analysis on your own machine; it never uploads or executes your source.
+- **Extracts a source-of-truth** — a searchable map of routes, models, data access, integrations, and events, grounded in real code.
+- **Generates and keeps docs fresh** — technical and business documentation, with every claim traceable back to source.
 
-Those components are proprietary to Paradigm Shift Labs. This repository is the public distribution surface for the agent plugin only.
+See **[guide/en/how-platty-works.md](guide/en/how-platty-works.md)** for the concepts and the local-first trust model.
 
-## Access
+## Quick install
 
-Platty runs as a local CLI with **no login, account, or sign-up required** — install it and run. The plugin simply teaches your agent how to drive that CLI; you also need the `platty` CLI installed and your own AI provider credentials for the documentation step.
-
-Platty is proprietary software (not open source); installation and use are governed by `LICENSE.md`. The plugin does not by itself grant access to private projects or any repository data.
-
-## Requirements
-
-- Node.js 20 or newer.
-- npm.
-- The `platty` CLI installed and available on `PATH`.
-- Codex or Claude Code with plugin support.
-
-Check your local environment:
-
-```bash
-node --version
-npm --version
-platty version
-```
-
-To confirm the global binary is on `PATH`, use the command for your shell:
-
-```bash
-# macOS, Linux, or Git Bash
-command -v platty
-```
-
-```powershell
-# PowerShell
-Get-Command platty
-```
-
-```cmd
-:: Command Prompt
-where platty
-```
-
-New to Platty? Start with [GETTING_STARTED.md](GETTING_STARTED.md). It walks
-through CLI installation, agent plugin installation, and your first Platty
-project.
-
-## Install The Platty CLI
-
-When the public npm package is available:
+Install the CLI (Node.js 20–24; Node 25 is not supported yet):
 
 ```bash
 npm install -g @paradigmshift/platty
-```
-
-Verify the global binary:
-
-```bash
-# macOS, Linux, or Git Bash
-command -v platty
-```
-
-```powershell
-# PowerShell
-Get-Command platty
-```
-
-```cmd
-:: Command Prompt
-where platty
-```
-
-Then run:
-
-```bash
 platty version
-platty --help
 ```
 
-## Install The Agent Plugin
-
-For Codex:
+Install the agent plugin for your runtime:
 
 ```bash
+# Codex
 codex plugin marketplace add paradigmshift-labs/platty
 codex plugin add platty@platty
 ```
 
-For Claude Code:
-
 ```text
+# Claude Code
 /plugin marketplace add paradigmshift-labs/platty
 /plugin install platty@platty
 ```
 
-After installing or updating the plugin, start a new agent session so the latest skills are loaded. Claude Code also loads the latest hook.
+After installing or updating the plugin, start a new agent session so the latest
+skills load. Then, from the repository you want to analyze, run:
 
-## Included Skills
+```bash
+platty setup
+```
 
-The plugin includes these Platty skills:
-
-- `platty:using-platty`
-- `platty:platty-cli-router`
-- `platty:platty-setup`
-- `platty:platty-static-analysis`
-- `platty:platty-docs-target-curation`
-- `platty:platty-generated-docs`
-- `platty:platty-sync`
-- `platty:platty-retrieval`
-- `platty:platty-sdd-spec`
-- `platty:platty-sdd-design`
-- `platty:platty-memory`
-
-Start with `platty:using-platty` when you are not sure which workflow applies.
+`platty setup` helps you choose or create a project, register repositories, and
+shows the next action at each step. The full command reference and the agent /
+CLI walkthroughs are in the [usage guide](guide/en/usage-guide.md).
 
 ## Documentation
 
@@ -136,98 +62,28 @@ and Korean:
 | Topic | English | 한국어 |
 | --- | --- | --- |
 | How Platty works (concepts, local-first, why you can trust it) | [EN](guide/en/how-platty-works.md) | [KO](guide/ko/how-platty-works.md) |
-| Usage guide (install, agent or CLI usage, commands) | [EN](guide/en/usage-guide.md) | [KO](guide/ko/usage-guide.md) |
+| Usage guide (install, AI provider, agent or CLI usage, commands) | [EN](guide/en/usage-guide.md) | [KO](guide/ko/usage-guide.md) |
 | Support matrix (languages, frameworks, ORMs, vendors) | [EN](guide/en/support-matrix.md) | [KO](guide/ko/support-matrix.md) |
 
-## Recommended First Run
+## This repository
 
-From the repository you want Platty to analyze, run:
+This repository is the **public distribution surface for the Platty agent
+plugin** — the skills that teach Codex and Claude Code how to drive the Platty
+CLI.
 
-```bash
-platty setup
-```
+**Contains:** Codex and Claude Code plugin manifests, the Platty skills under
+`plugins/platty/skills/`, Claude Code session-start hooks, and marketplace
+metadata.
 
-`platty setup` helps you choose or create a Platty project, register
-repositories, inspect current progress, and see the next action.
+**Does not contain:** the Platty engine, CLI implementation, backend, SaaS
+service, or private planning docs — those are proprietary to Paradigm Shift Labs.
 
-Use plain `platty setup` for human-guided setup.
-
-Use JSON output when an agent, script, or automation needs to inspect CLI state exactly,
-for example `platty setup --json`.
-
-## Workflow
-
-Most users should start with `platty setup`.
-
-The full Platty workflow is:
-
-```text
-setup -> analyze -> targets -> generate-docs
-```
-
-The CLI shows the next action based on project state. The agent plugin skills
-explain when to continue, auto-confirm EPICs through returned CLI commands,
-refresh existing generated outputs after source changes, or recover from a
-failed run.
-
-## Generated Docs Providers
-
-Generated docs use Codex CLI by default:
-
-```bash
-platty generate-docs run --project PROJECT --json
-```
-
-You can choose another provider when starting generation:
-
-```bash
-platty generate-docs run --project PROJECT --provider claude_api --json
-```
-
-If generation reaches EPIC confirmation, preserve the same provider when running
-the returned confirmation command:
-
-```bash
-platty generate-docs confirm-epics --project PROJECT --run-id RUN --provider claude_api --json
-```
-
-Supported providers are `codex_cli`, `claude_code`, and `claude_api`.
-`claude_api` requires `ANTHROPIC_API_KEY` in your shell environment or
-`~/.platty/.env`.
-
-For advanced recovery, if `build_docs` failed, repair the same run with
-`platty generate-docs retry-failed --project PROJECT --stage build_docs --run-id RUN`,
-then follow the returned `nextCommand` or `nextAction.command`.
-Commands such as `generate-docs agent-next` and `generate-docs agent-submit`
-are for manual worker recovery flows, not the normal first-run path.
-
-## Choose A Platty Project
-
-A Platty project is a workspace for related repositories and generated
-knowledge.
-
-Create a new project for a new product, app, customer workspace, or system area.
-Reuse an existing project when the repository already belongs to registered
-work. Add multiple repositories to the same project when they are part of one
-architecture.
-
-## Manual Setup
-
-If you prefer explicit commands, initialize Platty, create or select a project,
-register repositories, and ask Platty what comes next:
-
-```bash
-platty init
-platty project list
-platty project create "My Project" --description "Repository analysis workspace"
-platty project use PROJECT
-platty repo add REPOSITORY_PATH --project PROJECT
-platty status --project PROJECT
-```
-
-Follow the `Next:` line returned by `platty status` or by the previous command response.
-
-## Repository Layout
+Included skills: `platty:using-platty`, `platty:platty-cli-router`,
+`platty:platty-setup`, `platty:platty-static-analysis`,
+`platty:platty-docs-target-curation`, `platty:platty-generated-docs`,
+`platty:platty-sync`, `platty:platty-retrieval`, `platty:platty-sdd-spec`,
+`platty:platty-sdd-design`, `platty:platty-memory`. Start with
+`platty:using-platty` when you are not sure which workflow applies.
 
 ```text
 .agents/plugins/marketplace.json
@@ -238,32 +94,25 @@ plugins/platty/
   README.md
   hooks/
   skills/
+guide/
 ```
 
-The `plugins/platty/README.md` file contains the detailed CLI workflow guide used by the plugin.
+## Requirements
 
-## License And Use
+- Node.js 20–24 (Node 25 is not supported yet).
+- npm.
+- macOS or Linux. Windows: official support is planned — it may work today but you can hit issues.
+- The `platty` CLI on your `PATH`, plus Codex or Claude Code for the plugin.
+- Your own AI provider credentials for the documentation step. No login, account, or sign-up is required to run Platty.
 
-This repository is source-available for installation and review. It is not an open-source license grant.
+## License and support
 
-Use of the Platty agent plugin is governed by `LICENSE.md` and the Platty Terms of Service. Unless expressly permitted there, you may not redistribute, sublicense, sell, host, or provide this plugin to third parties, or use it to provide a competing product or service.
+Platty is proprietary software (not open source); installation and use are
+governed by [LICENSE.md](LICENSE.md). Unless expressly permitted there, you may
+not redistribute, sublicense, sell, host, or provide it to third parties, or use
+it to provide a competing product or service.
 
-Suggested package metadata:
-
-```json
-{
-  "license": "SEE LICENSE IN LICENSE.md"
-}
-```
-
-## Support
-
-For licensing, billing, or feature questions, use the official Platty support channel.
-
-For plugin installation issues, include:
-
-- your agent runtime and version,
-- your operating system,
-- the output of `platty version`,
-- the exact command that failed,
-- the full error output when available.
+For licensing, billing, or feature questions, use the official Platty support
+channel. For plugin installation issues, include your agent runtime and version,
+your operating system, the output of `platty version`, the exact command that
+failed, and the full error output.

--- a/guide/en/usage-guide.md
+++ b/guide/en/usage-guide.md
@@ -23,6 +23,8 @@
 - [Keeping docs fresh](#keeping-docs-fresh)
 - [Command reference](#command-reference)
 - [Troubleshooting](#troubleshooting)
+- [Support](#support)
+- [License](#license)
 
 ---
 
@@ -103,15 +105,27 @@ docs, so you choose a provider when you run it:
 > time — the three above are what's available today.
 
 ```bash
-# Example: generate docs with your own API key provider
+# Generated docs default to codex_cli; pass --provider to choose another
 platty generate-docs run --provider claude_api --model <model>
 ```
 
+`generate-docs` defaults to `codex_cli`. The `claude_api` provider reads your key
+from the `ANTHROPIC_API_KEY` environment variable (or `~/.platty/.env`). If
+generation pauses for EPIC confirmation, **keep the same `--provider`** on the
+follow-up `generate-docs confirm-epics` command.
+
 > 💡 **About cost:** the documentation phase sends your extracted map to an AI
 > model, so it consumes provider tokens and may incur cost on your AI provider
-> account.
-> The static-analysis phase does not. Start on a small repository to gauge usage
-> before running large projects.
+> account. The static-analysis phase does not — start on a small repository to
+> gauge usage before running large projects.
+
+### Recovery
+
+If a stage reports failed tasks, repair the same run with
+`platty generate-docs retry-failed --stage <stage> --run-id <id>`, then re-run
+`platty generate-docs run` (it resumes and re-extracts only the incomplete
+work). The `generate-docs agent-next` / `agent-submit` commands are for manual
+worker recovery, not the normal first run.
 
 ---
 
@@ -206,6 +220,12 @@ with every claim traceable to real code. From here you keep them fresh with
 > A repository path is **never** a project selector. Always resolve a project
 > first with `project create` / `project use` (or pass `--project <selector>`).
 
+> 💡 **What's a Platty project?** A project is a workspace for related
+> repositories and the knowledge generated from them. Create a new project for a
+> new product, app, or system area; reuse an existing one when the repository
+> already belongs to registered work; add several repositories to one project
+> when they form a single architecture.
+
 ---
 
 ## Output modes (human vs. agent)
@@ -217,6 +237,11 @@ Platty has two output modes:
 - **Agent / JSON mode (`--json`)** — machine-readable output. Automation,
   scripts, and AI agents should pass `--json` and read `data`, `nextAction`,
   `warnings`, `errors`, and `evidenceRefs`.
+
+The CLI owns the current state and the next action: most commands return a
+`Next:` hint (or `nextCommand` / `nextAction.command` in JSON). Following those
+returned commands is the intended way to drive Platty — the agent skills simply
+automate it.
 
 ```bash
 platty status
@@ -361,12 +386,32 @@ validation/user error.
 
 ---
 
+## Support
+
+For licensing, billing, or feature questions, use the official Platty support
+channel. When reporting an issue, include:
+
+- your runtime (and the agent runtime/version, if using one),
+- your operating system,
+- the output of `platty version`,
+- the exact command that failed,
+- the full error output.
+
+---
+
+## License
+
+Platty is **proprietary** software (not open source), licensed under the
+[PolyForm Internal Use License](../../LICENSE.md) for your own internal use.
+Unless expressly permitted there, you may not redistribute, sublicense, sell,
+host, or provide it to third parties, or use it to provide a competing product
+or service.
+
+---
+
 ## See also
 
 - **[How Platty Works](how-platty-works.md)** — concepts, two-phase model, and
   the local-first trust model.
 - **[Support Matrix](support-matrix.md)** — supported languages, frameworks,
   ORMs, HTTP clients, and SaaS vendors.
-
-Platty is proprietary software, licensed under the
-[PolyForm Internal Use License](../../LICENSE.md). It is not open source.

--- a/guide/ko/usage-guide.md
+++ b/guide/ko/usage-guide.md
@@ -24,6 +24,8 @@
 - [문서를 최신으로 유지하기](#문서를-최신으로-유지하기)
 - [명령어 레퍼런스](#명령어-레퍼런스)
 - [문제 해결](#문제-해결)
+- [지원](#지원)
+- [라이선스](#라이선스)
 
 ---
 
@@ -105,15 +107,28 @@ platty --help
 > 예정이며, 위 세 가지가 현재 사용 가능한 프로바이더입니다.
 
 ```bash
-# Example: generate docs with your own API key provider
+# Generated docs default to codex_cli; pass --provider to choose another
 platty generate-docs run --provider claude_api --model <model>
 ```
+
+`generate-docs`는 기본값으로 `codex_cli`를 사용합니다. `claude_api` 프로바이더는
+`ANTHROPIC_API_KEY` 환경 변수(또는 `~/.platty/.env`)에서 키를 읽습니다. EPIC
+확인을 위해 생성이 일시 중지되면, 후속 `generate-docs confirm-epics` 명령에서도
+**동일한 `--provider`를 유지하세요**.
 
 > 💡 **비용에 관하여:** 문서화 단계는 추출된 지도를 AI 모델로 보내므로,
 > 프로바이더 토큰을 소비하며 여러분의 AI 프로바이더 계정에 비용이 발생할 수
 > 있습니다. 정적
 > 분석 단계는 그렇지 않습니다. 대규모 프로젝트를 실행하기 전에 작은 저장소에서
 > 시작해 사용량을 가늠해 보세요.
+
+### 복구
+
+어떤 단계에서 실패한 작업이 보고되면, `platty generate-docs retry-failed
+--stage <stage> --run-id <id>`로 동일한 실행을 복구한 다음 `platty generate-docs
+run`을 다시 실행하세요(미완료된 작업만 재개해 다시 추출합니다). `generate-docs
+agent-next` / `agent-submit` 명령은 일반적인 첫 실행이 아니라 수동 워커 복구를
+위한 것입니다.
 
 ---
 
@@ -207,6 +222,12 @@ platty status
 > `project use`로 프로젝트를 먼저 확정하세요(또는 `--project <selector>`를
 > 전달하세요).
 
+> 💡 **Platty 프로젝트란 무엇인가요?** 프로젝트는 서로 관련된 저장소와 그로부터
+> 생성된 지식을 담는 워크스페이스입니다. 새로운 제품, 앱, 또는 시스템 영역에는
+> 새 프로젝트를 만드세요. 저장소가 이미 등록된 작업에 속한다면 기존 프로젝트를
+> 재사용하세요. 여러 저장소가 하나의 아키텍처를 이룬다면 그 저장소들을 하나의
+> 프로젝트에 추가하세요.
+
 ---
 
 ## 출력 모드 (사람 vs. 에이전트)
@@ -218,6 +239,11 @@ Platty에는 두 가지 출력 모드가 있습니다:
 - **에이전트 / JSON 모드 (`--json`)** — 기계가 읽을 수 있는 출력입니다. 자동화,
   스크립트, AI 에이전트는 `--json`을 전달하고 `data`, `nextAction`, `warnings`,
   `errors`, `evidenceRefs`를 읽어야 합니다.
+
+CLI가 현재 상태와 다음 동작을 책임집니다: 대부분의 명령어는 `Next:` 힌트(또는
+JSON에서는 `nextCommand` / `nextAction.command`)를 반환합니다. 반환된 그 명령어를
+따라가는 것이 Platty를 구동하는 의도된 방식이며, 에이전트 스킬은 단지 이를
+자동화할 뿐입니다.
 
 ```bash
 platty status
@@ -360,12 +386,32 @@ platty sot export                    # project the SOT to a Markdown tree for gr
 
 ---
 
+## 지원
+
+라이선스, 결제, 또는 기능 관련 문의는 공식 Platty 지원 채널을 이용하세요. 문제를
+신고할 때는 다음을 포함해 주세요:
+
+- 사용 중인 런타임(에이전트를 사용 중이라면 에이전트 런타임/버전도),
+- 운영 체제,
+- `platty version`의 출력,
+- 실패한 정확한 명령어,
+- 전체 오류 출력.
+
+---
+
+## 라이선스
+
+Platty는 **독점**(proprietary) 소프트웨어이며(오픈 소스가 아닙니다), 여러분의
+내부 사용을 위해 [PolyForm Internal Use License](../../LICENSE.md)에 따라
+라이선스가 부여됩니다. 거기에서 명시적으로 허용되지 않는 한, 이를 재배포,
+서브라이선스, 판매, 호스팅하거나 제3자에게 제공할 수 없으며, 경쟁 제품 또는
+서비스를 제공하는 데 사용할 수 없습니다.
+
+---
+
 ## 함께 보기
 
 - **[Platty의 동작 원리](how-platty-works.md)** — 개념, 2단계 모델, 그리고
   로컬 우선 신뢰 모델.
 - **[지원 매트릭스](support-matrix.md)** — 지원되는 언어, 프레임워크, ORM, HTTP
   클라이언트, SaaS 벤더.
-
-Platty는 [PolyForm Internal Use License](../../LICENSE.md)에 따라 라이선스가
-부여된 독점 소프트웨어입니다. 오픈 소스가 아닙니다.


### PR DESCRIPTION
## Summary
- Release Platty agent plugin v0.0.3 build 202606300812.

## Release metadata
- Version: `0.0.3`
- Build: `202606300812`
- Branch: `release/platty-plugin-v0.0.3-build-202606300812`
- Source commit: `8b50509b44f780008f4357764ee8a9e3e6bf92ce`

## Exported managed paths
- `.agents`
- `.claude-plugin`
- `plugins/platty`
- `guide`
- `README.md`
- `GETTING_STARTED.md`
- `LICENSE.md`

## Changed files
- `README.md`
- `guide/en/usage-guide.md`
- `guide/ko/usage-guide.md`

## Safety gate result
- `public_plugin_release_safety: passed`

## Verification
- `npm run check:agent-skills`
- `npm run check:agent-marketplace`
- `node --test tests/export-public-plugin-repo.test.mjs`
