### PR TITLE
Release Platty agent plugin v0.0.3 build 202606301506

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,42 +2,59 @@
 
 [English](README.md) · **한국어**
 
-**브라운필드에서 하는 바이브 코딩.**
+## 바이브 코딩. 이제 브라운필드에서도 가능.
 
-AI 코딩은 빈 저장소에선 잘 되지만 실제 코드베이스에선 무너집니다 — 기존
-시스템을 모르기 때문입니다. Platty는 여러분의 실제 코드베이스에서 살아있는
-소스 오브 트루스(SOT) 스펙을 역추출해, AI 에이전트가 기존 것을 망가뜨리지 않고
-계획·스펙 작성·변경 반영을 하도록 합니다.
+**수십만 줄의 기존 코드 위에서도, 아이디어가 자동으로 서비스가 됩니다.**
 
-→ 이미 가지고 있는 코드에서 시작하는 스펙 주도 개발(SDD).
+말만 하면 서비스가 뚝딱 나온다는 바이브 코딩. 왜 회사에서는 안될까요? 기존에
+있던 수십만 줄의 코드와 복잡한 레거시가 얽힌 브라운필드 환경에서 바이브 코딩은
+무용지물에 가깝습니다. AI한테 코드베이스 전체를 읽어서 작업하라고 하지만, 툭하면
+할루시네이션. 고치는 데 시간이 더 드는 경우도 많죠. 그 사이 토큰은 녹아버리고요.
 
-**독점 소프트웨어(오픈소스 아님) · 로컬 퍼스트 · 이 repo는 Platty 에이전트 플러그인의 공개 배포 표면입니다.**
+**Spec-Driven Development OS, 플래티를 써 보세요.** 아이디어는 Spec 문서로, Spec
+문서는 코드로 자동으로 변환됩니다. Spec 문서는 기존 서비스와 충돌하지 않으면서도
+논리적으로 완벽한 형태로 쓰여집니다. 코드도 마찬가지고요.
 
-## 여기서 시작
+플래티는 마치 CTO와 CPO처럼 우리 회사를 이해할 수 있는 백과사전을 자동으로
+만들어 줍니다. 기획·개발 AI Agent는 이 백과사전을 보고 작업합니다. 결과적으로
+기존 서비스와 전혀 충돌하지 않으면서 논리적으로 완벽한 Spec 문서와 코드가
+완성되죠.
 
-- Platty가 처음이신가요? **[GETTING_STARTED.md](GETTING_STARTED.md)** — CLI 설치, 에이전트 플러그인 설치, 첫 프로젝트.
-- 전체 사용 설명서: **[guide/ko/usage-guide.md](guide/ko/usage-guide.md)** · English **[guide/en/usage-guide.md](guide/en/usage-guide.md)**
+> 플래티는 주식회사 패러다임시프트의 독점 소프트웨어입니다.
 
-## Platty를 선택하는 이유
+## 플래티를 사용해 보세요
 
-- **파일이 아니라 기능으로 말하세요** — 동료에게 말하듯 던지면("환불 흐름이 건드리는 걸 전부 찾아서, 그 위에 부분 환불을 설계해줘"), Platty가 그걸 *실제로 구현한 코드*에 — 모든 서비스에 걸쳐 — 연결합니다.
-- **'대충'이 아니라 완전하고 근거 있게** — Platty는 시스템 전체의 *미리 추출된 증거 연결 지도*에서 작업하므로, 일반 에이전트가 놓치는 다운스트림 이벤트·권한 동기화·폐기된 경로까지 스펙에 들어갑니다. 모든 줄이 소스를 인용하니, 틀리면 고칠 수 있습니다.
-- **팀 전체의 단일 진실** — 같은 스펙이 기술 문서와 비즈니스 문서를 함께 만들어, 엔지니어와 리더가 같은 사실 위에서 일합니다.
+- [GETTING_STARTED.md](GETTING_STARTED.md) 에서 무료 CLI 버전을 설치해 보세요.
+- 사용 설명서를 참조하세요 — 한글: [guide/ko/usage-guide.md](guide/ko/usage-guide.md) · 영어: [guide/en/usage-guide.md](guide/en/usage-guide.md)
 
-*일반 코딩 에이전트는 그때그때 검색된 것에서 답하고, 못 본 것은 자신 있게 놓칩니다. Platty는 여러분의 시스템이 이미 하고 있는 것의 완전한 소스 기반 지도에서 시작해, 그것을 자연어로 다듬게 합니다.*
+## 아이디어 → 배포 속도를 10배 이상 빠르게
 
-**동작 방식:** 코드베이스를 로컬에서 분석 → 소스 오브 트루스 스펙 추출 → AI 에이전트가 그 스펙을 기준으로 계획·스펙·구현 → 코드가 바뀌면 문서가 동기화. 개념과 로컬 퍼스트 신뢰 모델은 **[guide/ko/how-platty-works.md](guide/ko/how-platty-works.md)**를 참고하세요.
+만들고 싶은 아이템이 있나요? 아이디어만 던지세요. 플래티의 기획 에이전트가 CPO
+이상으로 서비스를 이해하고 자동으로 기획서(Spec 문서)를 써 줍니다.
 
-## 빠른 설치
+AI 코딩, 플래티로 하면 차원이 달라집니다. 그냥 코드베이스를 읽히는 것 대비
+오류는 절반 이하, 토큰 사용은 10분의 1 이하로 줄어듭니다. 코딩이 자동으로 되는
+것은 당연, QA 시간이 혁신적으로 줄어듭니다.
 
-CLI 설치 (Node.js 20–24; Node 25는 아직 지원되지 않습니다):
+## 서비스를 이해하는 백과사전을 자동으로 만듭니다
+
+- **멀티 레포 정적분석으로 코드 그래프 작성** — 서비스 전체의 레포를 연결하는 코드 그래프를 자동으로 그립니다. 플래티의 정적분석 기술로 코드를 분석하기 때문에, LLM 분석 대비 정확도가 월등히 높습니다. CTO가 이해하듯이 우리 회사 코드를 정확히 이해합니다.
+- **코드 그래프를 서비스 백과사전으로 요약** — 코드 그래프를 분석해 서비스 전체를 체계적으로 이해할 수 있는 자연어 문서를 만듭니다. 이 문서는 백과사전처럼 목차와 목차별 요약본이 있습니다. AI가 마치 CPO처럼 서비스를 이해하도록 해 줍니다.
+- **기획·개발 에이전트가 백과사전을 보고 작업합니다** — 기존 레거시와 충돌하지 않는 결과물이 바로바로 나옵니다. 결국 회사 내에서도 바이브 코딩이 가능해집니다.
+
+코드가 업데이트되면 자동으로 백과사전도 업데이트됩니다. 자세한 개념은
+[guide/ko/how-platty-works.md](guide/ko/how-platty-works.md)를 참고하세요.
+
+---
+
+## 설치
 
 ```bash
 npm install -g @paradigmshift/platty
 platty version
 ```
 
-런타임에 맞는 에이전트 플러그인 설치:
+런타임에 맞는 에이전트 플러그인을 설치하세요:
 
 ```bash
 # Codex
@@ -51,72 +68,28 @@ codex plugin add platty@platty
 /plugin install platty@platty
 ```
 
-플러그인 설치/업데이트 후에는 최신 스킬이 로드되도록 새 에이전트 세션을
-시작하세요. 그런 다음 분석할 저장소에서 다음을 실행합니다:
-
-```bash
-platty setup
-```
-
-`platty setup`은 프로젝트 선택/생성과 저장소 등록을 돕고, 매 단계에서 다음
-동작을 안내합니다. 전체 명령어 레퍼런스와 에이전트 / CLI 사용 흐름은
-[사용 가이드](guide/ko/usage-guide.md)에 있습니다.
-
-## 문서
-
-전체 제품 문서는 [`guide/`](guide/) 폴더에 영어와 한국어로 있습니다:
-
-| 주제 | 한국어 | English |
-| --- | --- | --- |
-| Platty 동작 원리 (개념, 로컬 퍼스트) | [KO](guide/ko/how-platty-works.md) | [EN](guide/en/how-platty-works.md) |
-| 사용 가이드 (설치, AI provider, 명령어) | [KO](guide/ko/usage-guide.md) | [EN](guide/en/usage-guide.md) |
-| 지원 매트릭스 (언어, 프레임워크, 벤더) | [KO](guide/ko/support-matrix.md) | [EN](guide/en/support-matrix.md) |
+플러그인 설치 후 새 에이전트 세션을 시작하고, 분석할 저장소에서 `platty setup`을 실행하세요.
 
 ## 이 저장소
 
-이 저장소는 **Platty 에이전트 플러그인의 공개 배포 표면**입니다 — Codex와
-Claude Code가 Platty CLI를 구동하는 법을 가르치는 스킬 모음입니다.
-
-**담는 것:** Codex·Claude Code 플러그인 매니페스트, `plugins/platty/skills/`
-아래 Platty 스킬, Claude Code 세션 시작 훅, 마켓플레이스 메타데이터.
-
-**담지 않는 것:** Platty 엔진, CLI 구현, 백엔드, SaaS 서비스, 비공개 기획
-문서 — 이들은 Paradigm Shift Labs의 독점 자산입니다.
+이 저장소는 Platty 에이전트 플러그인의 공개 배포 표면입니다 — Codex와 Claude
+Code가 Platty CLI를 구동하는 법을 가르치는 스킬 모음입니다. Platty 엔진·CLI
+구현·백엔드는 포함하지 않습니다(주식회사 패러다임시프트 독점).
 
 포함 스킬: `platty:using-platty`, `platty:platty-cli-router`,
 `platty:platty-setup`, `platty:platty-static-analysis`,
 `platty:platty-docs-target-curation`, `platty:platty-generated-docs`,
 `platty:platty-sync`, `platty:platty-retrieval`, `platty:platty-sdd-spec`,
-`platty:platty-sdd-design`, `platty:platty-memory`. 어떤 워크플로인지 모를
-때는 `platty:using-platty`부터 시작하세요.
-
-```text
-.agents/plugins/marketplace.json
-.claude-plugin/marketplace.json
-plugins/platty/
-  .codex-plugin/plugin.json
-  .claude-plugin/plugin.json
-  README.md
-  hooks/
-  skills/
-guide/
-```
+`platty:platty-sdd-design`, `platty:platty-memory`.
 
 ## 요구 사항
 
 - Node.js 20–24 (Node 25는 아직 지원되지 않습니다).
-- npm.
-- macOS 또는 Linux. Windows: 정식 지원 예정 — 지금도 동작할 수 있지만 문제가 발생할 수 있습니다.
-- `PATH`에 `platty` CLI, 그리고 플러그인용 Codex 또는 Claude Code.
-- 문서 생성 단계에 쓰이는 본인의 AI provider 자격 증명. Platty 실행에 로그인·계정·가입은 필요 없습니다.
+- macOS 또는 Linux (Windows: 정식 지원 예정).
+- 문서 생성 단계에 쓰이는 본인의 AI provider 자격 증명. 실행에 로그인·계정은 필요 없습니다.
 
 ## 라이선스 및 지원
 
-Platty는 독점 소프트웨어(오픈소스 아님)이며, 설치와 사용은
-[LICENSE.md](LICENSE.md)를 따릅니다. 여기서 명시적으로 허용하지 않는 한
-재배포, 서브라이선스, 판매, 호스팅, 제3자 제공, 또는 경쟁 제품·서비스 제공에
-사용할 수 없습니다.
-
-라이선스·청구·기능 문의는 공식 Platty 지원 채널을 이용하세요. 플러그인 설치
-문제는 에이전트 런타임·버전, 운영체제, `platty version` 출력, 실패한 명령,
-전체 오류 출력을 포함해 알려주세요.
+플래티는 주식회사 패러다임시프트(Paradigm Shift Labs)의 독점 소프트웨어이며,
+설치와 사용은 [LICENSE.md](LICENSE.md)를 따릅니다. 라이선스·청구·기능 문의는
+공식 Platty 지원 채널을 이용하세요.

--- a/README.md
+++ b/README.md
@@ -2,35 +2,56 @@
 
 **English** · [한국어](README.ko.md)
 
-**Vibe coding — in brownfield.**
+## Vibe coding — now in brownfield, too.
 
-AI coding shines on empty repos and breaks on real ones: it doesn't know your
-existing system. Platty reverse-engineers a living source-of-truth spec from
-your actual codebase, so AI agents can plan, spec, and ship changes without
-breaking what's already there.
+**Even on hundreds of thousands of lines of existing code, your ideas turn into shipped services — automatically.**
 
-→ Spec-driven development that starts from the code you already have.
+Vibe coding promises a service the moment you describe it. So why doesn't it work
+inside a company? In a brownfield environment — hundreds of thousands of lines of
+existing code tangled with complex legacy — vibe coding is close to useless. You
+tell the AI to read the whole codebase and work on it, but it hallucinates
+constantly, and fixing the result often takes longer than doing it by hand.
+Meanwhile, your tokens melt away.
 
-**Proprietary (not open source) · local-first · this repo is the public Platty agent-plugin distribution surface.**
+**Try Platty, the Spec-Driven Development OS.** Ideas become spec documents, and
+spec documents become code — automatically. The spec is written so that it never
+conflicts with your existing services while staying logically complete. So is the
+code.
 
-## Start here
+Platty automatically builds an encyclopedia that understands your company the way
+a CTO and a CPO would. Your planning and development AI agents work from that
+encyclopedia. The result: spec documents and code that are logically complete and
+never conflict with your existing services.
 
-- New to Platty? **[GETTING_STARTED.md](GETTING_STARTED.md)** — CLI install, agent-plugin install, and your first project.
-- Full usage manual: **[guide/en/usage-guide.md](guide/en/usage-guide.md)** · 한국어 **[guide/ko/usage-guide.md](guide/ko/usage-guide.md)**
+> Platty is proprietary software of Paradigm Shift Labs, Inc.
 
-## Why Platty
+## Try Platty
 
-- **Talk in features, not files** — say it the way you'd tell a teammate ("map everything our refund flow touches, then design partial refunds on top of it"), and Platty connects that to the code that actually implements it — across every service.
-- **Complete and grounded, not best-effort** — Platty works from a pre-extracted, evidence-linked map of your whole system, so the spec includes the downstream event, the entitlement sync, and the deprecated path a general agent would miss — and every line cites its source, so you can correct it when it's wrong.
-- **One source of truth for the whole team** — the same spec feeds technical *and* business docs, so engineers and leaders work from the same facts.
+- Install the free CLI from [GETTING_STARTED.md](GETTING_STARTED.md).
+- Read the usage guide — English: [guide/en/usage-guide.md](guide/en/usage-guide.md) · 한국어: [guide/ko/usage-guide.md](guide/ko/usage-guide.md)
 
-*A general coding agent answers from whatever it happens to retrieve, and confidently misses what it didn't see. Platty starts from the full, source-grounded map of what your system already does — and lets you shape it in plain language.*
+## From idea to deploy — 10× faster
 
-**How it works:** analyze your codebase locally → extract a source-of-truth spec → your AI agents plan, spec, and build against it → docs stay in sync as the code changes. See **[guide/en/how-platty-works.md](guide/en/how-platty-works.md)** for the concepts and the local-first trust model.
+Have something you want to build? Just throw the idea in. Platty's planning agent
+understands your service better than a CPO and writes the spec document for you,
+automatically.
 
-## Quick install
+AI coding with Platty is on another level. Compared to just feeding the codebase
+to the model, errors drop by more than half and token usage drops to less than
+one-tenth. Automated coding is a given — and QA time shrinks dramatically.
 
-Install the CLI (Node.js 20–24; Node 25 is not supported yet):
+## It builds an encyclopedia that understands your service — automatically
+
+- **Multi-repo static analysis builds a code graph** — Platty automatically draws a code graph that connects every repository across your whole service. Because it analyzes code with Platty's static-analysis technology, accuracy is far higher than LLM analysis. It understands your company's code precisely, the way a CTO does.
+- **The code graph is summarized into a service encyclopedia** — Platty analyzes the code graph to produce a natural-language document that lets you understand the whole service systematically. Like an encyclopedia, it has a table of contents and a summary per entry. It lets AI understand your service the way a CPO would.
+- **Planning and development agents work from the encyclopedia** — results that don't conflict with your existing legacy come out right away. In the end, vibe coding becomes possible inside the company, too.
+
+When your code is updated, the encyclopedia updates automatically. For the
+concepts, see [guide/en/how-platty-works.md](guide/en/how-platty-works.md).
+
+---
+
+## Install
 
 ```bash
 npm install -g @paradigmshift/platty
@@ -51,76 +72,30 @@ codex plugin add platty@platty
 /plugin install platty@platty
 ```
 
-After installing or updating the plugin, start a new agent session so the latest
-skills load. Then, from the repository you want to analyze, run:
-
-```bash
-platty setup
-```
-
-`platty setup` helps you choose or create a project, register repositories, and
-shows the next action at each step. The full command reference and the agent /
-CLI walkthroughs are in the [usage guide](guide/en/usage-guide.md).
-
-## Documentation
-
-Full product documentation lives in the [`guide/`](guide/) folder, in English
-and Korean:
-
-| Topic | English | 한국어 |
-| --- | --- | --- |
-| How Platty works (concepts, local-first, why you can trust it) | [EN](guide/en/how-platty-works.md) | [KO](guide/ko/how-platty-works.md) |
-| Usage guide (install, AI provider, agent or CLI usage, commands) | [EN](guide/en/usage-guide.md) | [KO](guide/ko/usage-guide.md) |
-| Support matrix (languages, frameworks, ORMs, vendors) | [EN](guide/en/support-matrix.md) | [KO](guide/ko/support-matrix.md) |
+After installing the plugin, start a new agent session, then run `platty setup`
+from the repository you want to analyze.
 
 ## This repository
 
-This repository is the **public distribution surface for the Platty agent
-plugin** — the skills that teach Codex and Claude Code how to drive the Platty
-CLI.
-
-**Contains:** Codex and Claude Code plugin manifests, the Platty skills under
-`plugins/platty/skills/`, Claude Code session-start hooks, and marketplace
-metadata.
-
-**Does not contain:** the Platty engine, CLI implementation, backend, SaaS
-service, or private planning docs — those are proprietary to Paradigm Shift Labs.
+This repository is the public distribution surface for the Platty agent plugin —
+the skills that teach Codex and Claude Code how to drive the Platty CLI. It does
+not contain the Platty engine, CLI implementation, or backend (proprietary to
+Paradigm Shift Labs, Inc.).
 
 Included skills: `platty:using-platty`, `platty:platty-cli-router`,
 `platty:platty-setup`, `platty:platty-static-analysis`,
 `platty:platty-docs-target-curation`, `platty:platty-generated-docs`,
 `platty:platty-sync`, `platty:platty-retrieval`, `platty:platty-sdd-spec`,
-`platty:platty-sdd-design`, `platty:platty-memory`. Start with
-`platty:using-platty` when you are not sure which workflow applies.
-
-```text
-.agents/plugins/marketplace.json
-.claude-plugin/marketplace.json
-plugins/platty/
-  .codex-plugin/plugin.json
-  .claude-plugin/plugin.json
-  README.md
-  hooks/
-  skills/
-guide/
-```
+`platty:platty-sdd-design`, `platty:platty-memory`.
 
 ## Requirements
 
 - Node.js 20–24 (Node 25 is not supported yet).
-- npm.
-- macOS or Linux. Windows: official support is planned — it may work today but you can hit issues.
-- The `platty` CLI on your `PATH`, plus Codex or Claude Code for the plugin.
-- Your own AI provider credentials for the documentation step. No login, account, or sign-up is required to run Platty.
+- macOS or Linux (Windows: official support planned).
+- Your own AI provider credentials for the documentation step. No login or account is required to run Platty.
 
-## License and support
+## License & support
 
-Platty is proprietary software (not open source); installation and use are
-governed by [LICENSE.md](LICENSE.md). Unless expressly permitted there, you may
-not redistribute, sublicense, sell, host, or provide it to third parties, or use
-it to provide a competing product or service.
-
-For licensing, billing, or feature questions, use the official Platty support
-channel. For plugin installation issues, include your agent runtime and version,
-your operating system, the output of `platty version`, the exact command that
-failed, and the full error output.
+Platty is proprietary software of Paradigm Shift Labs, Inc.; installation and use
+are governed by [LICENSE.md](LICENSE.md). For licensing, billing, or feature
+questions, use the official Platty support channel.


### PR DESCRIPTION
## Summary
- Release Platty agent plugin v0.0.3 build 202606301506.

## Release metadata
- Version: `0.0.3`
- Build: `202606301506`
- Branch: `release/platty-plugin-v0.0.3-build-202606301506`
- Source commit: `9667cc0b29dc66b0fbd4530529f2b1412ab4a138`

## Exported managed paths
- `.agents`
- `.claude-plugin`
- `plugins/platty`
- `guide`
- `README.md`
- `README.ko.md`
- `GETTING_STARTED.md`
- `LICENSE.md`

## Changed files
- `README.ko.md`
- `README.md`

## Safety gate result
- `public_plugin_release_safety: passed`

## Verification
- `npm run check:agent-skills`
- `npm run check:agent-marketplace`
- `node --test tests/export-public-plugin-repo.test.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * README의 상단 소개와 구성 흐름을 새롭게 정리해, 제품 가치와 시작 방법을 더 간단하게 보여주도록 개선했습니다.
  * 저장소 설명, 요구 사항, 지원/라이선스 안내를 더 짧고 명확하게 다듬었습니다.
  * 일부 상세 안내와 중복되던 문서 섹션은 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->