### PR TITLE
Release Platty agent plugin v0.0.3 build 202607030551

### DIFF
--- a/plugins/platty/skills/platty-memory/SKILL.md
+++ b/plugins/platty/skills/platty-memory/SKILL.md
@@ -101,15 +101,15 @@ normalize a raw question. Alias memories are search hints only; they are not
 source-grounded business facts and must not be used as proof of behavior.
 
 ```bash
-platty memory add --project <project> --epic <epic-id> --kind context --content "alias: 응원친구 -> canonical: 친구; use only for retrieval query normalization, not as source-grounded business evidence" --export-sot --json
+platty memory alias add --project <project> --epic <epic-id> --term "응원친구" --canonical "친구" --json
 ```
 
 Prefer the narrowest confirmed anchor:
 
 - If the alias belongs to one EPIC, anchor it to that EPIC.
 - If the EPIC is not known, ask one clarifying question before recording it.
-- After export, retrieval should read the memory overlay before `catalog/glossary.md`
-  and EPIC `glossary.md`.
+- Retrieval should use `sot glossary search --project <project> --query "<raw term>" --json`;
+  alias memories are included in that CLI result and are not projected as glossary Markdown.
 
 ## Re-anchor Stranded Memory
 

--- a/plugins/platty/skills/platty-retrieval/SKILL.md
+++ b/plugins/platty/skills/platty-retrieval/SKILL.md
@@ -80,12 +80,11 @@ table/field impact questions.
 Before choosing a retrieval strategy, classify the project state from generic SOT structure.
 
 1. Resolve `projectId` and locate `~/.platty/sot/<projectId>/`.
-2. Read `README.md`, `catalog/epics.md`, and `catalog/glossary.md` when present.
-   Treat `catalog/glossary.md` as a shallow grep/routing index, not a project-level
-   glossary narrative or final evidence. Its job is to bridge raw user terms and
-   aliases to candidate EPICs; details still live in EPIC docs, source-near specs,
-   and code.
-3. If live EPIC rows have `documentCount > 0` and generated files exist under `epics/<epicId>/` such as `br.md`, `design.md`, `data_dictionary.md`, `glossary.md`, `usecases/ucl.md`, or `usecases/ucs.md`, use **Business Index Mode** for business, planning, policy/rules, journey, and concept questions. Project `overview.md` / `personas.md` routing cards are coarse route maps: they choose an EPIC and purpose docs, not exhaustive API/screen/event/schedule evidence.
+2. Read `README.md` and `catalog/epics.md`. For raw user terms, aliases,
+   abbreviations, Korean/English bridges, or domain slang, call
+   `platty sot glossary search --project <project> --query "<raw term>" --json`
+   instead of expecting a glossary Markdown file.
+3. If live EPIC rows have `documentCount > 0` and generated files exist under `epics/<epicId>/` such as `br.md`, `design.md`, `data_dictionary.md`, `usecases/ucl.md`, or `usecases/ucs.md`, use **Business Index Mode** for business, planning, policy/rules, journey, and concept questions. Project `overview.md` / `personas.md` routing cards are coarse route maps: they choose an EPIC and purpose docs, not exhaustive API/screen/event/schedule evidence.
 4. If business docs are absent, incomplete, or not exported, use **Static Analysis Mode** for static catalogs and graph/code primitives.
 5. If the state is mixed, use Business Index Mode for valid business-doc evidence and explicitly state coverage or freshness gaps before drilling into static evidence.
 6. For development/design-impact questions ("where do I add/change this", "what breaks", code location, precise screen/api/table impact), follow **Development Design Questions (4-Axis)** even when business docs exist: start with targeted static catalog grep + graph traces when the question is already anchored to an implementation entity or asks for code/impact, then use business docs for semantic scope and constraints when available.
@@ -110,10 +109,10 @@ mixes, and team-specific words that generated docs may never contain.
    and likely code-language equivalents from glossary hits.
 4. If the raw term has no glossary/spec/code hit and fuzzy candidates are tied,
    ask one clarifying question before answering.
-5. When the user confirms a new alias, recommend recording it with `platty memory add`
-   on the narrowest known EPIC/document/item scope. If no scope is known, ask one
-   clarifying question and find the candidate EPIC before recording. After export,
-   that memory should travel with the next retrieval pass.
+5. When the user confirms a new alias, recommend recording it with
+   `platty memory alias add --project <project> --epic <epicId> --term "<raw>" --canonical "<canonical>" --json`.
+   If no EPIC is known, ask one clarifying question and find the candidate EPIC
+   before recording. Alias memory is query normalization, not business proof.
 
 ## Boundary Declaration
 
@@ -169,14 +168,14 @@ bounded and prevents the "CLI is available, so trace first" failure mode.
 
 | Question shape | First hop | Drilldown gate | Stop rule |
 | --- | --- | --- | --- |
-| concept / term meaning | `catalog/glossary.md`, then `catalog/epics.md` | candidate epic `glossary.md` / `design.md` | stop before graph unless implementation is asked |
+| concept / term meaning | `sot glossary search`, then `catalog/epics.md` | candidate `epic.md` / `design.md` | stop before graph unless implementation is asked |
 | planning / product direction | `catalog/epics.md` | `design.md`, `br.md`, `usecases/ucl.md` | stop after business docs when supported |
 | policy / business rules | `catalog/epics.md` | `br.md`, `usecases/ucs.md`, `data_dictionary.md` | do not infer policy from code alone |
 | user journey / screen flow | `catalog/epics.md` plus `catalog/screens.md` | `design.md`, `usecases/ucl.md`, screen specs | separate journey from implementation |
 | precise API / screen / table impact | static catalog row (`apis.md`, `screens.md`, `tables.md`) | `graph trace` from `traceId` / `serviceMapNodes`, then source snippet | state graph limits and candidates |
 | data field / carrier impact | `catalog/tables.md` or field docs | DB-anchored upstream trace with `accesses_db,calls_api`, then source grep | check read carriers as well as writes |
-| code location | glossary `code_term` or static catalog | `code search` -> nodeId -> optional trace/snippet | never pass `code_term` directly to `graph trace` |
-| ambiguous domain term | `catalog/glossary.md` and `catalog/epics.md` | read 2-3 candidate epic folders | qualify or ask if candidates remain tied |
+| code location | glossary search `codeTerm` or static catalog | `code search` -> nodeId -> optional trace/snippet | never pass `codeTerm` directly to `graph trace` |
+| ambiguous domain term | `sot glossary search` and `catalog/epics.md` | read 2-3 candidate epic folders | qualify or ask if candidates remain tied |
 | negative evidence / missing graph links | static catalog anchor | targeted graph trace returning 0 confirmed | say "no confirmed graph evidence"; never say "no impact" |
 | business docs absent | static catalogs only | graph/code only for static structure | explicitly stop before business policy, journey, or intent |
 
@@ -202,15 +201,15 @@ STOP if you catch yourself thinking any of these:
 | --- | --- |
 | "I'll just use a legacy term-search command/`LIKE` for the term and answer from the hit" | The SOT folder is right there. `grep` `catalog/*.md` for the concept (name/summary), then read the detail MD. A term-match hit is not evidence; answering from titles and a score is fabrication. |
 | "I can't read the catalog (folder missing / read failed), so I'll guess from memory" | Do not fabricate. Either run `platty sot export --project <project>` to (re)create the folder, or fall back to the CLI graph walk. If neither works, report that the SOT projection is unavailable and recommend `sync` + `sot export`. |
-| "The question terms are clear, skip the catalog/glossary" | The user may ask in Korean while docs use English, Japanese, or code identifiers. `catalog/glossary.md` and `summary` columns map aliases — skipping them is how you pick the wrong EPIC. |
+| "The question terms are clear, skip glossary search" | The user may ask in Korean while docs use English, Japanese, or code identifiers. `sot glossary search` maps raw terms and aliases to candidate EPICs and code terms — skipping it is how you pick the wrong EPIC. |
 | "There are hundreds of MD files, I'll open them all to be safe" | Don't brute-force the tree. Use `catalog/*.md` to narrow, read only the named detail files, and for cross-layer reach use `graph trace` — high-cardinality code nodes are intentionally NOT in the MD (use `code search`). |
 | "The doc is stale/orphaned but probably still right — present it as fact" | State `validity` from frontmatter and recommend `sync` + `sot export`. Do not hide stale evidence. |
 | "I'll edit the MD file to fix the wrong value" | The MD is a `[regen]` projection. Edits are lost on next export. Write via `platty memory add` then `platty sot export`. |
-| "I found the `code_term` in glossary, I'll pass it straight to `graph trace --from`" | A `code_term` is a code identifier, NOT a service-map node id. `graph trace --from` needs a node id — first `code search --symbol <code_term>` to get the nodeId, then trace from that. Passing the raw `code_term` is a dangling-input error. |
+| "I found the `codeTerm` in glossary search, I'll pass it straight to `graph trace --from`" | A `codeTerm` is a code identifier, NOT a service-map node id. `graph trace --from` needs a node id — first `code search --symbol <codeTerm>` to get the nodeId, then trace from that. Passing the raw `codeTerm` is a dangling-input error. |
 | "I have an epicId/BR id/model id, so I'll pass it directly to graph trace" | EPIC ids, business document ids, item keys, and model ids are not necessarily graph node ids. Run `platty sot resolve` first. Prefer returned source-near `traceId`s. Use model `db:<table>` traces only after explicit scope/full-detail or when the question is a global table/field impact question. |
-| "The query is Korean but I know the English word, I'll skip glossary and trace from my guess" | Cross the language bridge through `catalog/glossary.md` first. Guessing the English/code term skips the canonical/`code_term` mapping and traces the wrong (or non-existent) node. |
+| "The query is Korean but I know the English word, I'll skip glossary and trace from my guess" | Cross the language bridge through `sot glossary search` first. Guessing the English/code term skips the canonical/`codeTerm` mapping and traces the wrong (or non-existent) node. |
 | "Business docs exist, but graph trace feels faster, so I'll start there" | Wrong mode for business/planning/policy/journey/concept questions. When valid business docs exist, treat them as the semantic index first for those questions. For development/design-impact questions already anchored to implementation or asking code/impact, use the 4-axis path: targeted static catalog grep + graph traces first, with business docs as semantic scope/constraints. |
-| "The business doc says it, so I'll assert it as fact" | Business docs are an **index, not ground truth**. LLM-generated business docs (`usecases/ucs.md`, `design.md`, `br.md`, `glossary.md`) can overclaim — an `authenticated user` written up as `owner`/`member-only`/`participant-only`, a minimal `"ok"` response written up as a returned/created record — or lag the source. Before asserting a behavior, actor/permission, response shape, or rule from a business doc, drill into the **connected** `specs/api/<id>.md` / `specs/screen/<id>.md` (via `relatedDocs`/`serviceMapNodes`/`traceId`, **only the related ones**) — and code via `graph trace`/`code search` when the spec is thin — and confirm it there. Assert from the source-near spec/code; cite the business doc as the index that located it. If they disagree, surface the gap. |
+| "The business doc says it, so I'll assert it as fact" | Business docs are an **index, not ground truth**. LLM-generated business docs (`usecases/ucs.md`, `design.md`, `br.md`) can overclaim — an `authenticated user` written up as `owner`/`member-only`/`participant-only`, a minimal `"ok"` response written up as a returned/created record — or lag the source. Before asserting a behavior, actor/permission, response shape, or rule from a business doc, drill into the **connected** `specs/api/<id>.md` / `specs/screen/<id>.md` (via `relatedDocs`/`serviceMapNodes`/`traceId`, **only the related ones**) — and code via `graph trace`/`code search` when the spec is thin — and confirm it there. Assert from the source-near spec/code; cite the business doc as the index that located it. If they disagree, surface the gap. |
 | "The connected spec says the handler persists/broadcasts/returns X, so I don't need to inspect the source" | Specs are source-near but still LLM-authored. If the source handler body is empty, only logs values, returns no value, or is a stub/TODO/not implemented shell, **source code wins**: report that the implementation is not confirmed. Do not trust a spec claim that a stub delegates to a service, persists data, emits events, enforces permissions, or returns a business result unless the code or included shared-module evidence shows it. |
 | "I grepped nearby repos and did not find it, so the project lacks it" | Wrong boundary. Before any absence claim, verify the repo id/path from SOT catalog/spec/code evidence and search only the intended project repository or explicitly state which repo scope was searched. Sibling examples or alternate implementations are not negative evidence for this project. |
 | "Business docs are missing, so retrieval cannot answer anything" | Wrong mode. Static catalogs, graph trace, and code search still answer static-analysis questions; just avoid inventing business rules. |
@@ -287,7 +286,7 @@ Read these first to get the map and solve unknown-unknowns (you don't need to kn
 ~/.platty/sot/<projectId>/catalog/screens.md  catalog/events.md  catalog/schedules.md  # 동일 스키마 (screenId/eventId/scheduleId | traceId | …)
 ~/.platty/sot/<projectId>/catalog/tables.md   # modelId | name | validity | repoId | traceId
 ~/.platty/sot/<projectId>/catalog/external-services.md
-~/.platty/sot/<projectId>/catalog/glossary.md # project-scope terms + epic glossary pointers
+~/.platty/sot/<projectId>/project/glossary.index.json # machine glossary index used by CLI/fallback only
 ```
 
 `README.md`'s `lastExportAt` tells you how fresh the projection is.
@@ -298,36 +297,37 @@ Read these first to get the map and solve unknown-unknowns (you don't need to kn
 
 ### 3. Discover candidates with grep (name/summary)
 
-grep the catalog for the user's concept, bridging language via `catalog/glossary.md`:
+grep the catalog for the user's concept, and use glossary search for raw terms or aliases:
 
 ```bash
 grep -in "환불\|refund" ~/.platty/sot/<projectId>/catalog/*.md
+platty sot glossary search --project <project> --query "환불" --json
 ```
 
 Pick 1-3 candidate epics/specs by the readable `name`/`summary` columns — not by a single matching word, and never by id (ids are opaque). The catalog is the table of contents; the `Excluded (orphaned/deleted)` section lists audit-only entries you must not treat as live.
 
 #### Glossary cross-lingual search protocol (run at search start)
 
-Before expanding or guessing terms, cross the language bridge through `catalog/glossary.md`:
+Before expanding or guessing terms, cross the language bridge through deterministic glossary search:
 
-1. **grep `catalog/glossary.md` for the query term first.** Its `Terms` index maps each
-   term to its `canonicalTerm`, `searchTerms` (aliases + synonyms + candidate aliases),
-   and **`code` (the `code_term` — the backend/code identifier bridge)**:
+1. **Run `sot glossary search` for the raw query term first.** Its matches map the
+   raw term to candidate EPICs, aliases, `canonicalTerm`, and **`codeTerm`** when
+   the generated glossary exposed a code identifier bridge:
 
    ```bash
-   grep -in "환불" ~/.platty/sot/<projectId>/catalog/glossary.md
+   platty sot glossary search --project <project> --query "환불" --json
    ```
 
-2. **If the term has a `code_term`, do NOT pass it to `graph trace --from`.** A `code_term`
+2. **If the match has a `codeTerm`, do NOT pass it to `graph trace --from`.** A `codeTerm`
    is a code identifier, **not a service-map node id** — `graph trace --from` expects a
    node id. Resolve the node id first, then trace:
 
    ```bash
-   platty code search --project <project> --symbol "<code_term>" --json   # -> get the nodeId
+   platty code search --project <project> --symbol "<codeTerm>" --json   # -> get the nodeId
    platty graph trace --project <project> --from <nodeId> --direction upstream|downstream --json
    ```
 
-3. **If there is no `code_term`, use `searchTerms` to expand `docs`/`code search`
+3. **If there is no `codeTerm`, use aliases/canonical terms from the matches to expand `docs`/`code search`
    candidates only — do not assert.** The aliases/synonyms widen discovery; they are not
    themselves evidence and do not bridge to a code node.
 
@@ -337,7 +337,7 @@ Open the named files. Business docs nest under the epic; technical specs are poo
 
 ```text
 epics/<epicId>/epic.md                         # epic body + relatedDocs (id + role + path)
-epics/<epicId>/br.md  design.md  data_dictionary.md  glossary.md
+epics/<epicId>/br.md  design.md  data_dictionary.md
 epics/<epicId>/usecases/ucl.md  epics/<epicId>/usecases/ucs.md
 epics/<epicId>/memory.md                        # human memories anchored here ([regen])
 specs/api/<fileId>.md  screen/<fileId>.md  event/<fileId>.md  schedule/<fileId>.md
@@ -465,7 +465,7 @@ For development/design-impact questions ("where do I add/change this", "what bre
 Discovery order:
 
 1. Start from the user question.
-2. Cross the glossary bridge with `catalog/glossary.md` and the relevant EPIC `glossary.md` when present.
+2. Cross the glossary bridge with `sot glossary search` when raw terms, aliases, or translated concepts may affect EPIC selection.
 3. Use `catalog/epics.md` to identify candidate rows by readable terms, summaries, and `documentCount`.
 4. Read only 1-3 candidate `epics/<epicId>/epic.md` files on the first pass.
 5. Read purpose-selected business docs from those candidate EPIC folders.
@@ -476,7 +476,7 @@ Purpose-to-document routing:
 
 | Purpose | Read first |
 | --- | --- |
-| concept | `catalog/glossary.md`, `glossary.md`, `epic.md`, `design.md` |
+| concept | `sot glossary search`, `epic.md`, `design.md` |
 | planning | `design.md`, `br.md`, `usecases/ucl.md`, `usecases/ucs.md` |
 | policy/rules | `br.md`, `usecases/ucs.md` |
 | user journey | `design.md`, `usecases/ucl.md` |
@@ -490,16 +490,16 @@ Token/speed budget:
 - Read at most 3 candidate EPIC folders on the first pass.
 - Open only docs matching the question intent.
 - For Business Index Mode answers, name the actual index path used before any
-  source/spec drill-down: `catalog/glossary.md` or alias terms checked,
+  source/spec drill-down: glossary search or alias terms checked,
   `catalog/epics.md` candidate rows, chosen `epics/<epicId>/`, and the selected
-  business docs (`br.md`, `design.md`, `usecases/*`, `data_dictionary.md`,
-  `glossary.md`) that support the answer.
+  business docs (`br.md`, `design.md`, `usecases/*`, `data_dictionary.md`)
+  that support the answer.
 - Read technical specs only after scope selection.
 - Run graph/code only when implementation, impact, or unresolved gaps require it.
 - Do not call graph/code just because the CLI is available. For business-only planning, policy, or journey answers, stop after the business docs once the answer is supported.
 - For business-index questions, graph/code is an escalation, not a validation ritual. Escalate only
   when the answer needs source location, confirmed implementation edges, graph-negative evidence, or
-  a code-level bridge from a `code_term`.
+  a code-level bridge from a `codeTerm`.
 - For static impact or DB questions, graph trace is worth the extra time/tokens only when it adds evidence grep cannot supply: confirmed DB/API/screen edges, source locations, candidates, or negative trace evidence.
 - If a graph/code call does not materially change the answer, treat that as a skill failure in later evals and tighten the routing rule rather than widening searches.
 
@@ -510,7 +510,7 @@ Use this when business docs are unavailable, incomplete, or not exported. Do not
 Discovery order:
 
 1. Start from the user question.
-2. Cross `catalog/glossary.md` if present.
+2. Use `sot glossary search` when raw terms, aliases, or translated concepts may affect candidate selection.
 3. Search static catalogs: `catalog/screens.md`, `catalog/apis.md`, `catalog/tables.md`, and `catalog/external-services.md` plus relevant static `events`/`schedules`.
 4. Pick candidate rows by readable `name`/`summary`/`repo` fields, not ids alone.
 5. Trace from `traceId` or `serviceMapNodes` when cross-layer relationships are needed.
@@ -568,7 +568,7 @@ Then synthesize: concrete **change points** (repo + file + node + layer), the **
 ## Answer Contract
 
 - Start with the evidence boundary when the project is static-only, mixed, stale, or docs are missing.
-- State the normalized terms used (and the alias bridge from `catalog/glossary.md`).
+- State the normalized terms used (and the alias bridge from `sot glossary search` when used).
 - Cite MD file paths and frontmatter `id`s; for code, cite repo + file + line.
 - Separate direct evidence from inference.
 - For docs-absent projects, explicitly say "business docs are absent/unavailable" and "static catalogs/graph/code can only support implementation structure." Do not merely imply this by saying "no SOT path."
@@ -612,19 +612,19 @@ PASS path and the Red (failure) paths it must prevent.
 
 **PASS path:**
 
-1. grep `catalog/glossary.md` for "환불" → hit on the `Terms` index row.
-2. Read that term's `code_term` from the `code` column (e.g. `refund`).
+1. Run `platty sot glossary search --project <project> --query "환불" --json`.
+2. Read the top match's `codeTerm` when present (e.g. `refund`) and candidate EPIC path.
 3. `platty code search --project <project> --symbol refund --json` → obtain the `nodeId`
    (with `filePath`/`lineStart`/`lineEnd`).
 4. `platty graph trace --project <project> --from <nodeId> ... --json` using that node id.
 
 **Red (any of these is a failure):**
 
-- Putting the `code_term` directly into `graph trace --from` (e.g. `--from refund`) — a
-  `code_term` is not a service-map node id.
-- Skipping `catalog/glossary.md` entirely and guessing an English term to search/trace.
-- The term has **no** `code_term`, yet the answer asserts a code location anyway instead of
-  using `searchTerms` only to widen `docs`/`code search` candidates without asserting.
+- Putting the `codeTerm` directly into `graph trace --from` (e.g. `--from refund`) — a
+  `codeTerm` is not a service-map node id.
+- Skipping `sot glossary search` entirely and guessing an English term to search/trace.
+- The term has **no** `codeTerm`, yet the answer asserts a code location anyway instead of
+  using aliases/canonical terms only to widen `docs`/`code search` candidates without asserting.
 
 ### Scenario: Product question but business docs are absent
 

--- a/plugins/platty/skills/platty-sdd-design/SKILL.md
+++ b/plugins/platty/skills/platty-sdd-design/SKILL.md
@@ -12,7 +12,8 @@ This skill may author files only inside the selected SDD output directory. It mu
 ## Required Inputs
 
 - Platty project selector.
-- SDD folder containing `request.md` and `stories.md`.
+- SDD folder containing `request.md` and `stories.md`, normally under
+  `~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/`.
 - Optional target repos, APIs, screens, tables, EPICs, or business terms.
 
 ## Required Gates
@@ -32,7 +33,7 @@ Use the Platty CLI convention from `using-platty`. Inside this repository, `AGEN
 
 1. Read `request.md` and `stories.md`.
 2. Extract actors, rules, scenarios, data concepts, screens, APIs, and areas.
-3. Search `catalog/glossary.md` and `catalog/epics.md`.
+3. Search `catalog/epics.md`; use `sot glossary search --project <project> --query "<raw term>" --json` for raw terms, aliases, or translated concepts.
 4. Read relevant business docs:
    - `br.md`
    - `data_dictionary.md`

--- a/plugins/platty/skills/platty-sdd-spec/SKILL.md
+++ b/plugins/platty/skills/platty-sdd-spec/SKILL.md
@@ -14,25 +14,24 @@ This skill is allowed to author files only inside the selected SDD output direct
 Default location:
 
 ```text
-docs/sdd/SPEC-<slug>-<YYYY-MM>/
+~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/
 ├── request.md
 └── stories.md
 ```
 
-Use a private local draft path only when the user asks:
-
-```text
-.platty/sdd/SPEC-<slug>-<YYYY-MM>/
-```
+Do not write SDD documents to repository-local paths such as `docs/sdd/` or
+`.platty/sdd/`. The Platty web dashboard treats the global Platty home as the
+managed SDD source.
 
 ## Required Gates
 
 1. Resolve a Platty project before project-scoped commands.
 2. Locate `~/.platty/sot/<projectId>/`.
-3. Read SOT `README.md`, `catalog/glossary.md`, and `catalog/epics.md` before product claims.
+3. Read SOT `README.md` and `catalog/epics.md`; use `sot glossary search` for raw terms, aliases, or translated concepts before product claims.
 4. Declare the evidence boundary: `business-docs`, `static-only`, `mixed`, or `stale`.
 5. Ask SOT-informed questions before finalizing `request.md`.
 6. Do not generate `stories.md` until `request.md` is `approved`, unless the user explicitly accepts unresolved assumptions.
+7. Set the output language before authoring. Use the language the user requested for the spec; if no language is explicitly requested, infer it from the user's latest idea/request and confirm only when mixed-language intent is ambiguous.
 
 Use the Platty CLI convention from `using-platty`. Inside this repository, `AGENTS.md` overrides public plugin examples: run the local build with `node packages/cli/dist/main.js <command> --json`.
 
@@ -43,11 +42,11 @@ Use the Platty CLI convention from `using-platty`. Inside this repository, `AGEN
    - repo list
    - SOT `README.md` freshness: `lastExportAt`, `sourceCommit`
 2. Term bridge:
-   - grep/read `catalog/glossary.md`
-   - if a glossary row has `code_term`, resolve it with `code search` before any graph trace
+   - run `sot glossary search --project <project> --query "<raw term>" --json`
+   - if a match has `codeTerm`, resolve it with `code search` before any graph trace
 3. Product area:
    - read `catalog/epics.md`
-   - read 1-3 relevant epic docs: `glossary.md`, `br.md`, `usecases/ucl.md`, `usecases/ucs.md`, `data_dictionary.md`, `design.md`
+   - read 1-3 relevant epic docs: `br.md`, `usecases/ucl.md`, `usecases/ucs.md`, `data_dictionary.md`, `design.md`
 4. Implementation hints only when needed:
    - catalog API/screen/table rows
    - graph trace for confirmed relationships
@@ -76,6 +75,16 @@ Question categories:
 - success: measurable validation and release criteria.
 
 Confirmed answers go to `§6 Confirmed Decisions`. Unresolved items stay in `§7 Open Questions`.
+
+## Output Language
+
+Write user-facing `request.md` and `stories.md` content in the requested language.
+
+- If the user asks in Korean or requests Korean output, write titles, section prose, questions, rules, stories, scenarios, and validation notes in Korean.
+- If the SOT is English but the requested language is Korean, translate product explanations while preserving source identifiers, API paths, model names, field names, statuses, and quoted evidence exactly.
+- If the user requests English, write the documents in English even when the idea or glossary query includes Korean terms.
+- Use the same language for SOT-informed questions, recommended defaults, open questions, assumptions, and both SDD files.
+- Record the chosen language in frontmatter as `outputLanguage`.
 
 ## Authoring
 
@@ -109,8 +118,9 @@ Read reference templates only when writing the files:
 
 | Temptation | Required behavior |
 | --- | --- |
-| "I know the domain term." | Search `catalog/glossary.md` first. |
+| "I know the domain term." | Run `sot glossary search` first. |
 | "The user wants speed, skip questions." | Draft with named assumptions and use `draft-with-open-questions`. |
 | "Business docs are missing, so invent product intent from code." | Use static evidence only and state the boundary. |
 | "A code term can go directly to graph trace." | Resolve code term with `code search` first. |
 | "Fix the generated SOT markdown." | Never edit SOT projection; suggest memory or regeneration. |
+| "The SOT is English, so the spec should be English." | Follow the requested language; keep only identifiers and evidence labels unchanged. |

--- a/plugins/platty/skills/platty-sdd-spec/references/request-template.md
+++ b/plugins/platty/skills/platty-sdd-spec/references/request-template.md
@@ -6,6 +6,7 @@ projectId: "<platty-project-id>"
 sourceCommit: "<sot-source-commit-or-unknown>"
 sotExportedAt: "<ISO timestamp>"
 evidenceBoundary: "<business-docs|static-only|mixed|stale>"
+outputLanguage: "<requested-output-language>"
 derivedFrom: []
 approvedAt:
 approvedBy:

--- a/plugins/platty/skills/platty-sdd-spec/references/stories-template.md
+++ b/plugins/platty/skills/platty-sdd-spec/references/stories-template.md
@@ -6,6 +6,7 @@ projectId: "<platty-project-id>"
 sourceCommit: "<sot-source-commit-or-unknown>"
 sotExportedAt: "<ISO timestamp>"
 evidenceBoundary: "<business-docs|static-only|mixed|stale>"
+outputLanguage: "<requested-output-language>"
 derivedFrom: ["request.md"]
 approvedAt:
 approvedBy:

--- a/plugins/platty/skills/platty-ultra-spec/SKILL.md
+++ b/plugins/platty/skills/platty-ultra-spec/SKILL.md
@@ -17,8 +17,35 @@ Inside this repository, `AGENTS.md` overrides public examples: run `node package
 4. Treat the one-page summary's **⚠️ conflicts** and **❓ open questions** as the only things needing a human decision; everything else is auto-derived.
 5. **Honor the dialogue gate.** If `spec generate` returns `status: "needs_answers"`, **nothing was minted** — the spec does not exist yet. Relay the `blockingQuestions` to the human, get their answers, and re-run with `--answer "<question>=<answer>"` (repeatable). Pass `--accept-open-questions` ONLY when the human explicitly chooses to proceed without answering. Never answer blocking questions yourself.
 
+## Grounding the idea first (semantic, agent-driven)
+
+Before compiling, **ground the idea against the SOT** — this is where ultra-spec earns its
+"source-grounded" name and where a general LLM guesses. Grounding is an **agent** step, not a
+string match: domain synonyms ("favorite"/"bookmark", "친구"/"팔로우") only unify by *meaning*,
+and unmappable words must be **asked about**, not invented.
+
+Flow (driver orchestrates; CLI stays the deterministic half):
+
+1. **Spawn a grounding sub-agent** following `references/grounding-agent.md`. It reads the SOT
+   (`~/.platty/sot/<projectId>/` — glossary, business rules, data dictionary) via `platty-retrieval`
+   discipline and returns the strict `grounding.v1` JSON report (grounded / net-new / ambiguous
+   terms, conflicts incl. soft inherited constraints, premise validity, blocking questions).
+2. **Gate it deterministically:** `spec gate --report <file>` (or pipe the JSON on stdin). The CLI
+   strictly validates the report and returns `status: "clear"` or `"needs_answers"` with the exact
+   `questions` a human must answer. The agent judged the semantics; the gate only turns that verdict
+   into stop-or-go — it never re-judges meaning, and it **rejects malformed reports** rather than coercing them.
+3. **On `needs_answers`:** relay `questions` to the human, get answers — do NOT answer them yourself.
+   Then proceed to `generate` folding the answers in via `--answer "<q>=<a>"`.
+4. **On `clear`:** proceed to compile (`spec generate`) directly.
+
+`spec generate` still runs its own proposal-level dialogue gate; grounding is the *earlier*,
+SOT-aware gate that catches ungrounded/ambiguous/conflicting ideas before any facts are minted.
+
 ## Commands
 
+- **Ground before compiling (semantic gate):**
+  `spec gate --report <grounding.v1.json> --json` → `status: clear` (compile) or `needs_answers` with
+  the human `questions`. Stateless and deterministic; consumes the grounding sub-agent's report.
 - **Triage scope first for a broad idea:**
   `spec triage "<idea>" --project <p> --json` → `single` epic (proceed) or an ordered multi-epic map. For multi, spec one epic at a time.
 - **Generate a spec:**
@@ -43,6 +70,7 @@ Inside this repository, `AGENTS.md` overrides public examples: run `node package
 - A required provider is unavailable (e.g. missing API key for `claude_api`).
 - Validation reports an as-is contradiction the user has not chosen to override.
 - `spec generate` returned `status: "needs_answers"` and the blocking questions are neither answered (`--answer`) nor explicitly accepted (`--accept-open-questions`) — do NOT treat the spec as created; nothing was minted.
+- The grounding gate (`spec gate`) returned `status: "needs_answers"` and the human has not answered its `questions` — do NOT compile yet; the idea isn't grounded.
 
 ## Red Flags
 
@@ -55,3 +83,5 @@ Inside this repository, `AGENTS.md` overrides public examples: run `node package
 | "Just pass `--accept-open-questions` to get past the gate." | Only on the human's explicit call. Otherwise answer via `--answer`. |
 | "`needs_answers`, so the spec was partially created." | **Nothing was minted.** It mints only on `status: "completed"`. |
 | "Use platty-sdd-spec for this." | Ultra-spec compiles + diffs against SOT; sdd-spec writes request/stories. Pick by need. |
+| "Ground by grepping the SOT for the idea's literal words." | Ground by **meaning** via the grounding sub-agent; synonyms unify and unknown domain words get asked, not string-matched. |
+| "The grounding report looks off — I'll fix the JSON and pass the gate." | Never hand-edit the report to clear the gate; re-run grounding. The gate rejects malformed reports by design. |

--- a/plugins/platty/skills/platty-ultra-spec/references/grounding-agent.md
+++ b/plugins/platty/skills/platty-ultra-spec/references/grounding-agent.md
@@ -1,0 +1,159 @@
+# Grounding Agent (pre-compile semantic grounding)
+
+This is the prompt/contract for the **grounding sub-agent** the ultra-spec driver spawns
+*before* compiling an idea into spec facts. Its job is to read the project's source-of-truth
+(SOT) and decide, **by meaning, not by string match**, how the idea lands against what already
+exists — then emit a strict structured report the deterministic gate (`platty spec gate`)
+turns into a stop-or-go decision.
+
+The whole reason this is an agent and not code: requirements are natural language. "친구",
+"절친", "응원친구", "팔로우" may all denote the same SOT concept, or three different ones — a
+`LIKE`/substring match can neither unify synonyms nor split a homonym. Only semantic judgment
+against the glossary can. When meaning is genuinely unclear, the agent **asks** instead of
+guessing.
+
+## Inputs
+
+- `idea`: the plain-language product idea (verbatim).
+- The projected SOT for the resolved project at `~/.platty/sot/<projectId>/` — a **routing index** into
+  code-traced specs (it points to truth; it is not the truth itself):
+  - **Catalog** (`catalog/apis.md`, `screens.md`, `events.md`, `tables.md`) plus `sot glossary search` — the
+    no-omission enumeration surface: discover every spec the idea could touch.
+  - **Detail specs** (`specs/<kind>/<id>.md`: api_spec / screen_spec / event_spec) — code-traced, with
+    `traceId`/`detailPath` pointers down to the actual source.
+  - **Business rules** (`br`) — existing as-is behavior, incl. *soft inherited constraints*
+    (e.g. "only signed-in users", "never increments unread") a new feature must not silently break.
+  - **Data dictionary** (`dd` / entities + fields) — the data shapes that exist.
+  - The raw code, reached by following the routed specs' `traceId`s — the final ground truth.
+
+### The SOT is a NO-OMISSION ROUTING PATH to code-traced specs — not shallow truth to read off
+
+Do NOT treat the SOT folder as "the answer" you read off the glossary. The glossary/data-dictionary are
+the *index*, not the ground truth. The SOT is a **routing layer built by static analysis** that points —
+**without omission** — to the code-traced detail specs (`api_spec`, `screen_spec`, `event_spec`, business
+rules, data dictionary) and, through their `traceId`s/`detailPath`s, to the **actual code**. That is the
+whole edge over a general grep agent: a grep agent can MISS a relevant route/screen/event; the SOT routing
+enumerates them all. So **ground by routing through the SOT to the specs and the code it points at**, not
+by skimming the catalog.
+
+Follow `platty-retrieval` discipline:
+
+1. **Scope by epic first — the epic list is already extracted.** Read `catalog/epics.md` and pick the
+   epic(s) the idea touches, PLUS any adjacent epic you are unsure about. Epic scoping is for *efficiency*
+   on a large SOT, NOT a licence to omit: a missed epic is a missed conflict, so when in doubt include it,
+   and if the idea is genuinely cross-cutting, widen the scope. Specs are epic-linked, so this bounds the
+   next steps to the relevant neighbourhood instead of re-reading the whole project every time.
+2. **Enumerate completely — within that scope.** Read `catalog/` (apis.md, screens.md, events.md,
+   tables.md) for the entries under the scoped epics, and run `sot glossary search` for raw terms,
+   aliases, or translated concepts to list EVERY spec the idea could touch — by meaning, not literal
+   words. This is the no-omission step (within the epic scope).
+3. **Resolve.** Use `sot resolve` (epic / document / item / model) to get the connected specs + `traceId`
+   seeds for anything you're holding an id for.
+4. **Follow to the KEY CODE — the spec is a summary, not the truth.** An `api_spec`/`screen_spec` is a
+   *summary*; do not stop at it. Each one points you at the exact code to read:
+   - **File**: the spec's `scopeId`/`traceId`/`serviceMapNodes` encode the source file (e.g.
+     `…:<repo>:<path/to/handler.ext>`).
+   - **Functions**: the spec summary names the key symbols (e.g. "runs `<authGuard>` before
+     `<handler>` … which calls `<helper>(...)`").
+   - **Richer list when available**: `graph trace --from <traceId> --direction downstream` returns the
+     connected code-node list. (It can be empty if those call edges weren't built — then fall back to the
+     file+function names the spec already gives you.)
+   Then **read just those key functions directly** in that file — a handful of targeted reads, not the
+   whole repo. That is the precise, no-omission grounding a blind grep can't match: the SOT told you the
+   exact functions; you verify the truth in them.
+
+Only conclude **net-new** or **premise invalid** when the routing turns up nothing AND the code the
+routing points to has no such surface. When the SOT routes you to a **thin handle** — a small piece of code
+that delegates to an externally-owned capability (an SDK/library/service) rather than implementing it — that
+handle IS the routing doing its job. Pull that thread into the code/deps it implicates and **verify** whether
+the app actually owns the state/schema or whether the external dependency does; if the dependency owns it,
+the surface may already work and need no app-side schema. Do not assume ownership either way — check.
+Reading code this way preserves the no-omission advantage while grounding on what is actually true. Never
+invent: if neither the routed specs nor the code support a claim, it is net-new or a question.
+
+## Method (per meaningful concept in the idea)
+
+For every domain concept, entity, action, or constraint the idea introduces, classify it:
+
+1. **Grounded** — it maps, *by meaning*, to an existing SOT concept. Record `{ term, mapsTo }`
+   where `mapsTo` names the existing glossary term / rule / entity it grounds to. Map synonyms to
+   the canonical term (the idea's "favorite" → existing "bookmark", etc.). Do **not** mark something
+   grounded just because a similar string appears — confirm the *meaning* matches.
+2. **Net-new** — it genuinely has no counterpart in the SOT. List the term in `netNewTerms`. Be
+   conservative: net-new means you looked for a synonym and there is none, not that the exact word is absent.
+3. **Ambiguous** — it could map to more than one existing concept, or it's a domain word whose
+   meaning isn't pinned down by the glossary. Record `{ term, question }` with the disambiguation
+   question a human must answer. Prefer **ask** over a confident wrong mapping.
+
+Then, independent of the term mapping:
+
+4. **Conflicts** — does the idea touch or contradict an existing business rule, *including soft
+   inherited constraints*? Record `{ withRule, why }` per touched rule (`withRule` = the rule's
+   stable key/id). A conflict is a candidate for human resolution, not a proven contradiction.
+5. **Premise** — does the idea presuppose something that must already exist (a screen, a model, a
+   capability)? Set `premiseValid: { value, reason }`. If the premise is false (idea assumes a
+   thing the SOT doesn't have), `value:false` with the reason — that gates.
+6. **Blocking questions** — the real ambiguities whose answer would change the spec's *shape*
+   (not cosmetic preferences). These are surfaced verbatim by the gate.
+
+### Completeness: enumerate the SYSTEMIC neighbourhood, not just the one target
+
+The no-omission routing edge is wasted if you stop at the single spec the idea names. After grounding the
+target, use the catalog to enumerate its **whole neighbourhood** and surface what a single-target code
+reader structurally omits:
+
+- **Sibling specs/surfaces that share the pattern.** If the idea touches one instance of a pattern (an
+  auth-gated route, but equally an API, screen, event, scheduled job, worker, or message consumer), route to
+  *every* sibling of that kind and check the rule is applied *consistently* — name the systemic invariant
+  ("the constraint is enforced per-instance with no shared/central enforcement, so a new instance can silently
+  forget it") and the **regression surface** (which siblings a change must re-verify).
+- **Catch-all / fallback invariants.** Wildcard/catch-all routes, default branches, fallback handlers, and
+  error paths the routing reveals but the idea didn't mention.
+- **The full set of inherited constraints**, each tied to its rule/spec id — not just the most obvious one.
+
+This systemic completeness is the durable edge even on a *small* idea where grounding itself is a tie: a grep
+agent reading the one named file won't reliably enumerate the sibling routes, the catch-all, and the
+cross-route invariant. Put these in `conflicts` (systemic constraints), `ambiguousTerms`/`blockingQuestions`
+(real shape-changers), and the spec's rules/tasks (regression surface).
+
+## Discipline (Red Flags)
+
+| Temptation | Required behavior |
+| --- | --- |
+| "The word appears in a rule, so it's grounded." | Confirm the *meaning* matches; a shared string is not grounding. |
+| "I don't see the exact word, so it's net-new." | Search synonyms/related concepts first; net-new only when meaning is truly absent. |
+| "It's not in the glossary, so it's net-new / premise invalid." | The glossary is an index, not the truth. Route through the catalog/specs and follow `traceId`s to code first. Net-new only when the routing turns up nothing AND the code it points to has no such surface. |
+| "I'll just read the catalog and decide." | The catalog enumerates; it doesn't prove. Follow the routed detail specs and their `traceId`s down to the code for ground truth — that no-omission routing is the edge over a grep agent. |
+| "The glossary lists no conflict, so the gate is clear." | Follow the routed specs/traceIds to the real runtime guard — an authorization/membership gap the index didn't spell out is a real blocking question. |
+| "I grounded the one spec the idea named — done." | Enumerate its neighbourhood: sibling specs sharing the pattern, catch-alls, the cross-target invariant + regression surface. That systemic completeness is the edge a single-file grep can't match even on a small idea. |
+| "I'll pick the most likely mapping and move on." | If two mappings are plausible, it's **ambiguous** — ask, don't guess. |
+| "No rule literally mentions this, so no conflict." | Check soft/inherited constraints (auth, unread, visibility) the feature could break. |
+| "Invent a plausible entity to map to." | Never fabricate SOT. Unmappable → net-new or ambiguous. |
+| "Return prose explaining my reasoning." | Return ONLY the JSON contract below. Reasoning goes in the `reason`/`why`/`question` fields. |
+
+## Output contract — `grounding.v1` (STRICT JSON, nothing else)
+
+Return exactly this shape. The harness validates it with `parseGroundingReport` and **rejects**
+malformed output (wrong types, missing fields, wrong `schemaVersion`) — it will not be silently coerced.
+
+```json
+{
+  "schemaVersion": "grounding.v1",
+  "idea": "<the idea, verbatim>",
+  "groundedTerms": [{ "term": "<idea word>", "mapsTo": "<existing SOT concept>" }],
+  "netNewTerms": ["<concept with no SOT counterpart>"],
+  "ambiguousTerms": [{ "term": "<idea word>", "question": "<disambiguation question for a human>" }],
+  "conflicts": [{ "withRule": "<existing rule stable key/id>", "why": "<how the idea touches/contradicts it>" }],
+  "premiseValid": { "value": true, "reason": "<why the idea's premise does/doesn't hold against the SOT>" },
+  "blockingQuestions": ["<question whose answer changes the spec's shape>"]
+}
+```
+
+Field rules:
+- All arrays present (use `[]`, never omit).
+- `groundedTerms[].mapsTo` and `conflicts[].withRule` reference **existing** SOT concepts/rules — not invented ones.
+- `blockingQuestions` is the subset of ambiguities/conflicts that must be resolved before minting;
+  the gate also synthesizes questions from `ambiguousTerms`, `conflicts`, `netNewTerms`, and an
+  invalid premise, so list here only blockers not already implied by those (duplicates are harmless
+  but noise).
+- Empty everything + `premiseValid.value:true` ⇒ the gate returns **clear** ⇒ safe to compile.


### PR DESCRIPTION
## Summary
- Release Platty agent plugin v0.0.3 build 202607030551.

## Release metadata
- Version: `0.0.3`
- Build: `202607030551`
- Branch: `release/platty-plugin-v0.0.3-build-202607030551`
- Source commit: `5e2d9b55cd5a2f3d0264c1523b084ebd056be015`

## Exported managed paths
- `.agents`
- `.claude-plugin`
- `plugins/platty`
- `guide`
- `README.md`
- `README.ko.md`
- `GETTING_STARTED.md`
- `LICENSE.md`

## Changed files
- `plugins/platty/skills/platty-memory/SKILL.md`
- `plugins/platty/skills/platty-retrieval/SKILL.md`
- `plugins/platty/skills/platty-sdd-design/SKILL.md`
- `plugins/platty/skills/platty-sdd-spec/SKILL.md`
- `plugins/platty/skills/platty-sdd-spec/references/request-template.md`
- `plugins/platty/skills/platty-sdd-spec/references/stories-template.md`
- `plugins/platty/skills/platty-ultra-spec/SKILL.md`
- `plugins/platty/skills/platty-ultra-spec/references/grounding-agent.md`

## Safety gate result
- `public_plugin_release_safety: passed`

## Verification
- `npm run check:agent-skills`
- `npm run check:agent-marketplace`
- `node --test tests/export-public-plugin-repo.test.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 별칭 조회/추가 흐름이 개선되어, 검색 결과에 별칭이 함께 표시됩니다.
  * SDD 관련 문서에 출력 언어 설정과 저장 위치 안내가 추가되었습니다.
  * 사양 작성 전, 근거화 확인 절차가 새로 도입되었습니다.

* **버그 수정**
  * 용어 검색과 코드 위치 추적 절차가 더 명확해져 잘못된 탐색을 줄였습니다.
  * 문서 생성 전 승인 및 질문 처리 규칙이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->