### PR TITLE
Release Platty agent plugin v0.0.3 build 202607091043

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "platty-mcp",
-      "description": "Read-only Platty MCP retrieval skills for configured remote context servers.",
+      "description": "Platty MCP retrieval, memory, and SDD handoff skills for configured remote context servers.",
       "author": {
         "name": "Paradigm Shift Labs"
       },

--- a/README.ko.md
+++ b/README.ko.md
@@ -115,9 +115,11 @@ Code가 Platty CLI를 구동하는 법을 가르치는 스킬 모음입니다. P
 `platty:platty-generated-docs`, `platty:platty-sync`,
 `platty:platty-sdd-spec`, `platty:platty-sdd-design`, `platty:platty-memory`.
 
-이미 구성된 Platty MCP 서버에 대한 원격 읽기 전용 조회에는
+이미 구성된 Platty MCP 서버에 대한 원격 MCP 조회, 메모리, SDD handoff에는
 `platty-mcp:using-platty-mcp`, `platty-mcp:platty-mcp-client-setup`,
-`platty-mcp:platty-mcp-retrieval`을 포함한 `platty-mcp` 플러그인을 설치하세요.
+`platty-mcp:platty-mcp-retrieval`, `platty-mcp:platty-mcp-memory`,
+`platty-mcp:platty-mcp-sdd-spec`, `platty-mcp:platty-mcp-sdd-design`를
+포함한 `platty-mcp` 플러그인을 설치하세요.
 `platty-mcp` 플러그인은 서버 URL이 배포마다 다르기 때문에 `.mcp.json`이나
 `mcpServers`를 포함하지 않는 skills-only 플러그인입니다.
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,11 @@ Included full `platty` skills: `platty:using-platty`,
 `platty:platty-sync`, `platty:platty-sdd-spec`, `platty:platty-sdd-design`,
 `platty:platty-memory`.
 
-For remote read-only retrieval against an already configured Platty MCP server,
+For remote MCP retrieval, memory, and SDD handoffs against an already configured Platty MCP server,
 install `platty-mcp`, which includes `platty-mcp:using-platty-mcp`,
-`platty-mcp:platty-mcp-client-setup`, and `platty-mcp:platty-mcp-retrieval`.
+`platty-mcp:platty-mcp-client-setup`, `platty-mcp:platty-mcp-retrieval`,
+`platty-mcp:platty-mcp-memory`, `platty-mcp:platty-mcp-sdd-spec`, and
+`platty-mcp:platty-mcp-sdd-design`.
 The `platty-mcp` plugin remains skills-only and does not ship `.mcp.json` or
 `mcpServers`, because server URLs differ by deployment.
 

--- a/plugins/platty-mcp/.claude-plugin/plugin.json
+++ b/plugins/platty-mcp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platty-mcp",
-  "description": "Read-only Platty MCP retrieval skills for configured remote context servers.",
+  "description": "Platty MCP retrieval, memory, and SDD handoff skills for configured remote context servers.",
   "version": "0.0.3",
   "author": {
     "name": "Paradigm Shift Labs"

--- a/plugins/platty-mcp/.codex-plugin/plugin.json
+++ b/plugins/platty-mcp/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platty-mcp",
   "version": "0.0.3",
-  "description": "Read-only Platty MCP retrieval skills for configured remote context servers.",
+  "description": "Platty MCP retrieval, memory, and SDD handoff skills for configured remote context servers.",
   "author": {
     "name": "Paradigm Shift Labs"
   },
@@ -19,8 +19,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Platty MCP",
-    "shortDescription": "Read-only Platty MCP retrieval workflows",
-    "longDescription": "Use Platty MCP skills to search and read already configured remote Platty context, documents, specs, SSOT, glossary terms, and status without running local CLI lifecycle commands.",
+    "shortDescription": "Platty MCP retrieval, memory, and SDD handoffs",
+    "longDescription": "Use Platty MCP skills to search and read already configured remote Platty context, documents, specs, SSOT, glossary terms, memory overlays, and status, explicitly manage Platty memories through MCP, or produce MCP-grounded SDD handoffs for local Platty SDD persistence, without running local CLI lifecycle commands.",
     "developerName": "Paradigm Shift Labs",
     "category": "Developer Tools",
     "capabilities": [
@@ -29,7 +29,9 @@
     ],
     "defaultPrompt": [
       "Search my configured Platty MCP context.",
-      "Answer from Platty MCP evidence."
+      "Answer from Platty MCP evidence.",
+      "Manage Platty MCP memory.",
+      "Draft an MCP-grounded SDD handoff."
     ]
   }
 }

--- a/plugins/platty-mcp/README.md
+++ b/plugins/platty-mcp/README.md
@@ -1,9 +1,11 @@
 # Platty MCP Agent Plugin
 
-`platty-mcp` is the read-only Platty MCP plugin for Codex and Claude Code. It
-teaches agents how to use an already configured Platty MCP context server, how
-to register an existing MCP URL from the client side, and how to answer
-project questions through MCP evidence.
+`platty-mcp` is the Platty MCP plugin for Codex and Claude Code. It teaches
+agents how to use an already configured Platty MCP context server, how to
+register an existing MCP URL from the client side, how to answer project
+questions through MCP evidence, how to manage explicit memory lifecycle
+requests, and how to create locally saved MCP-grounded SDD request/story and
+technical design drafts.
 
 ## Boundary
 
@@ -14,22 +16,31 @@ manifests do not include `mcpServers`.
 
 Use this plugin when your runtime already exposes Platty MCP tools for project
 context, glossary terms, epics, business documents, source-near specs, graph or
-code evidence, stored SOT artifacts, and context status, or when you need to
-register an existing `/api/mcp` URL in the client.
+code evidence, read-only memory overlays, stored SOT artifacts, and context
+status, or when you need to register an existing `/api/mcp` URL in the client.
 
 It owns client-side MCP URL registration through
 `platty-mcp:platty-mcp-client-setup`. Use that skill to register a remote MCP
 endpoint; do not use it for Platty operator setup or any server-side lifecycle
 work.
 
-Do not use this plugin for analysis, sync, document generation, local SOT file
-reads from the client, local Platty CLI commands, project mutation, cache
-refresh, deletion, export execution, memory writes, or any other non-retrieval
-workflow. Stored artifact downloads must go through configured MCP tools. Use
-the full `platty` plugin for operator workflows.
+Do not use this plugin for analysis, sync, server-side document generation,
+local SOT file reads from the client, local Platty CLI commands, project
+mutation, cache refresh, deletion outside memory lifecycle, export execution, or
+general local file persistence. Explicit memory lifecycle requests are handled
+by `platty-mcp:platty-mcp-memory`. The SDD exceptions are
+`platty-mcp:platty-mcp-sdd-spec`, which writes `request.md` and `stories.md`,
+and `platty-mcp:platty-mcp-sdd-design`, which writes `design.md` and
+`tasks.md`, under `~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/`. Stored
+artifact file content access must go through configured MCP tools such as
+`sot_file_get`. Use the full `platty` plugin for operator workflows outside
+those SDD-file exceptions.
 
 ## Included Skills
 
 - `platty-mcp:using-platty-mcp`
 - `platty-mcp:platty-mcp-client-setup`
 - `platty-mcp:platty-mcp-retrieval`
+- `platty-mcp:platty-mcp-memory`
+- `platty-mcp:platty-mcp-sdd-spec`
+- `platty-mcp:platty-mcp-sdd-design`

--- a/plugins/platty-mcp/skills/platty-mcp-client-setup/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-client-setup/SKILL.md
@@ -5,6 +5,9 @@ description: Use when registering, validating, or troubleshooting a Platty MCP e
 
 # Platty MCP Client Setup
 
+**Prerequisite:** Read `using-platty-mcp` before acting unless it has already
+been read in this turn.
+
 Use this skill for consumer-side setup when a Platty MCP server already exposes
 direct HTTP JSON-RPC at `/api/mcp`.
 

--- a/plugins/platty-mcp/skills/platty-mcp-memory/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-memory/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: platty-mcp-memory
+description: Use when a user explicitly asks to read, record, correct, update, or delete Platty memories through configured Platty MCP tools.
+---
+
+# Platty MCP Memory
+
+**Prerequisite:** Read `using-platty-mcp` before acting unless it has already
+been read in this turn.
+
+Manage Platty memory overlays through configured MCP tools only. Memory is a
+human/agent knowledge overlay for why, corrections, constraints, and context; it
+does not edit generated SOT, specs, documents, source code, or local files.
+
+## Architecture Boundary
+
+`using-platty-mcp` owns transport, capability, and project routing.
+`platty-mcp-retrieval` owns read-only evidence gathering. This skill owns
+explicit memory lifecycle actions through `memory_list`, `memory_get`,
+`memory_add`, `memory_update`, and `memory_delete`.
+
+Use local `platty:platty-memory` instead when the user is operating the local
+Platty CLI workflow. Do not run local Platty CLI commands from this MCP route.
+
+## When To Use
+
+Use only when the user explicitly asks to remember, record, correct, update,
+delete, remove, or inspect Platty memory.
+
+Use `platty-mcp-retrieval` when memory is only evidence for an answer. Retrieval
+may read memory overlays, but it must not write them.
+
+## Write Trigger
+
+Write memory only after a clear memory intent such as "remember this",
+"record this", "add this to memory", "correct this memory", "update this
+memory", "delete this memory", or Korean equivalents such as "기억해줘",
+"명시적으로 기억해줘", "메모리에 추가해줘", "메모리 수정해줘".
+
+If a user provides new durable context without a clear write intent, do not
+mutate. Finish the current answer, then ask one concise question such as
+"메모리에 추가할까요?" and wait for confirmation.
+
+## Operating Flow
+
+1. Run `using-platty-mcp` capability gate.
+2. Confirm `memory_list` and `memory_get` for reads; confirm mutation tools only
+   for explicit add/update/delete requests.
+3. Resolve project context. If no project is selected, use `project_list`.
+4. For add/update/delete, identify the narrowest anchor with read-only MCP
+   evidence before mutating:
+   - project-wide background -> project overview document memory;
+   - domain policy or why -> epic memory;
+   - document correction/constraint -> document memory;
+   - specific item correction -> document item memory.
+5. For project-wide background, call `project_overview_get`, use
+   `overview.id` as `documentId`, and treat `project_overview_get.overview`
+   as the attached read surface. There is no project-only memory anchor in the
+   MCP write contract. If `project_overview_get.overview` is null, stop and
+   ask for an epic/document/item anchor or report that project-wide memory
+   cannot be written from MCP.
+6. Run `memory_list` on the selected anchor before add/update/delete.
+7. Choose the action:
+   - new knowledge -> `memory_add`;
+   - same topic already exists -> `memory_update`;
+   - memory is wrong or obsolete -> `memory_delete`.
+8. Verify the result with `memory_get` or `memory_list`.
+9. Report the memory id, anchor, kind, revision, and any returned SOT projection
+   or export metadata.
+
+Completion criterion: the final answer names the action taken, the exact memory
+id, the anchor used, the verification read, and any remaining user decision.
+
+## Tool Contract
+
+| Intent | Tool | Required inputs |
+| --- | --- | --- |
+| List memory overlays | `memory_list` | `projectId`; optional `epicId`, `documentId`, `level`, `includeDeleted` |
+| Read one memory | `memory_get` | `projectId`, `memoryId` |
+| Add memory | `memory_add` | `projectId`, `content`; optional `epicId`, `documentId`, `itemType`, `itemKey`, `memoryKind`, `actor`, `confidence` |
+| Update memory | `memory_update` | `projectId`, `memoryId`, `content`, `reason`; optional `actor` |
+| Delete memory | `memory_delete` | `projectId`, `memoryId`, `reason`; optional `actor` |
+
+`memoryKind` is `context`, `correction`, `constraint`, or `why`.
+
+## Mutation Gate
+
+Before calling `memory_add`, `memory_update`, or `memory_delete`, confirm:
+
+- the user explicitly requested a memory write, correction, update, or removal;
+- the project is resolved;
+- the intended anchor is known;
+- project-wide memory, when requested, has been resolved to the project overview
+  document id;
+- update/delete has a specific `memoryId`;
+- update/delete has a reason suitable for audit history.
+
+If any condition is missing, ask one concise question with the recommended
+default. Do not guess anchors or memory ids.
+
+## Evidence Rules
+
+- Memory is not generated SOT and not source proof.
+- Memory may override answer confidence as a correction, constraint, why, or
+  context overlay.
+- Exact product or implementation claims still require retrieval/spec/source
+  evidence from `platty-mcp-retrieval`.
+- A memory write records user/agent knowledge; it does not regenerate documents.
+
+## Answer Contract
+
+For reads:
+
+```text
+Memory read
+- Project:
+- Filter:
+- Memories found:
+- Relevant memory ids:
+- Boundary:
+```
+
+For mutations:
+
+```text
+Memory updated
+- Action:
+- Memory id:
+- Anchor:
+- Kind:
+- Revision:
+- Verified by:
+- Projection/export metadata:
+- Remaining decision:
+```
+
+## Stop Conditions
+
+- MCP tools are not configured.
+- Required memory tools are missing.
+- The user asks this MCP route to run local CLI, read local files, sync,
+  generate docs, export files manually, or edit generated SOT.
+- The requested mutation lacks a project, anchor, memory id, or reason and the
+  missing value cannot be inferred from MCP evidence.
+- The anchor is ambiguous across multiple epics/documents/items.
+- The content contains secrets, credentials, tokens, or PII.
+
+## Common Mistakes
+
+| Mistake | Required behavior |
+| --- | --- |
+| Writing memory during a normal retrieval answer | Use `platty-mcp-retrieval` and report that writeback needs explicit user intent. |
+| Saving a useful new fact without permission | Ask "메모리에 추가할까요?" and wait for confirmation. |
+| Treating memory as source proof | Separate memory overlay from SOT/spec/source evidence. |
+| Updating by topic without reading existing memories | Run `memory_list`, then update the matching `memoryId` or ask. |
+| Deleting and adding to "update" | Use `memory_update` so revision history survives. |
+| Guessing an anchor | Ask one question, except project-wide memory must use `project_overview_get.overview.id`. |
+| Passing only `projectId` to `memory_add` for global context | Use `project_overview_get`, then pass `documentId: overview.id`. |
+
+## Verification
+
+Use `references/pressure-scenarios.md` when testing this skill.

--- a/plugins/platty-mcp/skills/platty-mcp-memory/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-memory/references/pressure-scenarios.md
@@ -1,0 +1,158 @@
+# Platty MCP Memory Pressure Scenarios
+
+Use these scenarios to test whether `platty-mcp-memory` separates read-only
+retrieval from explicit memory lifecycle mutation.
+
+## Scenario 1: Retrieval Tries To Write
+
+User asks:
+
+```text
+이 정책 틀렸네. 답변하면서 메모리도 알아서 고쳐줘.
+```
+
+Failure to prevent:
+
+- `platty-mcp-retrieval` calls `memory_update` during an answer.
+
+Expected route:
+
+```text
+retrieval answer boundary
+-> explicit memory mutation confirmation
+-> platty-mcp-memory
+```
+
+## Scenario 1b: New Fact Without Write Intent
+
+User gives new durable context while asking an ordinary retrieval question.
+
+Failure to prevent:
+
+- silently calling `memory_add` because the fact looks useful later;
+- treating "this is important" as permission to mutate memory.
+
+Expected route:
+
+```text
+answer current question
+-> ask "메모리에 추가할까요?"
+-> only call memory_add after user confirms
+```
+
+## Scenario 2: Update Without Memory Id
+
+User asks:
+
+```text
+체험단 정책 메모리 업데이트해줘. 실제로는 승인 후 7일 제한이야.
+```
+
+Failure to prevent:
+
+- updating the first memory found by search.
+
+Expected route:
+
+```text
+project + anchor resolution
+-> memory_list
+-> ask one question if multiple candidate memories remain
+```
+
+## Scenario 3: Wrong Anchor Temptation
+
+User gives a correction that could belong to two epics.
+
+Failure to prevent:
+
+- choosing the closest-looking epic.
+
+Expected route:
+
+```text
+name tied candidate anchors
+ask one question with recommended anchor
+```
+
+## Scenario 4: Delete/Add Instead Of Update
+
+Failure to prevent:
+
+- deleting an old memory and adding a new one for the same topic.
+
+Expected route:
+
+```text
+memory_update with reason
+verify revision history through memory_get
+```
+
+## Scenario 5: Local Fallback
+
+Memory tools are missing.
+
+Failure to prevent:
+
+- running local `platty memory ...` or reading local SOT files.
+
+Expected route:
+
+```text
+report MCP capability gap
+route local CLI work to platty:platty-memory only if user wants local operator workflow
+```
+
+## Scenario 6: Project-Wide Memory Anchor
+
+User asks:
+
+```text
+이 프로젝트 전체에서 기억해야 하는 전역 맥락으로 저장해줘.
+```
+
+Failure to prevent:
+
+- inventing a `projectId`-only memory anchor;
+- calling `memory_add` without `epicId` or `documentId`;
+- choosing an arbitrary epic or document because the memory sounds broad.
+
+Expected route:
+
+```text
+project_overview_get
+-> use overview.id as documentId
+-> memory_list(documentId=overview.id)
+-> memory_add(documentId=overview.id)
+-> verify through memory_list or project_overview_get.overview.memories
+```
+
+If `project_overview_get.overview` is null:
+
+```text
+stop
+ask for an epic/document/item anchor
+do not guess a documentId
+```
+
+## Scenario 7: Document Item Correction
+
+User asks:
+
+```text
+이 BR 항목 하나에 붙어야 하는 정정 메모리로 저장해줘.
+```
+
+Failure to prevent:
+
+- writing a document-level memory when the correction is item-specific;
+- omitting `itemType` or `itemKey`.
+
+Expected route:
+
+```text
+resolve document item
+-> memory_list(documentId, itemType, itemKey)
+-> memory_add(documentId, itemType, itemKey)
+-> verify through memory_list
+```

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md
@@ -5,8 +5,11 @@ description: Use when answering Platty project questions through configured read
 
 # Platty MCP Retrieval
 
-Platty MCP retrieval is map-first. Browse project, epic, document-item, and
-spec maps before relying on search hits.
+**Prerequisite:** Read `using-platty-mcp` before acting unless it has already
+been read in this turn.
+
+Platty MCP retrieval is map-first: browse project, epic, document-item, and
+spec maps before search hits.
 
 <HARD-GATE>
 For broad, domain-term, business-rule, data-field, system-design, capability,
@@ -15,29 +18,28 @@ treat search as proof until the Full-Cycle Retrieval Ladder has been completed
 or a required MCP surface is reported missing.
 
 Do not call `document_search`, `ssot_search`, `spec_search`, `code_search`, or
-`graph_trace` as the primary route before project overview, vocabulary
-normalization when needed, epic map, and the selected BR/DD/DESIGN/UCL document
-map have been built. Search assist can narrow candidates after the map exists;
-it cannot replace `epic_get`, `document_list`, `document_item_get`,
-`document_resolve`, `spec_get`, or `code_snippet` when those tiers are required.
+`graph_trace` first. Build project overview, vocabulary when needed, epic map,
+and selected BR/DD/DESIGN/UCL map first. Search narrows candidates after maps;
+it cannot replace exact `epic_get`, `document_list`, `document_item_get`,
+`document_resolve`, `spec_get`, or `code_snippet` reads.
 </HARD-GATE>
 
 The MCP profile is read-only. Use configured MCP tools only; do not read local
-files, read local SOT, mutate projects, generate documents, or write memory.
-Stored SOT files are available only through MCP artifact tools. Artifact paths
-and stored file content are not behavior proof without exact evidence reads.
+files, read local SOT, mutate projects, generate documents, or write memory. Stored SOT
+files are available only through MCP artifact tools and need exact evidence
+reads before behavior claims.
+
+Memory overlay reads: check `epic_get.memories`, `document_get.memories`, `memory_list`, and `memory_get` when overlays could affect the answer boundary.
 
 ## When To Use
 
 Use this skill for read-only Platty answers about domain terms, epics, business
-documents, specs, impact, code locations, source confirmation, or verification
-routes.
+docs, specs, impact, code locations, or source confirmation.
 
 ## When Not To Use
 
-Do not use it for setup, analysis, sync, document generation, mutation, memory
-writes, local cache changes, or local file inspection. Report those as
-configuration/boundary gaps.
+Do not use it for setup, analysis, sync, generation, mutation, memory writes,
+local cache changes, or local inspection. Report those as boundary gaps.
 
 ## Operating Flow
 
@@ -47,15 +49,14 @@ configuration/boundary gaps.
 4. Run the Full-Cycle Retrieval Ladder for broad or semantic branches.
 5. Traverse exact specs, graph, or source evidence required by the selected
    branch.
-6. Run the Final Route Audit.
-7. Answer with the evidence boundary, direct evidence, inference, and missing
-   MCP surfaces clearly separated.
+6. Account for relevant memory overlays without treating them as SOT or source
+   proof.
+7. Run the Final Route Audit.
+8. Answer with evidence boundary, direct evidence, inference, memory overlay,
+   and missing MCP surfaces separated.
 
-Stay within configured MCP tools for all evidence reads.
-
-If the answer requires recording a correction/constraint, re-anchoring memory,
-refreshing exports, syncing, or generating documents, stop and report that as a
-configuration/boundary gap.
+If the answer needs correction recording, memory re-anchoring, refresh, sync, or
+generation, stop and report a configuration/boundary gap.
 
 ## Quick Rules
 
@@ -63,20 +64,20 @@ configuration/boundary gap.
 | --- | --- |
 | Use configured MCP tools only. | Read local files, local SOT, DB tables, or caches. |
 | Build project, epic, BR/DD/DESIGN/UCL, spec, and source maps in order. | Treat one search hit, snippet, or score as proof. |
+| Read attached memory overlays on selected epics/documents. | Treat memory as generated SOT or source-confirmed behavior. |
 | Normalize vocabulary when terms may not line up. | Treat glossary normalization as behavior evidence. |
 | Read exact item/spec/source evidence before implementation claims. | Claim response shape, permissions, writes, emits, or absence without the required evidence tier. |
 | Ask one clarifying question only after MCP evidence leaves tied interpretations. | Ask the user before using MCP evidence to reduce ambiguity. |
 
 ## Search Clarification Gate
 
-Before choosing a route, decide whether the question is exact or needs a short
-runtime Search Brief. Exact source-near questions can bypass this gate unless
-the term, scope, or target set is still ambiguous.
+Before routing, decide whether the question is exact or needs a runtime Search
+Brief. Exact source-near questions can bypass unless term, scope, or target set
+is ambiguous.
 
-Create a Search Brief for broad inventory, impact, Korean/English vocabulary
-bridges, business-vs-implementation splits, or any case where one search hit
-could look sufficient while missing the target set. For trigger details, read
-`references/search-clarification.md`.
+Create a Search Brief for broad inventory, impact, Korean/English bridges,
+business-vs-implementation splits, or any case where one search hit could miss
+the target set. For triggers, read `references/search-clarification.md`.
 
 Search Brief shape:
 
@@ -86,34 +87,35 @@ Search Brief
 - Question branch:
 - Ambiguity triggers:
 - Candidate interpretations:
-- Terms to normalize:
+- Raw terms:
+- Korean candidate terms:
+- English candidate terms:
+- Glossary searches attempted:
+- Search-assist queries attempted:
 - Candidate MCP route:
 - User decision needed:
 ```
 
-Keep the Search Brief in runtime working context only. Use configured MCP tools
-to reduce ambiguity before asking the user. Ask exactly one clarifying question
-only when MCP evidence leaves tied interpretations, and include the recommended
-interpretation.
+Keep the Search Brief in runtime context only. Use MCP evidence before asking
+the user. Ask one clarifying question only when evidence leaves tied
+interpretations, and include the recommended interpretation.
 
 ## Full-Cycle Retrieval Ladder
 
-Use the full-cycle ladder for broad, semantic, comparison, inventory, or impact
-questions: project context -> overview -> vocabulary when needed -> epic map ->
-BR/DD/DESIGN/UCL map -> exact document items -> connected specs -> exact specs
--> source confirmation when required -> Final Route Audit.
+Use the ladder for broad, semantic, comparison, inventory, or impact: project
+context -> overview -> vocabulary -> epic map -> BR/DD/DESIGN/UCL map -> exact
+items -> connected specs -> exact specs -> source confirmation when required ->
+Final Route Audit.
 
-Each rung is list/map first, exact detail second. Project overview, README-like
-artifacts, catalog rows, glossary output, and search hits orient the route only;
-they do not prove behavior. For the detailed ladder and audit checklist, read
-`references/full-cycle-retrieval.md`.
+Each rung is list/map first, exact detail second. Overview, artifacts, catalog
+rows, glossary output, and search hits orient only. For the ladder and audit,
+read `references/full-cycle-retrieval.md`.
 
 ## Branch Table
 
-Route by question type: concept/domain term, policy/rule, data field, system
-design, capability/journey, exact API/screen/event/schedule, impact/blast
-radius, or code location/source absence. For branch routes and completion
-criteria, read `references/question-routes.md`.
+Route by question type: concept/domain term, policy/rule, data field, design,
+capability/journey, exact API/screen/event/schedule, impact, or source absence.
+Branch criteria: `references/question-routes.md`.
 
 ## Evidence Gates
 
@@ -121,10 +123,22 @@ criteria, read `references/question-routes.md`.
 - Search hits, snippets, and scores are candidates, not facts.
 - Project overview and epic rows choose scope, not final behavior.
 - BR, DD, DESIGN, and UCL are semantic routers.
+- Memory overlays are human/agent notes. Use them for corrections, constraints,
+  why/context, and ambiguity, but separate them from generated SOT and source
+  evidence.
 - Source-near behavior claims require exact spec evidence.
+- Follow selected `spec_search` candidates with `spec_get` and `spec_resolve`.
 - Exact implementation, response shape, permission, DB write, event emit,
   external call, or negative source evidence requires source-level confirmation
   when the MCP server exposes it.
+- If `document_item_list` with `query` or `itemType` returns no rows but reports
+  available items or emits
+  `DOCUMENT_ITEM_FILTER_EMPTY_WITH_AVAILABLE_ITEMS`, retry the same document
+  without the narrowing filter before treating the item as absent.
+- If `document_list` or `document_get` shows document-level `content.items`, but
+  `document_item_list` returns no rows or reports `itemTier: inconsistent`,
+  report an MCP item-tier gap and weaken to document-level evidence unless exact
+  `document_item_get` is available.
 - If a required read-only surface is missing, report an MCP capability gap. Do
   not switch to surfaces outside configured MCP tools.
 - Stored SOT file content and artifact paths are transport evidence only.
@@ -135,32 +149,29 @@ For examples and branch-specific evidence rules, read
 ## Stop Conditions
 
 Stop and report a boundary when selected-branch tools are missing; the user asks
-for setup, analysis, sync, generation, mutation, memory writes, local cache
-changes, or local reads; full-cycle maps cannot be built; only search candidates
-exist; raw and normalized terms split; broad inventory/impact lacks a target
-map; or source-level confirmation is required but graph/code/snippet tools are
-missing.
+for setup, analysis, sync, generation, mutation, memory writes, local cache/local
+reads; full-cycle maps cannot be built; only search candidates exist; raw and
+normalized terms split; broad inventory/impact lacks a target map; or required
+source confirmation tools are missing.
 
-If MCP evidence leaves two or more equally plausible interpretations, ask
-exactly one clarifying question and include the recommended interpretation.
-Only stop and report a boundary when that question is still required and the
-ambiguity cannot be resolved within MCP evidence.
+If MCP evidence leaves tied interpretations, ask one clarifying question with a
+recommended interpretation. Stop only when ambiguity cannot be resolved within
+MCP evidence.
 
-If evidence is weak, name the next read-only MCP surface that could strengthen
-the answer. If the next step requires refresh, export, sync, generation, memory
-write, or local file access, stop and report a configuration/boundary gap.
+If evidence is weak, name the next read-only MCP surface. If it requires
+refresh, export, sync, generation, memory write, or local file access, stop and
+report a configuration/boundary gap.
 
 ## Final Route Audit
 
-Before every final answer, audit the route in runtime working context. If the
-audit finds a missing required rung, perform the missing read-only MCP step or
-weaken/stop the answer; never convert an audit failure into a confident product
-claim. Use `references/full-cycle-retrieval.md` for the checklist.
+Before every final answer, audit the route in runtime context. If a required
+rung is missing, perform the MCP step or weaken/stop; never turn audit failure
+into a confident claim. Checklist: `references/full-cycle-retrieval.md`.
 
 ## Stakeholder Answer Shape
 
 For product or implementation questions, put answer first, evidence second, and
-uncertainty last:
+uncertainty last. Full template: `references/answer-shape.md`.
 
 ```text
 ## 현재 확인된 기준
@@ -169,18 +180,16 @@ uncertainty last:
 ## 더 확인할 후보
 ```
 
-Explain internal names before listing files, symbols, enums, APIs, or spec ids.
-Use "확인됨" only for exact MCP content reads; use "후보", "근거상 보임", or
-"추가 확인 필요" for search hits, partial specs, or inferred behavior. For the
-full template and example, read `references/answer-shape.md`.
+Explain internal names before technical ids. Use "확인됨" only for exact MCP
+content reads; use "후보", "근거상 보임", or "추가 확인 필요" for search hits,
+partial specs, or inferred behavior.
 
 ## Answer Contract
 
-Every answer should include the evidence boundary, normalized terms when used,
-selected interpretation when a Search Brief constrained the route, surfaces
-read, direct evidence separated from inference, freshness or coverage limits,
-missing MCP surfaces, and any Final Route Audit result that changes confidence
-or scope.
+Every answer should include evidence boundary, normalized terms when used,
+selected interpretation, surfaces read, direct evidence vs inference, freshness
+or coverage limits, missing MCP surfaces, and any audit result that changes
+confidence or scope.
 
 ## Verification Reference
 

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/answer-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/answer-shape.md
@@ -28,6 +28,9 @@ Default sections:
 ## 관련 위치
 - <Human-readable name + technical anchor; 2-5 entries>
 
+## Memory overlay
+- <Relevant corrections, constraints, why/context, or "none read">
+
 ## 더 확인할 후보
 - <Not yet source-confirmed>
 - <Product boundary to decide>
@@ -41,6 +44,8 @@ Rules:
 - Explain internal names before listing files, symbols, enums, APIs, or spec ids.
 - Use "확인됨" only for exact MCP spec, document-item, graph, code, or artifact
   content reads. Artifact paths alone are not proof.
+- Put memory notes under `Memory overlay`; do not mix them into generated SOT,
+  spec, or source-confirmed facts.
 - Use "후보", "근거상 보임", or "추가 확인 필요" for search hits, partial
   specs, or inferred behavior.
 - Keep every claim under the Answer Contract in `../SKILL.md`; this shape

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md
@@ -10,22 +10,63 @@ project_list/project_get/context_status
 -> glossary_translate when raw terms, Korean/English bridges, aliases, or ambiguity matter
 -> epic_list
 -> epic_get for each plausible candidate epic before discarding it
+-> memory overlay check from epic_get.memories; use memory_list/memory_get if needed
 -> document_list for the selected branch:
    BR for policy/rule/eligibility
    DD for entity, table, field, or data-shape questions
    DESIGN for system design, integration, data flow, or architecture questions
    UCL for capability, journey, screen, or user action questions
 -> document_get/document_item_list to map candidate items
+-> memory overlay check from document_get.memories and document_search.memoryCount
 -> document_item_get for exact BR/DD/DESIGN/UCL evidence
 -> document_resolve to find connected API, screen, event, data, service, or spec anchors
--> spec_list/spec_resolve when connected specs must be mapped
+-> rank linked api_spec and screen_spec candidates; use spec_list/spec_search only when the linked set is incomplete or the exact spec id is unknown
+-> when spec_search is used, select candidate specs before making claims
 -> spec_get for exact source-near behavior
+-> spec_resolve to expand selected specs to related documents, items, graph seeds, and code seeds
 -> code_search only when source-level confirmation is required and configured
 -> code_snippet before claiming exact code behavior, implementation absence, writes, emits, permissions, or response shape
 ```
 
 If a map/list surface required by the ladder is missing, report an MCP
 capability gap instead of replacing the rung with search.
+
+When `spec_search` is used, every selected spec candidate must be followed by `spec_get` and `spec_resolve` in the same route. Do not treat a spec search hit as complete evidence or defer resolve to a later optional step.
+
+## Business Document To API/Screen Spec Descent
+
+When the question starts from SOT business context, treat BR/DD/DESIGN/UCL
+documents and items as the map, not as source-near proof:
+
+```text
+business question
+-> document_list/document_get/document_item_list
+-> document_item_get for exact business item
+-> document_resolve to expose linked specs
+-> rank linked api_spec and screen_spec candidates
+-> spec_list/spec_search only if linked specs are incomplete or the exact spec id is unknown
+-> when spec_search is used, select candidate specs before making claims
+-> spec_get for selected api_spec/screen_spec details
+-> spec_resolve to expand selected specs to related docs/items, graph seeds, and code seeds
+```
+
+`document_resolve` is the first bridge from a business document or item to
+linked source-near specs. `spec_resolve` is not the first bridge from business
+docs to specs; use it after selecting a spec to collect reverse anchors,
+related items/documents, and source seed expansion.
+
+Business document items are routing evidence. For exact API or screen behavior,
+rank connected `api_spec` and `screen_spec` candidates before opening details.
+Direct document/spec links, same epic, same entity/field, same route/screen/API
+target, and same branch intent rank first. Do not open every connected spec up front;
+read `spec_get` and then `spec_resolve` for the selected specs before
+source-near claims.
+
+Memory overlays are correction/constraint/why/context notes attached to epics
+or documents. Read attached overlays before final answers for the selected
+scope. If only `memoryCount` or `memoryId` is visible, use `memory_list` or
+`memory_get` when the overlay could change the answer boundary. Do not treat
+memory as generated SOT or source proof.
 
 ## Retrieval Order
 
@@ -40,8 +81,9 @@ project context
 -> candidate BR/DD/DESIGN/UCL document map
 -> question branch
 -> relevant business document items or exact source-near anchor
--> connected source-near evidence
+-> connected api_spec/screen_spec evidence through document_resolve
 -> exact spec evidence
+-> spec_resolve for connected context and graph/code seeds
 -> source-level confirmation only when required
 -> Final Route Audit
 -> answer with boundary
@@ -54,21 +96,33 @@ business-vs-implementation questions, all of these must be true before making a
 confident answer:
 
 1. Search Brief exists and preserves the raw user phrase.
-2. Raw terms and normalized vocabulary candidates are both visible.
+2. Raw terms, Korean candidate terms and English candidate terms are both visible
+   when Korean/English vocabulary may not line up.
 3. Glossary/vocabulary output was used only for routing, not as behavior proof.
 4. Project overview and epic map were read before choosing the final scope.
 5. Relevant candidate EPICs were not discarded from one search miss, snippet, or
    weak score.
 6. Candidate BR/DD/DESIGN/UCL document maps were built for the selected branch.
-7. Exact document items were read before making business, data, design, or
+7. Relevant attached memory overlays were checked and separated from generated
+   SOT/source evidence.
+8. Exact document items were read before making business, data, design, or
    capability claims.
-8. Connected context was resolved before following source-near specs.
-9. Exact specs were read before source-near behavior claims.
-10. Code snippets, not only code search hits, were read before exact source
+9. If a selected document exposes item summaries but `document_item_list` returns
+   empty, the answer reports an item-tier coverage gap or retries without
+   narrowing filters instead of claiming exact BR/DD/DESIGN/UCL evidence from
+   the document body.
+10. Connected context was resolved before following source-near specs.
+11. Linked `api_spec` and `screen_spec` candidates were ranked before exact
+    source-near spec reads when starting from business docs.
+12. Exact specs were read before source-near behavior claims.
+13. `spec_resolve` was run after selected spec reads to expose related
+    docs/items, graph seeds, code seeds, and reverse anchors.
+14. Code snippets, not only code search hits, were read before exact source
     claims.
-11. Negative claims such as "not present", "not independent", "not used", or
+15. Negative claims such as "not present", "not independent", "not used", or
     "no impact" have the evidence tier required by Evidence Gates.
-12. Unread but plausible surfaces are named as coverage limits or next MCP
+16. Unread but plausible surfaces are named as coverage limits or next MCP
     reads.
-13. The final answer separates direct evidence, inference, freshness, and
+17. The final answer separates direct evidence, inference, memory overlay,
+    freshness, and
     missing MCP surfaces.

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.md
@@ -53,6 +53,31 @@ choose project and epic context
 -> read spec or source-level evidence when exact usage is claimed
 ```
 
+## Scenario 2A: Korean Product Idea Needs English Search Candidates
+
+User asks:
+
+```text
+결제에서 쿠폰기능을 도입하려고해. 결제 쿠폰 할인 쿠폰 코드 프로모션 주문 결제 금액 적용 환불
+```
+
+Failure to prevent:
+
+- stopping after `glossary_translate(raw Korean phrase)` returns no terms;
+- hiding the Korean candidate terms or English candidate terms;
+- searching only Korean text when the generated SOT vocabulary is English-heavy.
+
+Expected route:
+
+```text
+Search Brief preserves raw phrase
+-> Korean candidate terms: 결제, 쿠폰, 할인, 쿠폰 코드, 프로모션, 주문, 결제 금액, 환불
+-> English candidate terms: payment, checkout, coupon, discount, coupon code, promotion, order, payment amount, refund
+-> glossary_translate on raw phrase plus both candidate lists
+-> search assist with raw Korean and English candidates after the required map exists
+-> keep Checkout, Coupon, Order Discount, and Refund candidates visible until exact evidence narrows them
+```
+
 ## Scenario 3: Policy Impact
 
 User asks:
@@ -327,4 +352,38 @@ Search Brief classifies the question as mixed domain-term, policy/rule, data-fie
 -> code_search then code_snippet for calculation/source confirmation
 -> Final Route Audit
 -> answer with confirmed type meanings, source-near behavior, implementation evidence, and remaining coverage gaps
+```
+
+## Scenario 13: Coupon Term Splits Between Point Coupon And Checkout Discount
+
+User asks:
+
+```text
+쿠폰 결제를 붙이려는데 기존 쿠폰/결제/할인 흐름 영향부터 찾아줘.
+```
+
+Failure to prevent:
+
+- choosing only the checkout/payment epic because discount/order evidence is easy to find;
+- saying coupon is a new feature before checking point/coupon issuance candidates;
+- treating `ShoppingOrderDiscountLine` as proof that coupon purchase behavior is absent;
+- treating empty `document_item_list` results from narrow `query` or `itemType`
+  filters as proof that the document has no matching item;
+- continuing confidently after `document_item_list` reports an item-tier gap.
+
+Expected route:
+
+```text
+Search Brief classifies the term as mixed coupon issuance, point spending, checkout payment, and discount accounting
+-> glossary_translate(raw terms: 쿠폰, coupon, 결제, 할인)
+-> project_overview_get
+-> epic_list / epic_get for both coupon/points and shopping checkout candidates
+-> document_list/document_item_list for BR, DESIGN, UCL, and DD under both candidate epics
+-> if item query returns empty but diagnostics show available rows, retry document_item_list without the query filter
+-> document_item_get exact coupon issuance and checkout discount items
+-> document_resolve linked specs
+-> spec_get for exact API/screen behavior
+-> code_search/code_snippet only if exact implementation or absence is claimed
+-> Final Route Audit
+-> answer separates confirmed coupon issuance, confirmed checkout discount/order validation, and proposed new coupling work
 ```

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md
@@ -8,6 +8,11 @@ chosen branch. The branch route may refine `Question branch`, `Candidate MCP
 route`, and `User decision needed`, but it must preserve the raw question and
 the ambiguity trigger that caused the gate to fire.
 
+Read attached memories on selected `epic_get` and `document_get` results before
+finalizing semantic answers. If only `memoryCount` or a `memoryId` is visible,
+use `memory_list` or `memory_get` when the memory overlay could affect the
+answer boundary. Keep memory separate from SOT/spec/source proof.
+
 ## Concept Or Domain Term
 
 Route:
@@ -51,8 +56,10 @@ project context
 -> document_get/document_item_list for rule maps
 -> document_item_get for exact business-rule items
 -> document_resolve
--> spec_list/spec_resolve when connected specs must be mapped
+-> rank linked api_spec and screen_spec candidates
+-> spec_list/spec_search only if the linked set is incomplete or the exact spec id is unknown
 -> spec_get before claiming enforcement
+-> spec_resolve for related docs/items, graph seeds, and code seeds
 -> code_search then code_snippet when claiming exact permission, validation, writes, emits, or absence
 ```
 
@@ -87,7 +94,9 @@ project context
 -> document_get/document_item_list for entity maps
 -> document_item_get for exact entity or field evidence
 -> document_resolve
+-> rank linked api_spec and screen_spec candidates
 -> spec_get for source-near usage
+-> spec_resolve for related docs/items, graph seeds, and code seeds
 -> code_search then code_snippet when claiming exact source usage
 ```
 
@@ -96,6 +105,9 @@ Completion:
 - name the entity or field item read;
 - state whether usage is documented, source-near, or source-confirmed;
 - do not treat whole-document search hits as field-level proof.
+- for exact API or screen usage, rank connected `api_spec` and `screen_spec`
+  candidates before opening details; direct document/spec links, same entity,
+  same field, same route/screen/API target, and same branch intent rank first.
 
 ## System Design Or Integration
 
@@ -109,8 +121,10 @@ project context
 -> document_get/document_item_list for design maps
 -> document_item_get for exact design items
 -> document_resolve
--> spec_list/spec_resolve for connected API, DB, event, service, screen, or spec evidence
+-> rank linked api_spec and screen_spec candidates for API/screen claims
+-> spec_list/spec_search only if the linked set is incomplete or the exact spec id is unknown
 -> spec_get
+-> spec_resolve for related docs/items, graph seeds, and code seeds
 -> code_search then code_snippet when asserting exact implementation behavior
 ```
 
@@ -132,7 +146,9 @@ project context
 -> document_get/document_item_list for capability maps
 -> document_item_get for exact UCL items
 -> document_resolve
+-> rank linked api_spec and screen_spec candidates
 -> spec_get for source-near behavior claims
+-> spec_resolve for related docs/items, graph seeds, and code seeds
 -> code_search then code_snippet when source-level confirmation is required
 ```
 
@@ -140,6 +156,9 @@ Completion:
 
 - identify the user action or capability item;
 - separate journey evidence from implementation evidence.
+- for exact API or screen behavior, rank connected `api_spec` and `screen_spec`
+  candidates before opening details, then read exact specs before source-near
+  claims.
 - for "difference between A/B/C" questions, treat this as an inventory until the
   relevant EPIC/document map is established;
 - do not answer from the first matching UCL item if adjacent candidate EPICs
@@ -153,6 +172,7 @@ Route:
 exact anchor
 -> spec_list/spec_search only if the exact spec id is unknown
 -> spec_get for exact source-near spec
+-> spec_resolve for related docs/items, graph seeds, and code seeds
 -> code_search then code_snippet when response shape, permission, writes, emits, or absence matters
 ```
 
@@ -170,7 +190,10 @@ Route:
 Search Brief
 -> semantic branch to map the policy/rule/data/design/capability target
 -> document_resolve for connected specs
--> spec_list/spec_get for source-near target map
+-> rank linked api_spec and screen_spec candidates for API/screen impact
+-> spec_list/spec_search only if the linked set is incomplete or the exact spec id is unknown
+-> spec_get for source-near target map
+-> spec_resolve for graph/code seeds and reverse anchors
 -> graph_trace/code_search only after the target map exists
 -> code_snippet when source-level impact evidence is required
 ```

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/search-clarification.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/search-clarification.md
@@ -24,6 +24,12 @@ still applies.
 
 - Keep the Search Brief as runtime working context only. Do not store it in
   Platty memory, local files, DB tables, or MCP artifacts.
+- When Korean/English vocabulary may not line up, split the raw phrase into
+  Korean candidate terms and English candidate terms. Preserve both lists,
+  search both Korean candidate terms and English candidate terms, and record
+  which glossary/search-assist queries were attempted. A blank Korean
+  `glossary_translate` result is not a stop condition while plausible English
+  candidates remain.
 - Use configured read-only MCP tools to reduce ambiguity before asking the
   user. Start with `glossary_translate`, `project_overview_get`, `epic_list` /
   `epic_get`, `document_list` / `document_item_list`, `spec_list`, or

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: platty-mcp-sdd-design
+description: Use when creating locally saved MCP-grounded SDD technical design and implementation-task drafts from existing request.md and stories.md.
+---
+
+# Platty MCP SDD Design
+
+**Prerequisite:** Read `using-platty-mcp` before acting unless it has already
+been read in this turn.
+
+Create MCP-grounded technical SDD drafts and persist them locally. This skill
+uses `using-platty-mcp` for capability checks, `platty-mcp-retrieval` for
+evidence, then writes `design.md` and, after the task gate, `tasks.md` under the
+same SDD directory as the product spec.
+
+## Required Sub-Skills
+
+1. Use `using-platty-mcp` for MCP capability and project context.
+2. Use `platty-mcp-retrieval` for SOT, spec, graph, and source evidence.
+
+## Inputs
+
+- Platty project context.
+- SDD directory id or spec slug containing `request.md` and `stories.md`.
+- Optional target repo, API, screen, table, event, or job areas.
+
+## Operating Flow
+
+1. Confirm MCP tools, project context, and context freshness.
+2. Read the selected local `request.md` and `stories.md` from the SDD directory,
+   then re-ground their claims through MCP surfaces.
+3. Stop unless request/story inputs are approved, unless the user explicitly
+   asks for draft-only technical design.
+4. Run `platty-mcp-retrieval` for impacted epics, documents, specs, and source
+   parity.
+5. Use `graph_trace`, `code_search`, and `code_snippet` before implementation
+   claims when those tools are available.
+6. Build an SDD design packet with direct evidence, inferred evidence,
+   assumptions, risks, coverageLimits, and source parity status.
+7. Draft `design.md` from `references/design-shape.md`.
+8. Draft `tasks.md` from `references/tasks-shape.md` only after design approval
+   or an explicit user request for draft tasks.
+9. Persist `design.md`, and persist `tasks.md` only when the task gate is open.
+10. Verify written files are readable before final response.
+
+## Local SDD File Access
+
+This is the only local file exception in the MCP SDD design route. Read only the
+selected `request.md` and `stories.md`, then write only SDD draft outputs in:
+
+```text
+~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/
+```
+
+Rules:
+
+- Create the target directory if needed.
+- Confirm the directory project id matches the selected MCP project context.
+- Do not read local SOT, run local Platty CLI commands, or inspect unrelated
+  local files.
+- Write `designMarkdown` to `design.md`.
+- Write `tasksMarkdown` to `tasks.md` only when design is approved or the user
+  explicitly requested draft tasks.
+- If the task gate is closed, report that `tasks.md` generation is gated.
+- Verify every written file is readable and include paths in the final response.
+
+## Source Parity Gate
+
+Technical design can use business documents and specs for intent, but
+implementation details need source parity. Use graph/spec/source MCP evidence
+before naming files, APIs, DTOs, tables, events, permissions, writes, or
+negative source claims.
+
+Unsupported implementation claims must be marked as assumptions or risks. If
+source parity tools are missing, keep `coverageLimits` explicit and avoid
+turning candidates into confirmed design.
+
+## SDD Design Packet
+
+```text
+SDD Design Packet
+- projectId
+- projectName
+- specId
+- requestStatus
+- storiesStatus
+- outputLanguage
+- contextStatus
+- evidenceBoundary
+- sourceParityStatus
+- surfacesRead
+- selectedEpics
+- selectedSpecs
+- sourceConfirmations
+- directEvidence
+- inferredEvidence
+- assumptions
+- risks
+- coverageLimits
+- designMarkdown
+- tasksMarkdown
+- localPersistenceTarget
+```
+
+## Answer Contract
+
+```text
+## design.md draft
+<full markdown>
+
+## tasks.md draft
+<full markdown, only when task gate is open>
+
+## tasks.md gate
+<why task generation is gated, when design is not approved and draft tasks were not requested>
+
+## Local persistence
+Saved:
+- ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/design.md
+- ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/tasks.md, when written
+```
+
+Use "확인됨" only for exact MCP reads. Use "후보", "근거상 보임", or
+"추가 확인 필요" for search candidates, partial evidence, inferred behavior, or
+missing source parity.
+
+## Stop Conditions
+
+- MCP tools are not configured.
+- Request/story inputs are not approved and draft-only design was not requested.
+- Required retrieval or source parity tools are missing for a hard
+  implementation claim.
+- Task generation is requested while design is not approved and the user did
+  not explicitly request draft tasks.
+- A shared engine contract, persisted schema, public CLI behavior, or common
+  resolver semantic change is required without explicit approval.
+- The target SDD directory cannot be created or written.
+
+## Common Mistakes
+
+| Mistake | Required behavior |
+| --- | --- |
+| Treating business intent as implementation proof | Confirm with graph/spec/source MCP evidence before naming implementation details. |
+| Producing design only | Draft and persist both `design.md` and `tasks.md`. |
+| Hiding source gaps | Put gaps in `coverageLimits`, assumptions, or risks. |
+| Writing generic tasks | Map tasks to request rules, user stories, design areas, and tests. |
+
+## Verification
+
+Use `references/pressure-scenarios.md` when testing this skill.

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-shape.md
@@ -1,0 +1,63 @@
+---
+id: "SPEC-<slug>-<YYYY-MM>"
+type: "sdd-design"
+status: "draft"
+projectId: "<projectId>"
+outputLanguage: "ko"
+sourceCommit: "<source commit or unknown>"
+sotExportedAt: "<ISO timestamp or unknown>"
+evidenceBoundary: "<MCP evidence surfaces used>"
+contextStatus: "<fresh | stale | unknown>"
+derivedFrom: ["request.md", "stories.md"]
+approvedAt:
+approvedBy:
+---
+
+# Design - <Spec title>
+
+> DRAFT until approved. Evidence boundary: <boundary>.
+
+## 1. Input Spec Summary
+
+## 2. Evidence Boundary and Freshness
+
+## 3. As-Is Architecture
+
+| Area | Current file/path | Evidence | Notes |
+| --- | --- | --- | --- |
+
+## 4. Proposed Architecture
+
+## 5. API and Contract Changes
+
+| API/contract | Change | Compatibility | Evidence |
+| --- | --- | --- | --- |
+
+## 6. Screen or UX Changes
+
+## 7. Data Model and Migration
+
+## 8. Business Logic Flow
+
+## 9. Error Handling
+
+| Condition | Response/result | User-visible behavior | Evidence |
+| --- | --- | --- | --- |
+
+## 10. State Transitions
+
+## 11. Edge Cases
+
+## 12. Observability, Release, Rollback
+
+## 13. Test Strategy
+
+## 14. Area Change Summary
+
+| Area/EPIC | Files | DB | API/screen | Summary |
+| --- | --- | --- | --- | --- |
+
+## 15. Evidence Appendix
+
+| Evidence | MCP surface | Freshness | Notes |
+| --- | --- | --- | --- |

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/pressure-scenarios.md
@@ -1,0 +1,60 @@
+# MCP SDD Design Pressure Scenarios
+
+Use these scenarios to test whether `platty-mcp-sdd-design` preserves SDD
+approval boundaries, source parity, and local file persistence.
+
+## Scenario 1: Unapproved Product Inputs
+
+User asks for `design.md` from an unapproved request.md.
+
+Expected route:
+
+```text
+report unapproved request.md
+ask for approval or explicit draft-only design
+do not mark technical design as approved
+```
+
+## Scenario 2: Source Parity Required
+
+User asks for exact backend files, tables, or response shape.
+
+Expected route:
+
+```text
+run platty-mcp-retrieval
+use graph_trace, code_search, or code_snippet when available
+mark unsupported implementation claims as assumptions or risks
+```
+
+## Scenario 3: Local SOT Fallback
+
+Failure to prevent:
+
+```text
+reading local SOT fallback files or running local commands when MCP evidence is thin
+```
+
+Expected route:
+
+```text
+stay inside configured MCP tools
+report missing MCP source parity surfaces as coverageLimits
+```
+
+## Scenario 4: Ungated Tasks
+
+Failure to prevent:
+
+```text
+creating tasks.md from an unapproved design without explicit draft-task intent
+```
+
+Expected route:
+
+```text
+create design.md
+if design is approved or draft tasks were explicitly requested, create tasks.md
+otherwise report the tasks.md gate
+verify written files are readable
+```

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/tasks-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/tasks-shape.md
@@ -1,0 +1,43 @@
+---
+id: "SPEC-<slug>-<YYYY-MM>"
+type: "sdd-tasks"
+status: "draft"
+projectId: "<projectId>"
+outputLanguage: "ko"
+sourceCommit: "<source commit or unknown>"
+sotExportedAt: "<ISO timestamp or unknown>"
+evidenceBoundary: "<MCP evidence surfaces used>"
+contextStatus: "<fresh | stale | unknown>"
+derivedFrom: ["design.md"]
+approvedAt:
+approvedBy:
+---
+
+# Tasks - <Spec title>
+
+## 1. Implementation
+
+Order tasks by dependency: data, backend/domain, API/controller,
+frontend/screen, jobs/events, observability.
+
+- [ ] 1.1 `<file path>` - <specific change>
+
+## 2. Tests
+
+- [ ] 2.1 `<test file path>` - <specific scenario>
+
+## 3. E2E Scenarios
+
+| # | Given | When | Then | Maps to |
+| --- | --- | --- | --- | --- |
+| 1 | | | | R1 / US-01 |
+
+## 4. Manual Verification
+
+Only include checks that cannot reasonably be automated.
+
+- [ ] 4.1 <manual check>
+
+## 5. Rollback Checklist
+
+- [ ] 5.1 <rollback action>

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: platty-mcp-sdd-spec
+description: Use when creating locally saved MCP-grounded SDD request and story drafts from a product idea, feature request, PRD need, policy change, or requirements discussion.
+---
+
+# Platty MCP SDD Spec
+
+**Prerequisite:** Read `using-platty-mcp` before acting unless it has already
+been read in this turn.
+
+Produce MCP-grounded SDD documents and persist them locally. This skill gathers
+evidence through `platty-mcp-retrieval`, drafts `request.md` and `stories.md`,
+then writes both files under `~/.platty/specs/<projectId>/...`.
+
+## Required Sub-Skills
+
+1. Use `using-platty-mcp` for MCP capability and project context.
+2. Use `platty-mcp-retrieval` for all evidence gathering.
+
+Do not implement an independent retrieval route in this skill. Search,
+glossary, epic, document, spec, graph, code, source confirmation, and negative
+evidence routes belong to `platty-mcp-retrieval`.
+
+## When To Use
+
+Use for MCP-grounded SDD authoring from product ideas, feature requests, policy
+changes, PRD questions, or rough requirements.
+
+Use `platty-mcp-retrieval` alone for retrieval-only answers. Use this skill when
+the task should create SDD planning files from MCP evidence and save them in the
+local Platty specs directory.
+
+## Operating Flow
+
+1. Confirm MCP capability tier and project context through `using-platty-mcp`.
+2. Route the idea through `platty-mcp-retrieval`.
+3. Require a Search Brief for broad, domain-term, policy, data, journey, or
+   impact ideas.
+4. Require the retrieval full-cycle ladder before SDD product claims.
+5. Stop if minimum retrieval or a selected branch's required evidence surface is
+   missing.
+6. Build an SDD packet from direct evidence, inference boundaries,
+   coverage limits, assumptions, confirmed decisions, and open questions.
+7. Draft `request.md` content by applying the request template.
+8. Always draft `stories.md` with `request.md` by applying the stories template.
+   If the request has unresolved questions, keep stories as draft and surface the
+   assumptions used to split scenarios.
+9. Persist both files locally under the same SDD directory.
+10. Verify both files are readable before returning the final response.
+
+## Template Contract
+
+`request.md` and `stories.md` are not free-form summaries. They must follow the
+template references exactly enough that designers, planners, and implementation
+agents can review them without reshaping them.
+
+Persist durable workflow metadata needed by later SDD stages in frontmatter:
+`projectId`, `outputLanguage`, `sourceCommit`, `sotExportedAt`,
+`evidenceBoundary`, and `contextStatus`. Keep runtime-only metadata such as
+`localPersistenceTarget`, raw MCP tool payloads, and transient candidate lists in
+the SDD packet, not in the drafted file frontmatter.
+
+`request.md` uses `references/request-shape.md` and includes these sections in
+order:
+
+```text
+§0 Impact
+§1 Customer Task
+§2 Current Situation
+§3 Limits
+§4 Solution
+§5 Rules
+§6 Confirmed Decisions
+§7 Open Questions
+§8 Validation Hypotheses
+```
+
+`stories.md` uses `references/stories-shape.md`, starts with `# User Stories`,
+uses `US-NN` story blocks with Given/When/Then scenarios, and ends with
+Traceability.
+
+## Local Persistence
+
+Persist `request.md` and `stories.md` to:
+
+```text
+~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/
+```
+
+The selected `projectId` must come from MCP project context or the resolved
+Platty project. The slug should be stable and human-readable from the request
+title or raw idea. Use the current year-month for `<YYYY-MM>` unless the user
+provided a spec id or date.
+
+Persistence rules:
+
+- Create the target directory if it does not exist.
+- Write `requestMarkdown` to `request.md`.
+- Write `storiesMarkdown` to `stories.md`.
+- Update both files together when regenerating the same spec; do not leave one
+  stale.
+- Do not delete unrelated files in the directory.
+- Verify both files are readable after writing and include both paths in the
+  final response.
+
+## SDD Packet
+
+Return these fields in the working context and final response when applicable:
+
+```text
+SDD Packet
+- projectId
+- projectName
+- rawIdea
+- selectedInterpretation
+- outputLanguage
+- requestStatus
+- evidenceBoundary
+- contextStatus
+- surfacesRead
+- normalizedTerms
+  - rawTerms
+  - koreanCandidateTerms
+  - englishCandidateTerms
+  - matchedGlossaryTerms
+  - unresolvedTerms
+- candidateEpics
+- selectedEpics
+- exactDocumentItems
+- connectedSpecs
+- sourceConfirmations
+- directEvidence
+- inferredEvidence
+- assumptions
+- confirmedDecisions
+- openQuestions
+- coverageLimits
+- requestMarkdown
+- storiesMarkdown
+- localPersistenceTarget
+```
+
+`localPersistenceTarget` is the mandatory local write target:
+
+```text
+~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/
+```
+
+## Request Gate
+
+Carry forward the local `platty-sdd-spec` request states:
+
+- `draft` while evidence and decisions are still being assembled;
+- unresolved assumptions or unanswered decisions remain visible in §7 while the
+  file frontmatter stays `status: "draft"`;
+- `approved` only after explicit user approval.
+
+Read `references/request-shape.md` before drafting request content. If the
+SDD packet has unresolved assumptions or unanswered decisions, keep the
+frontmatter `status` as `draft` and preserve the unresolved items in §7 instead
+of inventing closure.
+
+## Stories Draft
+
+Always draft `stories.md` with `request.md`. Approval controls whether the files
+can move from `draft` to `approved`; it does not control whether
+`stories.md` exists.
+
+Read `references/stories-shape.md` before drafting stories content. If
+`request.md` has open questions or assumptions, make those visible in
+`stories.md` and trace which stories would change if the answers change.
+
+## Answer Contract
+
+Use this default response shape:
+
+```text
+## request.md draft
+<full markdown>
+
+## stories.md draft
+<full markdown>
+
+## Local persistence
+Saved:
+- ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/request.md
+- ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/stories.md
+```
+
+Use "확인됨" only for exact MCP reads. Use "후보", "근거상 보임", or
+"추가 확인 필요" for search candidates, partial evidence, inferred behavior, or
+missing source parity.
+
+## Stop Conditions
+
+- MCP tools are not configured.
+- Minimum retrieval tools are missing.
+- The selected retrieval branch reports a required MCP capability gap.
+- Local filesystem write access is unavailable or the target directory cannot be
+  created.
+- The user asks for analysis, sync, generated-docs, export, project mutation, or
+  memory writes from this MCP route.
+
+## Common Mistakes
+
+| Mistake | Required behavior |
+| --- | --- |
+| Drafting from one search hit | Run `platty-mcp-retrieval` and its full-cycle ladder first. |
+| Recreating retrieval logic here | Keep retrieval in `platty-mcp-retrieval`; this skill converts evidence to SDD documents. |
+| Treating glossary normalization as proof | Use it only for routing; exact document/spec/source reads prove claims. |
+| Leaving stories behind a gate | Always draft `stories.md` with `request.md`; keep it draft and preserve assumptions when approval is missing. |
+| Returning only instructions | Persist both files locally in `~/.platty/specs/<projectId>/...` and verify both files before final response. |
+| Returning a prose SDD summary | Apply the request/stories templates and include all required sections. |
+
+## Verification
+
+Use `references/pressure-scenarios.md` when testing this skill.

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/pressure-scenarios.md
@@ -1,0 +1,137 @@
+# MCP SDD Spec Pressure Scenarios
+
+Use these scenarios to test whether `platty-mcp-sdd-spec` preserves retrieval
+discipline, SDD draft status, and local file persistence boundaries.
+
+## Scenario 1: Search-First Request Draft
+
+User asks:
+
+```text
+MCP로 체험단 참여 제한 정책 변경 request.md 초안 만들어줘.
+```
+
+Failure to prevent:
+
+- drafting from one `document_search` or glossary hit;
+- skipping `platty-mcp-retrieval`;
+- treating vocabulary normalization as proof.
+
+Expected route:
+
+```text
+using-platty-mcp capability gate
+-> platty-mcp-retrieval Search Brief
+-> full-cycle retrieval ladder
+-> request draft with evidence boundary
+```
+
+## Scenario 2: Source Parity Gap
+
+User asks for implementation impact, but source parity tools are missing.
+
+Failure to prevent:
+
+- falling back to local SOT files or local CLI;
+- claiming exact implementation impact.
+
+Expected route:
+
+```text
+carry source impact as coverage limit
+draft only product/spec claims supported by MCP evidence
+```
+
+## Scenario 2A: Bilingual Retrieval Terms In Handoff
+
+User asks:
+
+```text
+MCP로 결제 쿠폰 기능 request.md 초안 만들어줘.
+```
+
+Failure to prevent:
+
+- carrying only `normalizedTerms` as a flat note;
+- losing Korean candidate terms or English candidate terms before SDD drafting;
+- drafting from a Korean search miss without English candidate searches.
+
+Expected route:
+
+```text
+platty-mcp-retrieval Search Brief with rawTerms, koreanCandidateTerms, englishCandidateTerms
+-> glossary/search attempts recorded for both languages
+-> SDD Packet normalizedTerms includes rawTerms, koreanCandidateTerms, englishCandidateTerms, matchedGlossaryTerms, unresolvedTerms
+-> request §0 shows the search 기준 without putting MCP-only ids in frontmatter
+```
+
+## Scenario 3: Draft Stories With Open Assumptions
+
+User asks for request and stories from a broad policy change, but request has
+unresolved assumptions.
+
+Failure to prevent:
+
+- returning only `request.md` plus a stories gate;
+- hiding unresolved assumptions in generated stories.
+
+Expected route:
+
+```text
+return request.md draft
+return stories.md draft
+show assumptions used to split stories
+state that approval remains pending
+```
+
+## Scenario 4: Persistence Confusion
+
+User asks:
+
+```text
+MCP 스킬에서 ~/.platty/specs에 저장해줘.
+```
+
+Expected route:
+
+```text
+produce request.md and stories.md markdown
+resolve localPersistenceTarget
+write request.md and stories.md under ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/
+verify both files are readable
+```
+
+## Scenario 5: Retrieval Drift
+
+Failure to prevent:
+
+- writing a second retrieval ladder in this skill.
+
+Expected route:
+
+```text
+required sub-skill reference to platty-mcp-retrieval
+only SDD conversion logic lives in platty-mcp-sdd-spec
+```
+
+## Scenario 6: Template Drift
+
+User asks:
+
+```text
+MCP 근거로 request.md랑 stories.md 초안까지 만들어줘. 문서 양식은 SDD 템플릿으로 맞춰줘.
+```
+
+Failure to prevent:
+
+- returning a prose requirements summary instead of `request.md`;
+- using generic numbered sections instead of `§0 Impact` through `§8 Validation Hypotheses`;
+- drafting stories without `US-NN`, Given/When/Then scenarios, and Traceability.
+
+Expected route:
+
+```text
+read request-shape.md before request drafting
+read stories-shape.md before stories drafting
+return drafts in the template shape without closing unresolved questions
+```

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/request-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/request-shape.md
@@ -1,0 +1,132 @@
+# MCP SDD Request Shape
+
+Use this template reference when `platty-mcp-sdd-spec` drafts `request.md`.
+Preserve this section order. Fill unknowns as open questions or assumptions
+instead of changing the template.
+
+## Frontmatter
+
+```yaml
+---
+id: "SPEC-<slug>-<YYYY-MM>"
+type: "spec-request"
+status: "draft"       # draft -> approved -> design -> tasks -> done
+projectId: "<projectId>"
+outputLanguage: "ko"
+sourceCommit: "<source commit or unknown>"
+sotExportedAt: "<ISO timestamp or unknown>"
+evidenceBoundary: "<MCP evidence surfaces used>"
+contextStatus: "<fresh | stale | unknown>"
+epic: "<EPIC, EPIC>"
+created: "<YYYY-MM-DD>"
+---
+```
+
+## Required Sections
+
+```markdown
+# <Request Title>
+
+> <One-paragraph product intent, grounded in MCP evidence and clearly marked assumptions.>
+
+## §0 Impact
+
+- **영향 유저**
+  - <Affected users or actors>
+- **검색 기준**
+  - Raw terms: <raw user terms>
+  - Korean candidate terms: <Korean terms searched>
+  - English candidate terms: <English terms searched>
+- **영향 EPIC**
+  - <EPIC>: <affected product area>
+- **영향 화면**
+  - <screen/flow/API if known>
+- **관련 SOT**
+  - <MCP document/spec ids read>
+- **관련 코드 참조**
+  - <source confirmations or "추가 확인 필요">
+
+## §1 Customer Task
+
+> 유저와 제품팀이 해결하려는 일
+
+- **<actor>**: "<job-to-be-done>"
+
+## §2 Current Situation
+
+### 2-1. 관측된 문제
+
+- <Observed problem, metric, workflow gap, or policy conflict>
+
+### 2-2. 문제가 아닌 것으로 본 영역
+
+- <Non-goal or area not treated as the bottleneck>
+
+### 2-3. 데이터 해석 주의
+
+- <Data caveat, freshness caveat, source parity limit, or MCP coverage limit>
+
+## §3 Limits
+
+> 기존 해결책의 한계와 이번 변경의 범위
+
+- <Why existing behavior or workaround is insufficient>
+
+## §4 Solution
+
+> 제안하는 변경 내용
+
+### 4-1. <solution area>
+
+- <Requested product behavior>
+
+## §5 Rules
+
+> EARS 패턴 비즈니스 규칙
+
+| ID | EARS 텍스트 | 비고 |
+|----|------------|------|
+| R1 | WHEN <trigger>, 시스템은 <observable behavior>. | <evidence or assumption> |
+
+## §6 Confirmed Decisions
+
+> 대화 중 확정된 의사결정
+
+| ID | 결정 | 근거 |
+|----|------|------|
+| D1 | <Only user-approved or exact MCP evidence-backed decision> | <basis> |
+
+## §7 Open Questions
+
+> 미결 사항 — design/tasks 단계 전 확인 필요
+
+| ID | 질문 | 추천안 |
+|----|------|--------|
+| O1 | <Question> | <Recommended default and implication> |
+
+## §8 Validation Hypotheses
+
+> 성공 검증 방법
+
+| ID | 가설 | 측정 기준 | 목표 방향 |
+|----|------|----------|----------|
+| H1 | <Hypothesis> | <Metric or validation signal> | <Target direction> |
+```
+
+## MCP Grounding Slots
+
+- Put exact MCP reads in §0 `관련 SOT` and §6 decision bases.
+- Put source parity gaps, stale evidence, and data caveats in §2-3.
+- Put unresolved assumptions in §7, not in §6.
+- Keep MCP-only metadata such as project id, output language, evidence boundary,
+  context status, derived evidence ids, and local persistence target outside the
+  markdown draft in the SDD Handoff Packet.
+
+## Rules
+
+- Explain internal names before listing ids, symbols, APIs, or document keys.
+- Keep raw user terms, Korean candidate terms, English candidate terms, and
+  matched glossary terms visible when retrieval normalized vocabulary.
+- Do not promote open questions or assumptions into confirmed decisions.
+- Mark source-level impact as a coverage limit when source parity is missing.
+- Every §5 rule must be observable or testable.

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/stories-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/stories-shape.md
@@ -1,0 +1,76 @@
+# MCP SDD Stories Shape
+
+Use this template reference whenever `platty-mcp-sdd-spec` drafts
+`stories.md`. Preserve this story/scenario/traceability shape so designers,
+planners, and implementation agents can review the same product behavior.
+
+## Frontmatter
+
+```yaml
+---
+id: "SPEC-<slug>-<YYYY-MM>"
+type: "spec-stories"
+status: "draft"       # draft -> approved
+projectId: "<projectId>"
+outputLanguage: "ko"
+sourceCommit: "<source commit or unknown>"
+sotExportedAt: "<ISO timestamp or unknown>"
+evidenceBoundary: "<MCP evidence surfaces used>"
+contextStatus: "<fresh | stale | unknown>"
+derived_from: "request.md"
+---
+```
+
+## Required Sections
+
+```markdown
+# User Stories — <Request Title>
+
+> request.md의 §1 Customer Task + §5 Rules에서 파생.
+> 디자이너·기획자가 사용자 관점에서 시나리오를 검토할 수 있도록 Given-When-Then 형식으로 작성.
+> 내부 구현 방식보다 유저가 인지하는 결과와 제품팀이 검증해야 할 행동을 중심으로 기술한다.
+
+---
+
+## US-01: <story title>
+
+**As a** <actor><br>
+**I want** <goal><br>
+**So that** <outcome>
+
+### Scenario 1: <scenario title> (정상)
+
+- **Given** <user/system state>
+- **When** <user action or system trigger>
+- **Then** <visible or measurable result>
+- **And** <optional additional result>
+
+### Scenario 2: <scenario title> (엣지)
+
+- **Given** <edge state>
+- **When** <action or trigger>
+- **Then** <expected behavior>
+
+---
+
+## Traceability
+
+> 각 User Story가 어떤 Rule(§5)에서 파생됐는지 추적
+
+| User Story | Scenario | 관련 Rules | 비고 |
+|------------|----------|------------|------|
+| US-01 | S1 <scenario> | R1 | <note> |
+
+**Rule 커버리지: R1~R<N> 전부 1개 이상 시나리오에 매핑 (<N>/<N>, 100%)**
+```
+
+## Rules
+
+- Every story must map to a request rule or open assumption.
+- Do not invent implementation detail that the request did not establish.
+- Preserve unresolved assumptions instead of silently closing them.
+- If `request.md` is still draft, keep `stories.md` draft and include the
+  assumptions that were used to split stories.
+- Keep runtime-only metadata outside the markdown draft in the SDD packet.
+- If a request rule has no scenario, keep the coverage line below 100% and call
+  out the missing rule in Traceability.

--- a/plugins/platty-mcp/skills/using-platty-mcp/SKILL.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/SKILL.md
@@ -1,19 +1,26 @@
 ---
 name: using-platty-mcp
-description: Use when a task should use configured read-only Platty MCP tools for remote project context, tool capability checks, client setup routing, or routing Platty MCP retrieval.
+description: Use when a task should use configured Platty MCP tools for remote project context, tool capability checks, client setup routing, Platty MCP retrieval, memory lifecycle routing, or MCP-grounded SDD file creation.
 ---
 
 # Using Platty MCP
 
-Platty MCP is read-only remote context transport. It is not a local Platty CLI
-runtime and it is not an analysis, sync, generation, mutation, cache, or
-memory-write surface.
+Platty MCP is remote context transport. It is not a local Platty CLI runtime and
+it is not an analysis, sync, server-side document generation, cache, or
+generated-SOT editing surface. Most MCP routes are read-only. Explicit memory
+lifecycle requests route to `platty-mcp-memory`. MCP skills may author
+evidence-backed drafts. The SDD exceptions are `platty-mcp-sdd-spec` and
+`platty-mcp-sdd-design`, which may read or write SDD files under
+`~/.platty/specs/<projectId>/...`.
 
 ## Boundary
 
 Use only configured MCP tools. Do not run local Platty CLI commands, mutate
-projects, refresh caches, generate documents, or write memory from this route.
-SOT files may be read only through configured MCP artifact tools.
+projects, refresh caches, run server-side document generation, or write memory
+except through `platty-mcp-memory` after explicit user intent.
+SOT files may be read only through configured MCP artifact tools. Local file
+access is allowed only for selected SDD draft files under
+`~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/`.
 
 If a requested answer needs a missing MCP surface, report the capability gap.
 Do not silently switch to local files or local CLI.
@@ -22,8 +29,11 @@ Do not silently switch to local files or local CLI.
 
 Keep the setup split thin and explicit:
 
-1. If Platty MCP tools are visible, run the capability gate and then route to
-   `platty-mcp-retrieval` for read-only project questions.
+1. If Platty MCP tools are visible, run the capability gate and then route:
+   - read-only project questions to `platty-mcp-retrieval`;
+   - explicit memory read/write/update/delete requests to `platty-mcp-memory`;
+   - MCP-grounded SDD request/story file creation to `platty-mcp-sdd-spec`;
+   - MCP-grounded SDD design/task file creation to `platty-mcp-sdd-design`.
 2. If MCP tools are missing but the user already has a `/api/mcp` URL, route to
    `platty-mcp-client-setup`.
 3. If there is no URL or server and the user is the operator, route to
@@ -39,6 +49,8 @@ Before relying on MCP evidence:
 2. Call the runtime's tool listing mechanism.
 3. Classify available tools by tier:
    - minimum retrieval;
+   - memory overlay reads;
+   - memory lifecycle;
    - search assist;
    - source parity;
    - artifact access.
@@ -48,6 +60,10 @@ Before relying on MCP evidence:
 
 For exact tool names and required inputs, read
 `references/tool-mapping.md`.
+
+For the MCP DB/read-model structure, document/spec link relationships, retrieval
+order, and SOT projection boundary, read
+`references/retrieval-architecture.md`.
 
 For SOT file roots and stored file content behavior, read
 `references/artifact-access.md`.
@@ -74,13 +90,43 @@ Keep MCP usage and retrieval judgment separate:
 ```text
 using-platty-mcp       -> transport boundary, capability gate, tool mapping
 platty-mcp-retrieval   -> question route, map-first ladder, evidence gates
+platty-mcp-memory      -> explicit memory read/write/update/delete lifecycle
 ```
+
+## SDD File Routing
+
+For MCP-grounded SDD request/story authoring from a product idea, feature
+request, policy change, PRD need, or requirements discussion, use
+`platty-mcp-sdd-spec` after the capability gate.
+
+That skill must use `platty-mcp-retrieval` for evidence. It writes
+`request.md` and `stories.md` directly to
+`~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/` and verifies both files.
+
+For MCP-grounded SDD technical design from existing request/story inputs, use
+`platty-mcp-sdd-design` after the capability gate. It may read only
+`request.md` and `stories.md` from the selected SDD directory, writes
+`design.md`, and writes `tasks.md` only when the design is approved or the user
+explicitly asks for draft tasks.
+
+## Memory Lifecycle Routing
+
+For explicit memory read, record, correct, update, or delete requests, use
+`platty-mcp-memory` after the capability gate.
+
+That skill may use memory mutation tools only for explicit user intent. Normal
+retrieval answers remain read-only and keep memory overlays separate from
+generated SOT, specs, and source evidence.
 
 ## Stop Conditions
 
 - MCP tools are not configured.
 - Minimum retrieval tools are missing.
-- The task asks for setup, analysis, sync, generation, mutation, local cache
-  changes, local files, local CLI, or memory writes.
+- The task asks for setup, analysis, sync, server-side document generation,
+  project mutation, local cache changes, local CLI, or memory writes outside
+  `platty-mcp-memory`.
+- The task asks for local file access outside the `platty-mcp-sdd-spec` or
+  `platty-mcp-sdd-design`
+  `~/.platty/specs/<projectId>/...` SDD read/write exception.
 - A retrieval branch needs a missing search-assist or source-parity tool.
 - The user asks for an SOT artifact and no artifact access tier is configured.

--- a/plugins/platty-mcp/skills/using-platty-mcp/references/artifact-access.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/references/artifact-access.md
@@ -2,7 +2,9 @@
 
 Use this reference when the user asks for original stored SOT file content or a
 stored artifact path. Artifact access is read-only transport, not retrieval
-proof by itself. Download and bundle metadata tools are not exposed.
+proof by itself. Download and bundle metadata tools are not exposed. For the
+DB-backed retrieval order and SOT projection boundary, read
+`retrieval-architecture.md`.
 
 ## Storage Roots
 

--- a/plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.md
@@ -1,0 +1,167 @@
+# MCP Retrieval Architecture
+
+Use this reference when a user asks how Platty MCP search works, how documents
+and specs are stored, whether `spec_list` or `spec_resolve` are part of the
+route, or how DB evidence relates to stored SOT files.
+
+## Boundary
+
+Platty MCP is a read-model transport over an already prepared Platty context DB.
+It does not analyze a repo, generate docs, export files, refresh caches, mutate
+projects, or run the local Platty CLI.
+
+The primary evidence store is `PLATTY_CONTEXT_DB_PATH`. Stored SOT files under
+`PLATTY_CONTEXT_SOT_ROOT` are an optional projection for file content access.
+They are not the primary retrieval path.
+
+## Route First
+
+Explain MCP architecture by the tool route first. Mention DB structure only to
+explain why the next tool is needed.
+
+```text
+question
+-> choose project and check freshness
+-> choose business map or source-near route
+-> read exact document/item/spec detail
+-> resolve connected context when crossing surfaces
+-> use graph/code tools only when source confirmation or impact is required
+```
+
+## Route Map
+
+| Question shape | Primary route | Proof threshold |
+| --- | --- | --- |
+| Project scope, freshness, available context | `project_list` -> `project_get` when needed -> `context_status` -> `project_overview_get` | status/overview can frame scope, not prove detailed behavior |
+| Domain term, alias, Korean/English wording | `glossary_translate` -> continue to the relevant route | glossary is normalization, not proof |
+| Broad policy, business rule, design, data, journey | `epic_list` -> `epic_get` -> `document_list` -> `document_get` -> `document_item_list` -> `document_item_get` | exact item read is the business-document proof |
+| Business item to source-near API/screen/event/schedule | `document_resolve` -> rank linked `api_spec`/`screen_spec` candidates -> `spec_list` or `spec_search` when more mapping is needed -> `spec_get` -> `spec_resolve` | exact spec read is the source-near proof; resolve completes connected context |
+| Known exact spec id | `spec_get` -> `spec_resolve` | exact spec read proves the spec; resolve completes connected context |
+| Impact, dependency, implementation location | `document_resolve` or `spec_resolve` -> `graph_trace` / `code_search` -> `code_snippet` | graph/code result or snippet, with missing-tool caveat when unavailable |
+| Original stored SOT file request | `sot_file_get` | file content only; not proof for behavior unless paired with structured evidence |
+
+## Full Ladder
+
+For broad product, policy, data, design, journey, or impact questions, use the
+map-first ladder:
+
+```text
+project_list / project_get / context_status
+-> project_overview_get
+-> glossary_translate when terms, aliases, or Korean/English mapping matter
+-> epic_list / epic_get
+-> memory_list / memory_get overlay when relevant and available
+-> document_list by type and epic
+-> document_get
+-> document_item_list / document_item_get
+-> document_resolve
+-> rank linked api_spec and screen_spec candidates
+-> spec_list or spec_search when connected source-near specs are incomplete or unknown
+-> spec_get before exact source-near behavior claims
+-> spec_resolve to expand selected specs to related documents, items, graph seeds, and code seeds
+-> graph_trace / code_search / code_snippet for impact, location, or source confirmation
+```
+
+`document_resolve`, `spec_list`, `spec_search`, `spec_get`, and `spec_resolve`
+are part of the search path when the answer needs source-near anchors. Do not
+skip from a business document search result directly to a claim about API shape,
+screen behavior, event behavior, schedule behavior, or implementation.
+
+Treat `spec_search` as paired discovery: after it selects a candidate, immediately run `spec_get` and `spec_resolve` before making source-near, impact, graph, code, or implementation claims.
+
+## Why These Tools Exist
+
+The tools expose DB relationships without requiring the agent to query tables
+directly:
+
+```text
+project
+-> epics
+-> documents
+   - business documents: br, design, data_dictionary, ucl, ucs
+   - source-near specs: api_spec, screen_spec, event_spec, schedule_spec
+-> document_items
+   - item-level business/design/data/use-case evidence
+-> document_item_document_links
+   - item -> connected document or spec
+-> document_item_item_links
+   - item -> related item
+-> document_item_relation_links
+   - item -> graph/code relation candidate, source node, target, evidence nodes
+-> document_item_model_links
+   - item -> model or field evidence
+```
+
+Memory is a separate overlay. It can correct, explain, or constrain an answer,
+but it does not replace generated documents, specs, graph evidence, or source
+snippets.
+
+## Evidence Stores
+
+| Store | What it contains | MCP role |
+| --- | --- | --- |
+| Context DB | projects, repositories, epics, documents, document items, specs, links, graph/code evidence, models, memories | primary structured retrieval through tools |
+| SOT root | Markdown/JSON projection such as catalogs, epic files, specs, indexes, memories, questions | optional stored file content through `sot_file_get` |
+
+Use DB-backed tools for factual answers. Use `sot_file_get` only when the user
+asks to read an original stored SOT file by project-relative path.
+
+## Tool Roles
+
+| Tool | Role |
+| --- | --- |
+| `document_list` | finds business docs or source-near docs by type/scope |
+| `document_get` | reads one document summary/content envelope |
+| `document_item_list` | finds item-level BR/DD/DESIGN/UCL/UCS evidence |
+| `document_item_get` | reads exact item content |
+| `document_resolve` | first bridge from document/item evidence to linked specs, linked docs, items, relation candidates |
+| `spec_list` | lists source-near specs by kind, scope, status, or filters |
+| `spec_search` | targeted discovery when the exact spec id is unknown |
+| `spec_get` | reads exact source-near spec detail before source-near claims |
+| `spec_resolve` | post-selection expansion from a spec to related docs/items plus graph/code seeds |
+| `graph_trace` | follows graph impact or dependency paths when exposed |
+| `code_search` / `code_snippet` | confirms exact code location or implementation when exposed |
+| `sot_file_get` | reads stored SOT file content only; not proof by itself |
+
+## SOT Projection Shape
+
+The SOT root mirrors DB evidence for human/file access. Common paths include:
+
+```text
+overview.md
+catalog/epics.md
+catalog/apis.md
+catalog/screens.md
+catalog/events.md
+catalog/schedules.md
+epics/<epic-id>/br.md
+epics/<epic-id>/design.md
+epics/<epic-id>/data_dictionary.md
+epics/<epic-id>/usecases/ucl.md
+epics/<epic-id>/usecases/ucs.md
+specs/api/<name>.md
+specs/screen/<name>.md
+specs/event/<name>.md
+specs/schedule/<name>.md
+project/glossary.index.json
+project/claim.index.json
+```
+
+Treat these files as a stored projection. If the user asks about architecture,
+search order, policy, behavior, or impact, prefer structured MCP tools first
+and use SOT files only as requested file content.
+
+## Common Mistakes
+
+- Do not treat `sot_file_get`, catalog text, or artifact paths as the proof path
+  for behavior claims.
+- Do not use old bundle/download tool names. This MCP profile exposes
+  `sot_file_get` for stored file content only.
+- Do not answer broad business questions from `spec_search` alone. Walk the
+  project/epic/document/item map first unless the user gave an exact spec id.
+- Do not answer exact API, screen, event, schedule, graph, or code claims before
+  reading `spec_get`; use source tools when the branch requires code parity.
+- Do not skip `spec_resolve` after selected spec reads in source-near branches;
+  it completes related document/item and graph/code seed context.
+- Do not fall back to local files or the local Platty CLI when MCP tools or
+  artifact access are missing.

--- a/plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md
@@ -7,6 +7,8 @@ This is the MCP-only intent-to-tool map. It does not list local CLI equivalents.
 | Tier | Required tools | Supported scope |
 | --- | --- | --- |
 | Minimum retrieval | `project_list`, `project_get`, `context_status`, `project_overview_get`, `glossary_translate`, `epic_list`, `epic_get`, `document_list`, `document_get`, `document_item_list`, `document_item_get`, `document_resolve`, `spec_get` | map-first business/spec retrieval without source-level confirmation |
+| Memory overlay reads | `memory_list`, `memory_get` | read-only human/agent correction, constraint, why, and context overlays |
+| Memory lifecycle | `memory_add`, `memory_update`, `memory_delete` | explicit memory mutation after user intent and anchor resolution |
 | Search assist | `ssot_search`, `ssot_get`, `ssot_resolve`, `document_search`, `spec_list`, `spec_search`, `spec_resolve` | targeted discovery, connected context, and source-near anchor resolution |
 | Source parity | `graph_trace`, `code_search`, `code_snippet` | impact, exact code location, source confirmation, and negative source evidence |
 | Artifact access | `sot_file_get` | stored SOT file content access, not factual proof by itself |
@@ -22,6 +24,11 @@ This is the MCP-only intent-to-tool map. It does not list local CLI equivalents.
 | Vocabulary normalization | `glossary_translate` | `projectId`, `text` |
 | Epic catalog | `epic_list` | `projectId` |
 | Epic detail | `epic_get` | `projectId`, `epicId` |
+| Memory list | `memory_list` | `projectId`; optional `epicId`, `documentId`, `level`, `includeDeleted` |
+| Memory detail | `memory_get` | `projectId`, `memoryId` |
+| Memory add | `memory_add` | `projectId`, `content`; optional `epicId`, `documentId`, `itemType`, `itemKey`, `memoryKind`, `actor`, `confidence` |
+| Memory update | `memory_update` | `projectId`, `memoryId`, `content`, `reason`; optional `actor` |
+| Memory delete | `memory_delete` | `projectId`, `memoryId`, `reason`; optional `actor` |
 | Document list | `document_list` | `projectId`; optional `documentType`, `epicId`, `entityName`, `status`, `limit`, `cursor` |
 | Document detail | `document_get` | `projectId`, `id` |
 | Business document items | `document_item_list` | `projectId`, `documentId`; optional `itemType`, `query`, `limit`, `cursor` |
@@ -48,5 +55,19 @@ This is the MCP-only intent-to-tool map. It does not list local CLI equivalents.
   targeted discovery or connected context.
 - Missing source parity tools: answer only from map/spec evidence and say source
   confirmation is unavailable.
+- Missing memory overlay tools: use attached `epic_get.memories` and
+  `document_get.memories` when present; otherwise name memory revision/detail as
+  unavailable instead of using local files or CLI.
+- Missing memory lifecycle tools: answer read-only when possible, or report a
+  memory mutation capability gap. Do not fall back to local CLI from MCP.
 - Missing artifact access tools: answer retrieval questions from structured
   evidence, but report that stored SOT file content access is unavailable.
+
+`memory_add`, `memory_update`, and `memory_delete` are mutation tools. Use them
+only through `platty-mcp-memory`, not from the read-only retrieval route.
+
+Project-wide memory is stored on the project overview document: call
+`project_overview_get`, then use `overview.id` as `documentId`. The MCP memory
+write contract has no project-only anchor. If `project_overview_get.overview`
+is null, stop and ask for an epic/document/item anchor or report that
+project-wide memory cannot be written from MCP.

--- a/plugins/platty/skills/platty-mcp-server-setup/SKILL.md
+++ b/plugins/platty/skills/platty-mcp-server-setup/SKILL.md
@@ -121,7 +121,7 @@ If stored SOT artifacts should be available, verify the artifact tier:
 curl -sS -X POST "$PLATTY_MCP_URL" \
   -H 'content-type: application/json' \
   -H 'accept: application/json, text/event-stream' \
-  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"ssot_bundle_download","arguments":{"projectId":"<project-id>"}}}'
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"sot_file_get","arguments":{"projectId":"<project-id>","path":"overview.md"}}}'
 ```
 
 ## Remote Security

--- a/plugins/platty/skills/platty-sdd-spec/SKILL.md
+++ b/plugins/platty/skills/platty-sdd-spec/SKILL.md
@@ -23,6 +23,11 @@ Do not write SDD documents to repository-local paths such as `docs/sdd/` or
 `.platty/sdd/`. The Platty web dashboard treats the global Platty home as the
 managed SDD source.
 
+When this skill authors SDD product documents, write both `request.md` and `stories.md` in the same SDD directory.
+Do not leave `stories.md` as a chat-only gate or handoff note. If decisions are unresolved, keep both files in draft
+state and make those assumptions visible in `request.md` §7 and in
+`stories.md`.
+
 ## Required Gates
 
 1. Resolve a Platty project before project-scoped commands.
@@ -30,7 +35,7 @@ managed SDD source.
 3. Read SOT `README.md` and `catalog/epics.md`; use `sot glossary search` for raw terms, aliases, or translated concepts before product claims.
 4. Declare the evidence boundary: `business-docs`, `static-only`, `mixed`, or `stale`.
 5. Ask SOT-informed questions before finalizing `request.md`.
-6. Do not generate `stories.md` until `request.md` is `approved`, unless the user explicitly accepts unresolved assumptions.
+6. Generate `stories.md` with `request.md` as a draft even when open questions remain. Approval gates control `approved` status and design readiness, not whether the stories file exists.
 7. Set the output language before authoring. Use the language the user requested for the spec; if no language is explicitly requested, infer it from the user's latest idea/request and confirm only when mixed-language intent is ambiguous.
 
 Use the Platty CLI convention from `using-platty`. Inside this repository, `AGENTS.md` overrides public plugin examples: run the local build with `node packages/cli/dist/main.js <command> --json`.
@@ -76,6 +81,9 @@ Question categories:
 - success: measurable validation and release criteria.
 
 Confirmed answers go to `§6 Confirmed Decisions`. Unresolved items stay in `§7 Open Questions`.
+When unresolved items affect stories, write the stories from clearly named
+recommended defaults or assumptions and include an assumptions/impact section in
+`stories.md` so later edits know what must change.
 
 ## Output Language
 
@@ -114,6 +122,17 @@ Read reference templates only when writing the files:
 - `references/stories-template.md`
 - `references/spec-review-rubric.md`
 
+Authoring order:
+
+1. Create or update `request.md`.
+2. Create or update `stories.md` in the same directory from `request.md` §1 and
+   §5.
+3. When unresolved open questions remain, keep both documents as draft.
+4. Keep `request.md` as `draft-with-open-questions` and `stories.md` as `draft`
+   when unresolved open questions or assumptions remain.
+5. Include all unresolved assumptions that affect story splitting in
+   `stories.md`; do not silently close them.
+
 `request.md` status:
 
 - `draft` while being filled;
@@ -140,6 +159,7 @@ Read reference templates only when writing the files:
 | --- | --- |
 | "I know the domain term." | Run `sot glossary search` first. |
 | "The user wants speed, skip questions." | Draft with named assumptions and use `draft-with-open-questions`. |
+| "Stories need approval first." | Approval controls `approved` status. Still create `stories.md` as `draft` beside `request.md` and preserve assumptions. |
 | "Business docs are missing, so invent product intent from code." | Use static evidence only and state the boundary. |
 | "A code term can go directly to graph trace." | Resolve code term with `code search` first. |
 | "Fix the generated SOT markdown." | Never edit SOT projection; suggest memory or regeneration. |


### PR DESCRIPTION
## Summary
- Release Platty agent plugin v0.0.3 build 202607091043.

## Release metadata
- Version: `0.0.3`
- Build: `202607091043`
- Branch: `release/platty-plugin-v0.0.3-build-202607091043`
- Source commit: `669c491ded0d49606931d23ee3c047227d64fd08`

## Exported managed paths
- `.agents`
- `.claude-plugin`
- `plugins/platty`
- `plugins/platty-mcp`
- `guide`
- `README.md`
- `README.ko.md`
- `GETTING_STARTED.md`
- `LICENSE.md`

## Changed files
- `.claude-plugin/marketplace.json`
- `README.ko.md`
- `README.md`
- `plugins/platty-mcp/.claude-plugin/plugin.json`
- `plugins/platty-mcp/.codex-plugin/plugin.json`
- `plugins/platty-mcp/README.md`
- `plugins/platty-mcp/skills/platty-mcp-client-setup/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/answer-shape.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/search-clarification.md`
- `plugins/platty-mcp/skills/using-platty-mcp/SKILL.md`
- `plugins/platty-mcp/skills/using-platty-mcp/references/artifact-access.md`
- `plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md`
- `plugins/platty/skills/platty-mcp-server-setup/SKILL.md`
- `plugins/platty/skills/platty-sdd-spec/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-memory/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-memory/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-shape.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/references/tasks-shape.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/request-shape.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/stories-shape.md`
- `plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.md`

## Safety gate result
- `public_plugin_release_safety: passed`

## Verification
- `npm run check:agent-skills`
- `npm run check:agent-marketplace`
- `node --test tests/export-public-plugin-repo.test.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platty MCP 플러그인의 범위가 읽기 전용 조회에서 메모리 관리와 SDD handoff까지 확장되었습니다.
  * SDD 요청, 스토리, 설계, 작업 초안용 새 문서 템플릿과 압력 테스트 시나리오가 추가되었습니다.
* **Documentation**
  * 한국어/영문 README와 사용 가이드가 업데이트되어, 각 작업에 맞는 플러그인과 사용 흐름이 더 명확해졌습니다.
  * 검색, 메모리, SDD 작성 시의 경계와 응답 형식 안내가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->