### PR TITLE
Release Platty agent plugin v0.0.3 build 202607100115

### DIFF
--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md
@@ -29,7 +29,9 @@ files, read local SOT, mutate projects, generate documents, or write memory. Sto
 files are available only through MCP artifact tools and need exact evidence
 reads before behavior claims.
 
-Memory overlay reads: check `epic_get.memories`, `document_get.memories`, `memory_list`, and `memory_get` when overlays could affect the answer boundary.
+Memory overlay reads: read selected `project_overview_get.overview.memories`,
+`epic_get.memories`, and `document_get.memories`. Use `memory_list` or
+`memory_get` when only counts/ids are visible or overlays may affect the answer.
 
 ## When To Use
 
@@ -55,8 +57,8 @@ local cache changes, or local inspection. Report those as boundary gaps.
 8. Answer with evidence boundary, direct evidence, inference, memory overlay,
    and missing MCP surfaces separated.
 
-If the answer needs correction recording, memory re-anchoring, refresh, sync, or
-generation, stop and report a configuration/boundary gap.
+If the answer needs correction recording, re-anchoring, refresh, sync, or
+generation, report a boundary gap.
 
 ## Quick Rules
 
@@ -90,6 +92,7 @@ Search Brief
 - Raw terms:
 - Korean candidate terms:
 - English candidate terms:
+- Alias candidates:
 - Glossary searches attempted:
 - Search-assist queries attempted:
 - Candidate MCP route:
@@ -131,7 +134,7 @@ Branch criteria: `references/question-routes.md`.
 - Exact implementation, response shape, permission, DB write, event emit,
   external call, or negative source evidence requires source-level confirmation
   when the MCP server exposes it.
-- If `document_item_list` with `query` or `itemType` returns no rows but reports
+- If `document_item_list` with `itemType` returns no rows but reports
   available items or emits
   `DOCUMENT_ITEM_FILTER_EMPTY_WITH_AVAILABLE_ITEMS`, retry the same document
   without the narrowing filter before treating the item as absent.
@@ -158,9 +161,9 @@ If MCP evidence leaves tied interpretations, ask one clarifying question with a
 recommended interpretation. Stop only when ambiguity cannot be resolved within
 MCP evidence.
 
-If evidence is weak, name the next read-only MCP surface. If it requires
-refresh, export, sync, generation, memory write, or local file access, stop and
-report a configuration/boundary gap.
+If evidence is weak, name the next read-only MCP surface. If that requires
+refresh, export, sync, generation, memory write, or local files, report a
+configuration/boundary gap.
 
 ## Final Route Audit
 
@@ -181,8 +184,8 @@ uncertainty last. Full template: `references/answer-shape.md`.
 ```
 
 Explain internal names before technical ids. Use "확인됨" only for exact MCP
-content reads; use "후보", "근거상 보임", or "추가 확인 필요" for search hits,
-partial specs, or inferred behavior.
+content reads; use "후보", "근거상 보임", or "추가 확인 필요" for search hits or
+inferred behavior.
 
 ## Answer Contract
 

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md
@@ -6,21 +6,19 @@ detail second.
 
 ```text
 project_list/project_get/context_status
--> project_overview_get
--> glossary_translate when raw terms, Korean/English bridges, aliases, or ambiguity matter
+-> project_overview_get; read project_overview_get.overview.memories when present
+-> glossary_translate when raw terms, Korean/English bridges, aliases, or ambiguity matter; record matched terms and alias candidates
 -> epic_list
--> epic_get for each plausible candidate epic before discarding it
--> memory overlay check from epic_get.memories; use memory_list/memory_get if needed
+-> epic_get for each plausible candidate epic before discarding it; read epic_get.memories for selected candidate epics
 -> document_list for the selected branch:
    BR for policy/rule/eligibility
    DD for entity, table, field, or data-shape questions
-   DESIGN for system design, integration, data flow, or architecture questions
+   [MUST] DESIGN for system design, integration, data flow, or architecture questions
    UCL for capability, journey, screen, or user action questions
--> document_get/document_item_list to map candidate items
--> memory overlay check from document_get.memories and document_search.memoryCount
+-> document_get/document_item_list to map candidate items; read document_get.memories for selected documents
 -> document_item_get for exact BR/DD/DESIGN/UCL evidence
--> document_resolve to find connected API, screen, event, data, service, or spec anchors
--> rank linked api_spec and screen_spec candidates; use spec_list/spec_search only when the linked set is incomplete or the exact spec id is unknown
+-> document_resolve to find connected API, screen, event, data, service, or spec anchors and collect linked api_spec/screen_spec spec ids when returned
+-> rank linked api_spec and screen_spec candidates and keep the selected spec ids visible; use spec_list/spec_search only when the linked set is incomplete or the exact spec id is unknown
 -> when spec_search is used, select candidate specs before making claims
 -> spec_get for exact source-near behavior
 -> spec_resolve to expand selected specs to related documents, items, graph seeds, and code seeds
@@ -42,8 +40,8 @@ documents and items as the map, not as source-near proof:
 business question
 -> document_list/document_get/document_item_list
 -> document_item_get for exact business item
--> document_resolve to expose linked specs
--> rank linked api_spec and screen_spec candidates
+-> document_resolve to expose linked specs and collect linked api_spec/screen_spec spec ids when returned
+-> rank linked api_spec and screen_spec candidates and keep selected spec ids visible
 -> spec_list/spec_search only if linked specs are incomplete or the exact spec id is unknown
 -> when spec_search is used, select candidate specs before making claims
 -> spec_get for selected api_spec/screen_spec details
@@ -62,11 +60,13 @@ target, and same branch intent rank first. Do not open every connected spec up f
 read `spec_get` and then `spec_resolve` for the selected specs before
 source-near claims.
 
-Memory overlays are correction/constraint/why/context notes attached to epics
-or documents. Read attached overlays before final answers for the selected
-scope. If only `memoryCount` or `memoryId` is visible, use `memory_list` or
-`memory_get` when the overlay could change the answer boundary. Do not treat
-memory as generated SOT or source proof.
+Memory overlays are correction/constraint/why/context notes attached to the
+overview, epics, documents, items, or specs. Read attached memories at each
+selected surface: `project_overview_get.overview.memories`,
+`epic_get.memories`, `document_get.memories`, item memories, and spec memories
+when those surfaces return them. If only `memoryCount` or `memoryId` is visible,
+use `memory_list` or `memory_get` when the overlay could change the answer
+boundary. Do not treat memory as generated SOT or source proof.
 
 ## Retrieval Order
 
@@ -75,8 +75,8 @@ project context
 -> context status
 -> capability check
 -> Search Clarification Gate when triggers fire
--> project overview
--> vocabulary normalization when raw terms, Korean/English bridges, aliases, or ambiguity matter
+-> project overview with attached overview memories when present
+-> vocabulary normalization when raw terms, Korean/English bridges, aliases, or ambiguity matter; include alias candidates
 -> candidate epic
 -> candidate BR/DD/DESIGN/UCL document map
 -> question branch
@@ -99,12 +99,14 @@ confident answer:
 2. Raw terms, Korean candidate terms and English candidate terms are both visible
    when Korean/English vocabulary may not line up.
 3. Glossary/vocabulary output was used only for routing, not as behavior proof.
-4. Project overview and epic map were read before choosing the final scope.
+4. Project overview, attached overview memories when present, and epic map were
+   read before choosing the final scope.
 5. Relevant candidate EPICs were not discarded from one search miss, snippet, or
    weak score.
 6. Candidate BR/DD/DESIGN/UCL document maps were built for the selected branch.
-7. Relevant attached memory overlays were checked and separated from generated
-   SOT/source evidence.
+7. Relevant attached memory overlays on selected overview, epics, documents,
+   items, or specs were checked and separated from generated SOT/source
+   evidence.
 8. Exact document items were read before making business, data, design, or
    capability claims.
 9. If a selected document exposes item summaries but `document_item_list` returns
@@ -113,7 +115,8 @@ confident answer:
    the document body.
 10. Connected context was resolved before following source-near specs.
 11. Linked `api_spec` and `screen_spec` candidates were ranked before exact
-    source-near spec reads when starting from business docs.
+    source-near spec reads when starting from business docs, and returned spec
+    ids were kept visible for the selected candidates.
 12. Exact specs were read before source-near behavior claims.
 13. `spec_resolve` was run after selected spec reads to expose related
     docs/items, graph seeds, code seeds, and reverse anchors.

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.md
@@ -367,7 +367,7 @@ Failure to prevent:
 - choosing only the checkout/payment epic because discount/order evidence is easy to find;
 - saying coupon is a new feature before checking point/coupon issuance candidates;
 - treating `ShoppingOrderDiscountLine` as proof that coupon purchase behavior is absent;
-- treating empty `document_item_list` results from narrow `query` or `itemType`
+- treating empty `document_item_list` results from narrow `itemType`
   filters as proof that the document has no matching item;
 - continuing confidently after `document_item_list` reports an item-tier gap.
 
@@ -379,7 +379,7 @@ Search Brief classifies the term as mixed coupon issuance, point spending, check
 -> project_overview_get
 -> epic_list / epic_get for both coupon/points and shopping checkout candidates
 -> document_list/document_item_list for BR, DESIGN, UCL, and DD under both candidate epics
--> if item query returns empty but diagnostics show available rows, retry document_item_list without the query filter
+-> if itemType filtering returns empty but diagnostics show available rows, retry document_item_list without the itemType filter
 -> document_item_get exact coupon issuance and checkout discount items
 -> document_resolve linked specs
 -> spec_get for exact API/screen behavior

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md
@@ -8,10 +8,11 @@ chosen branch. The branch route may refine `Question branch`, `Candidate MCP
 route`, and `User decision needed`, but it must preserve the raw question and
 the ambiguity trigger that caused the gate to fire.
 
-Read attached memories on selected `epic_get` and `document_get` results before
-finalizing semantic answers. If only `memoryCount` or a `memoryId` is visible,
-use `memory_list` or `memory_get` when the memory overlay could affect the
-answer boundary. Keep memory separate from SOT/spec/source proof.
+Read attached memories on selected `project_overview_get.overview.memories`,
+`epic_get.memories`, and `document_get.memories` results before finalizing
+semantic answers. If only `memoryCount` or a `memoryId` is visible, use
+`memory_list` or `memory_get` when the memory overlay could affect the answer
+boundary. Keep memory separate from SOT/spec/source proof.
 
 ## Concept Or Domain Term
 
@@ -19,14 +20,14 @@ Route:
 
 ```text
 project context
--> project overview
--> vocabulary normalization
+-> project overview and attached overview memories when present
+-> vocabulary normalization, including alias candidates
 -> epic_list
 -> epic_get for each plausible concept epic
 -> document_list for BR/DD/DESIGN/UCL candidates as the concept requires
 -> document_item_list
 -> document_item_get for exact concept evidence
--> document_resolve
+-> document_resolve; collect linked api_spec/screen_spec spec ids when returned
 -> spec_get when asserting source-near behavior
 ```
 
@@ -90,7 +91,7 @@ project context
 -> vocabulary normalization when needed
 -> epic_list
 -> epic_get for data candidate epics
--> document_list(documentType=DD, epicId=<candidate>, entityName=<entity when known>)
+-> document_list(documentType=DD, epicId=<candidate>)
 -> document_get/document_item_list for entity maps
 -> document_item_get for exact entity or field evidence
 -> document_resolve
@@ -117,10 +118,10 @@ Route:
 project context
 -> epic_list
 -> epic_get for design candidate epics
--> document_list(documentType=DESIGN, epicId=<candidate>)
+-> document_list(documentType=DESIGN, epicId=<candidate>) [MUST] for system design questions
 -> document_get/document_item_list for design maps
 -> document_item_get for exact design items
--> document_resolve
+-> document_resolve; collect linked api_spec/screen_spec spec ids when returned
 -> rank linked api_spec and screen_spec candidates for API/screen claims
 -> spec_list/spec_search only if the linked set is incomplete or the exact spec id is unknown
 -> spec_get

--- a/plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md
@@ -29,9 +29,9 @@ This is the MCP-only intent-to-tool map. It does not list local CLI equivalents.
 | Memory add | `memory_add` | `projectId`, `content`; optional `epicId`, `documentId`, `itemType`, `itemKey`, `memoryKind`, `actor`, `confidence` |
 | Memory update | `memory_update` | `projectId`, `memoryId`, `content`, `reason`; optional `actor` |
 | Memory delete | `memory_delete` | `projectId`, `memoryId`, `reason`; optional `actor` |
-| Document list | `document_list` | `projectId`; optional `documentType`, `epicId`, `entityName`, `status`, `limit`, `cursor` |
+| Document list | `document_list` | `projectId`; optional `documentType`, `epicId`, `status`, `limit`, `cursor` |
 | Document detail | `document_get` | `projectId`, `id` |
-| Business document items | `document_item_list` | `projectId`, `documentId`; optional `itemType`, `query`, `limit`, `cursor` |
+| Business document items | `document_item_list` | `projectId`, `documentId`; optional `itemType`, `limit`, `cursor` |
 | Business document item detail | `document_item_get` | `projectId`, `itemId` |
 | Document/item connected context | `document_resolve` | `projectId` plus `documentId` or `itemId` |
 | Spec list | `spec_list` | `projectId`; optional `specKind`, `scopeId`, `status`, `filters`, `limit`, `cursor` |


### PR DESCRIPTION
## Summary
- Release Platty agent plugin v0.0.3 build 202607100115.

## Release metadata
- Version: `0.0.3`
- Build: `202607100115`
- Branch: `release/platty-plugin-v0.0.3-build-202607100115`
- Source commit: `df21b01760079ad31c8706f536bf89f7cf21e11f`

## Exported managed paths
- `.agents`
- `.claude-plugin`
- `plugins/platty`
- `plugins/platty-mcp`
- `guide`
- `README.md`
- `README.ko.md`
- `GETTING_STARTED.md`
- `LICENSE.md`

## Changed files
- `plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md`
- `plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md`

## Safety gate result
- `public_plugin_release_safety: passed`

## Verification
- `npm run check:agent-skills`
- `npm run check:agent-marketplace`
- `node --test tests/export-public-plugin-repo.test.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 검색 및 조회 과정에서 프로젝트, 에픽, 문서, 항목, 사양에 연결된 메모리 정보를 더욱 일관되게 확인합니다.
  * 관련 사양을 연결하고 선택된 사양 정보를 조회 흐름 전반에서 유지합니다.
  * 검색 결과의 별칭 후보와 증거 구분이 강화되어 답변의 맥락과 정확성이 향상되었습니다.
  * 문서 및 항목 조회 필터가 간소화되고, 결과가 없을 때 더 적절한 재시도 경로를 사용합니다.
  * 필요한 정보가 제한적으로 표시될 경우 추가 메모리 조회 절차가 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->