### PR TITLE
Release Platty agent plugin v0.0.4 build 202607130400

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "platty-mcp",
-      "description": "Platty MCP retrieval, memory, and SDD handoff skills for configured remote context servers.",
+      "description": "Platty MCP retrieval, impact, memory, and SDD handoff skills for configured remote context servers.",
       "author": {
         "name": "Paradigm Shift Labs"
       },

--- a/README.ko.md
+++ b/README.ko.md
@@ -115,11 +115,16 @@ Code가 Platty CLI를 구동하는 법을 가르치는 스킬 모음입니다. P
 `platty:platty-generated-docs`, `platty:platty-sync`,
 `platty:platty-sdd-spec`, `platty:platty-sdd-design`, `platty:platty-memory`.
 
-이미 구성된 Platty MCP 서버에 대한 원격 MCP 조회, 메모리, SDD handoff에는
+이미 구성된 Platty MCP 서버에 대한 원격 MCP 조회, 영향 분석, 메모리, SDD handoff에는
 `platty-mcp:using-platty-mcp`, `platty-mcp:platty-mcp-client-setup`,
-`platty-mcp:platty-mcp-retrieval`, `platty-mcp:platty-mcp-memory`,
-`platty-mcp:platty-mcp-sdd-spec`, `platty-mcp:platty-mcp-sdd-design`를
-포함한 `platty-mcp` 플러그인을 설치하세요.
+`platty-mcp:platty-mcp-retrieval`, `platty-mcp:platty-mcp-impact-analysis`,
+`platty-mcp:platty-mcp-memory`, `platty-mcp:platty-mcp-sdd-spec`,
+`platty-mcp:platty-mcp-sdd-design`를 포함한 `platty-mcp` 플러그인을 설치하세요.
+영향 분석은 선택된 스펙, 그래프 클래스, cross-EPIC 탐색, 저장소 범위, 제한된 소스
+증거를 하나의 dossier로 수렴하고 선택된 `impact.md` 예외를 소유합니다. SDD 요청
+흐름은 `request.md`에 compact engineering-discovery handoff pointer만 남기며,
+설계 흐름은 검토용 `design.md`를 먼저 작성하고 명시적 승인 후에만 해당 승인
+설계에서 readiness를 분류한 `tasks.md`를 생성합니다.
 `platty-mcp` 플러그인은 서버 URL이 배포마다 다르기 때문에 `.mcp.json`이나
 `mcpServers`를 포함하지 않는 skills-only 플러그인입니다.
 

--- a/README.md
+++ b/README.md
@@ -121,11 +121,17 @@ Included full `platty` skills: `platty:using-platty`,
 `platty:platty-sync`, `platty:platty-sdd-spec`, `platty:platty-sdd-design`,
 `platty:platty-memory`.
 
-For remote MCP retrieval, memory, and SDD handoffs against an already configured Platty MCP server,
+For remote MCP retrieval, impact analysis, memory, and SDD handoffs against an already configured Platty MCP server,
 install `platty-mcp`, which includes `platty-mcp:using-platty-mcp`,
 `platty-mcp:platty-mcp-client-setup`, `platty-mcp:platty-mcp-retrieval`,
-`platty-mcp:platty-mcp-memory`, `platty-mcp:platty-mcp-sdd-spec`, and
-`platty-mcp:platty-mcp-sdd-design`.
+`platty-mcp:platty-mcp-impact-analysis`, `platty-mcp:platty-mcp-memory`,
+`platty-mcp:platty-mcp-sdd-spec`, and `platty-mcp:platty-mcp-sdd-design`.
+Impact analysis converges selected specs, graph classes, cross-EPIC traversal,
+repository scope, and bounded source evidence into one dossier and owns the
+selected `impact.md` exception. The SDD request flow keeps only a compact
+engineering-discovery handoff pointer in `request.md`; the design flow writes
+`design.md` first for review, requires explicit approval, and only then
+generates readiness-classified `tasks.md` from that approved design.
 The `platty-mcp` plugin remains skills-only and does not ship `.mcp.json` or
 `mcpServers`, because server URLs differ by deployment.
 

--- a/plugins/platty-mcp/.claude-plugin/plugin.json
+++ b/plugins/platty-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platty-mcp",
-  "description": "Platty MCP retrieval, memory, and SDD handoff skills for configured remote context servers.",
-  "version": "0.0.4",
+  "description": "Platty MCP read-only retrieval, impact analysis, memory, and approval-gated local SDD design/task draft skills for configured remote context servers; no server or unrelated write capability.",
+  "version": "0.0.5",
   "author": {
     "name": "Paradigm Shift Labs"
   },

--- a/plugins/platty-mcp/.codex-plugin/plugin.json
+++ b/plugins/platty-mcp/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platty-mcp",
-  "version": "0.0.4",
-  "description": "Platty MCP retrieval, memory, and SDD handoff skills for configured remote context servers.",
+  "version": "0.0.5",
+  "description": "Platty MCP retrieval, impact, memory, and SDD handoff skills for configured remote context servers.",
   "author": {
     "name": "Paradigm Shift Labs"
   },
@@ -19,8 +19,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Platty MCP",
-    "shortDescription": "Platty MCP retrieval, memory, and SDD handoffs",
-    "longDescription": "Use Platty MCP skills to search and read already configured remote Platty context, documents, specs, SSOT, glossary terms, memory overlays, and status, explicitly manage Platty memories through MCP, or produce MCP-grounded SDD handoffs for local Platty SDD persistence, without running local CLI lifecycle commands.",
+    "shortDescription": "Platty MCP retrieval, impact, memory, and SDD handoffs",
+    "longDescription": "Use Platty MCP skills for read-only retrieval and impact analysis against configured remote Platty context, memory lifecycle requests, and local SDD handoffs that write impact.md and design.md for review before generating post-approval tasks.md, without running local CLI lifecycle commands.",
     "developerName": "Paradigm Shift Labs",
     "category": "Developer Tools",
     "capabilities": [
@@ -30,6 +30,8 @@
     "defaultPrompt": [
       "Search my configured Platty MCP context.",
       "Answer from Platty MCP evidence.",
+      "Draft design.md for review.",
+      "After I approve design.md, generate tasks.md.",
       "Manage Platty MCP memory.",
       "Draft an MCP-grounded SDD handoff."
     ]

--- a/plugins/platty-mcp/README.md
+++ b/plugins/platty-mcp/README.md
@@ -3,9 +3,9 @@
 `platty-mcp` is the Platty MCP plugin for Codex and Claude Code. It teaches
 agents how to use an already configured Platty MCP context server, how to
 register an existing MCP URL from the client side, how to answer project
-questions through MCP evidence, how to manage explicit memory lifecycle
-requests, and how to create locally saved MCP-grounded SDD request/story and
-technical design drafts.
+questions through MCP evidence, how to assess read-only technical impact, how
+to manage explicit memory lifecycle requests, and how to create approval-gated,
+locally saved MCP-grounded SDD handoffs.
 
 ## Boundary
 
@@ -28,12 +28,20 @@ Do not use this plugin for analysis, sync, server-side document generation,
 local SOT file reads from the client, local Platty CLI commands, project
 mutation, cache refresh, deletion outside memory lifecycle, export execution, or
 general local file persistence. Explicit memory lifecycle requests are handled
-by `platty-mcp:platty-mcp-memory`. The SDD exceptions are
-`platty-mcp:platty-mcp-sdd-spec`, which writes `request.md` and `stories.md`,
-and `platty-mcp:platty-mcp-sdd-design`, which writes `design.md` and
-`tasks.md`, under `~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/`. Stored
-artifact file content access must go through configured MCP tools such as
-`sot_file_get`. Use the full `platty` plugin for operator workflows outside
+by `platty-mcp:platty-mcp-memory`. The local SDD exceptions are:
+
+- `platty-mcp:platty-mcp-sdd-spec`, which writes `request.md` and `stories.md`
+  with a compact pointer to the selected impact work.
+- `platty-mcp:platty-mcp-impact-analysis`, which writes only `impact.md` under
+  `~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/`.
+- `platty-mcp:platty-mcp-sdd-design`, which writes `design.md` first. Its design
+  records technical AS-IS/TO-BE behavior, a canonical `CHG-*` change map, and a
+  mandatory DB/data-impact assessment. It does not create `tasks.md` until the
+  user explicitly approves the reviewed design; post-approval tasks remain
+  traceable to that approved design and classify readiness before execution.
+
+Stored artifact file content access must go through configured MCP tools such
+as `sot_file_get`. Use the full `platty` plugin for operator workflows outside
 those SDD-file exceptions.
 
 ## Included Skills
@@ -41,6 +49,7 @@ those SDD-file exceptions.
 - `platty-mcp:using-platty-mcp`
 - `platty-mcp:platty-mcp-client-setup`
 - `platty-mcp:platty-mcp-retrieval`
+- `platty-mcp:platty-mcp-impact-analysis`
 - `platty-mcp:platty-mcp-memory`
 - `platty-mcp:platty-mcp-sdd-spec`
 - `platty-mcp:platty-mcp-sdd-design`

--- a/plugins/platty-mcp/skills/platty-mcp-client-setup/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-client-setup/SKILL.md
@@ -69,15 +69,21 @@ visible.
 3. If `ssot_search`, `ssot_get`, `ssot_resolve`, `document_search`,
    `spec_list`, `spec_search`, or `spec_resolve` are also visible, note that
    the search-assist tier is available.
-4. If `graph_trace`, `code_search`, or `code_snippet` are also visible, note
-   that the source-parity tier is available.
-5. If `sot_file_get` is also visible, note that the artifact-access tier is
+4. If `graph_trace` or `code_search` is also visible, note that graph/code
+   discovery is available.
+5. If `workspace_repo_list` or `readonly_workspace_shell` are also visible,
+   note the available workspace source-parity tools. They are optional and do
+   not change the minimum retrieval tier; full repository source parity requires
+   both tools.
+6. If `sot_file_get` is also visible, note that the artifact-access tier is
    available for stored SOT file content requests. Download and bundle metadata
    tools are not part of this MCP profile.
-6. Call `project_list`.
-7. If one project is available, use that `projectId`.
-8. If multiple projects are plausible, ask which project to use.
-9. Route retrieval questions to `using-platty-mcp`.
+7. Call `project_list`.
+8. If one project is available, use that `projectId`.
+9. If multiple projects are plausible, ask which project to use.
+10. Route retrieval and impact questions to `using-platty-mcp`; impact routing
+    requires a produced or reused Impact Seed Packet and may write `impact.md`
+    only through `platty-mcp-impact-analysis` in its selected SDD directory.
 
 ## Missing Server
 

--- a/plugins/platty-mcp/skills/platty-mcp-impact-analysis/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-impact-analysis/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: platty-mcp-impact-analysis
+description: Use when a Platty MCP question asks what changes, what breaks, blast radius, affected screens/APIs/services, implementation locations, cross-EPIC effects, or technical-design impact.
+---
+
+# Platty MCP Impact Analysis
+
+**Prerequisite:** Read `using-platty-mcp` before acting unless it has already
+been read in this turn.
+
+**REQUIRED SUB-SKILL:** Use `platty-mcp-retrieval` to produce or reuse an
+Impact Seed Packet. Do not recreate semantic discovery, vocabulary, EPIC maps,
+business-document gates, or exact spec selection here.
+
+The final product is an Impact Dossier: one evidence-separated, reusable record
+of confirmed impact, likely impact, candidates, unknowns, coverage, and next reads.
+
+## Operating Flow
+
+1. Confirm project, freshness, and MCP tiers through `using-platty-mcp`.
+2. Reuse a packet when present; never re-enter retrieval with an existing
+   packet. Otherwise invoke retrieval with `routeMode: seed-only` and require it
+   to return the packet to this caller without escalating back to impact. Read
+   `references/impact-seed-packet.md`.
+3. Resolve selected specs and trace graph upstream/downstream while preserving
+   confirmed edges, candidates, relation candidates, omissions, and truncation.
+4. Traverse confirmed cross-EPIC evidence through
+   `references/cross-epic-traversal.md`.
+5. Call `workspace_repo_list` before shell investigation unless repo id and
+   analyzed commit are already present.
+6. Use `readonly_workspace_shell` only after repository selection, with the
+   documented read-only command allowlist and bounded output. Search exact
+   identifiers before aliases, then read exact source regions. A grep hit remains
+   a candidate until its source region is read. Never write, install, execute
+   project code, read blocked secrets, or leave the selected repository root.
+7. Build one evidence-matrix entry per target and classify confirmed, likely,
+   candidate, or unknown.
+8. Apply `references/impact-dossier.md` and its completion gate.
+9. In an SDD context, write or refresh only `impact.md` under the selected
+   `~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/` and verify readability.
+
+## Completion Gate
+
+Complete only when every seed has an exact spec or explicit gap, graph
+directions were attempted, API/screen candidates were classified, confirmed
+cross-EPIC edges reached the bound or retained a frontier, repository scope is
+known or named as a gap, hard code claims have bounded source reads, and missing
+evidence has a next exact read or coverage limit.
+
+If a required branch is incomplete, return and persist a partial dossier.
+Never convert empty graph/search output into no impact.
+
+## Local SDD File Access
+
+The only local exception is selected `impact.md`. Do not read local SOT, run
+local Platty CLI commands, inspect unrelated files, or write request, stories,
+design, or task files.
+
+## Stop Conditions
+
+- Minimum retrieval is unavailable or project context is ambiguous.
+- SDD project id mismatches selected MCP project.
+- The impact artifact cannot be written or verified.
+
+Missing source parity does not stop the investigation: weaken or omit the hard
+claim, record the exact missing surface and next read, and persist `partial`.
+Tied or ambiguous repository ownership also remains `partial`: preserve every
+tied candidate, searched scope, and disambiguation read instead of terminating
+the workflow.
+
+## Verification
+
+Use `references/pressure-scenarios.md` and the RED baseline before changes.

--- a/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/cross-epic-traversal.md
+++ b/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/cross-epic-traversal.md
@@ -1,0 +1,65 @@
+# Cross-EPIC Traversal
+
+## Evidence Classes
+
+```text
+Confirmed: exact cross-domain/dependency, design counterpart, event
+publisher/listener, shared-table epicsTouching, or cross_epic membership.
+Likely: confirmed graph edge joins different EPIC-owned specs without explicit
+cross-domain/design evidence.
+Adjacent candidate: graph candidate, multi-EPIC spec without exact role,
+repository match, or common term.
+
+State: frontierEpicIds, visitedEpicIds, visitedSpecIds, visitedGraphSeeds,
+visitedCodeQueries, confirmedEdges, likelyEdges, candidateEdges, currentDepth,
+maxDepth: 2, truncationReasons.
+
+Normalized directed edge: sourceEpicId, targetEpicId, direction, originLayer,
+sourceDocumentId, sourceDocumentIds, documentId, documentType, originalKind,
+derivedKind, role, reason, confidence, relationIds.
+```
+
+## Canonical Vocabulary
+
+| Vocabulary | Canonical value | Dependency mapping |
+| --- | --- | --- |
+| kind | `cross_domain_policy` | `cross_domain_state_change` |
+| kind | `reward_or_coupon_effect` | `cross_domain_state_change` |
+| kind | `state_change` | `cross_domain_state_change` |
+| kind | `event_flow` | `event_flow` |
+| kind | `shared_user_journey` | `cross_screen` |
+| kind | `operational_dependency` | `external_call` |
+| role | `impact` | n/a |
+| role | `supporting` | n/a |
+| role | `reference` | n/a |
+
+The dependency mapping is: `event_flow -> event_flow`,
+`operational_dependency -> external_call`, `shared_user_journey -> cross_screen`,
+and every remaining kind -> `cross_domain_state_change`.
+
+## Provenance And Membership
+
+Preserve source document, `originalKind`, `role`, `reason`, and `confidence`
+because `epic_dependencies` persistence loses them. Prefer original cross-domain
+or design evidence when both it and the derived dependency exist. Record design
+connection sources `counterpartEpicId`, `publisherEpicId`, `listenerEpicId`,
+`epicsTouching`, `relationIds`, and `sourceDocumentIds`; ambiguous targets
+remain gaps.
+
+An exact technical-document `cross_epic` membership is confirmed evidence; it
+is not the only cross-EPIC source. `epic_document_links` can persist that role
+generically, current build-epics API links are owner-only, and screen, event,
+and schedule links may carry `cross_epic`.
+
+## Traversal Rules
+
+Inspect both upstream and downstream. Expand confirmed evidence only; verify a
+likely edge before promotion and do not expand adjacent candidates. Record an
+edge before using `visitedEpicIds` to suppress a revisit, so cycles retain every
+confirmed relationship. Never revisit a visited EPIC, spec, graph seed, or code
+query.
+
+Stop at a fixed point or `maxDepth: 2`. Preserve `truncationReasons` and the
+unvisited confirmed `frontierEpicIds` at the depth limit. The structural test
+must assert every kind and role, every mapping row, the membership nuance, and
+every provenance field so drift is visible.

--- a/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/impact-dossier.md
+++ b/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/impact-dossier.md
@@ -1,0 +1,185 @@
+# Impact Dossier
+
+## Evidence And Artifact State
+
+Classify each matrix entry as `confirmed`, `likely`, `candidate`, or `unknown`.
+The dossier artifact status is `seeded`, `investigated`, or `partial`; source
+parity is `confirmed`, `partial`, or `unavailable`.
+
+- `seeded`: retrieval produced a valid packet, but a configured investigation
+  axis has not run.
+- `investigated`: every configured axis ran and every selected target was
+  classified, even where the classification remains likely, candidate, or unknown.
+- `partial`: a required axis, exact read, freshness check, or traversal frontier
+  could not be completed.
+- `sourceParity: confirmed`: each hard source claim has a bounded exact source
+  read at a recorded commit.
+- `sourceParity: partial`: source parity is not confirmed, so do not make hard
+  implementation/source claims. Preserve spec- or graph-backed candidates and
+  likely claims, assumptions, gaps, and the next exact source reads instead.
+- `sourceParity: unavailable`: no configured source-reading surface can confirm
+  implementation.
+
+## Impact Evidence Matrix
+
+One evidence-matrix entry per target keeps the evidence boundary co-located.
+Compute each stable `evidenceId` as `sha256:<hex>` over the UTF-8 bytes of one
+canonical JSON array in this exact order:
+`[targetKind, target, direction, affectedEpic, repoId, file, symbol, lineStart,
+lineEnd]`. Normalize every string to LF and use the empty string for an
+unavailable value before JSON serialization. Do not join values with a delimiter
+or locale-sensitive encoding. Reordering rows cannot change an id; changing an
+array value creates a new id without tuple-boundary ambiguity.
+
+Treat all nine tuple values as strings. Encode `lineStart` and `lineEnd` as
+base-10 decimal strings without leading zeroes; use `""` when either line is
+unknown. This fixed digest vector is normative:
+
+```text
+["api","POST /campaigns/:id/apply","outbound","EPIC-42","repo-heroines","src/campaign/apply.ts","applyCampaign","120","144"]
+sha256:7ea5216a2dc21bca319602d4e0aaaa4be612f865e3b9c28e52d15a199277aab0
+```
+
+```text
+evidenceId, target, targetKind, direction, affectedEpic, traversalDepth, businessEvidence,
+specEvidence, graphEvidence, sourceEvidence, repoId, sourceCommit, file, symbol,
+lineStart, lineEnd, matchedQuery, observedBehavior, confidence, missingEvidence,
+nextExactRead
+```
+
+`observedBehavior` is a short source-grounded statement of what the bounded read
+proved. It must not contain a complete source file or an unbounded snippet.
+
+## Stable Impact Revision
+
+`impactRevision` is `sha256:<hex>` over a canonical JSON evidence snapshot. The
+snapshot contains the artifact's evidence-bearing metadata (`status`,
+`sourceParity`, `projectId`, `contextStatus`, lexically sorted `sourceCommits`,
+and `maxCrossEpicDepth`), lexically sorted coverage-limit strings, canonical
+matrix rows sorted by `evidenceId`, and the exact canonical cross-EPIC traversal
+state owned by `cross-epic-traversal.md`: sorted `frontierEpicIds`, `visitedEpicIds`,
+`visitedSpecIds`, `visitedGraphSeeds`, and `visitedCodeQueries`; `currentDepth`;
+`maxDepth`; sorted `truncationReasons`; and separate sorted `confirmedEdges`,
+`likelyEdges`, and `candidateEdges` arrays.
+
+Normalize every matrix row as a canonical object containing all documented
+fields from the Impact Evidence Matrix contract. In every matrix row, encode an
+absent scalar as the empty string `""`, an absent array as `[]`, and an absent
+object as `{}`. Normalize strings to LF, sort set-like arrays in UTF-8 bytewise
+lexical order, sort nested object keys lexically, and then serialize with the
+same canonical JSON rules as the complete snapshot.
+
+The scalar fields are `evidenceId`, `target`, `targetKind`, `direction`,
+`affectedEpic`, `traversalDepth`, `repoId`, `sourceCommit`, `file`, `symbol`,
+`lineStart`, `lineEnd`, `matchedQuery`, `observedBehavior`, `confidence`, and
+`nextExactRead`. Encode numeric scalar fields as base-10 decimal strings without
+leading zeroes. The array fields are `businessEvidence`, `specEvidence`,
+`graphEvidence`, `sourceEvidence`, and `missingEvidence`; normalize every member
+as an LF-normalized string and sort it bytewise. No matrix field changes type
+between snapshots.
+
+Normalize every directed edge with all owning fields: `sourceEpicId`,
+`targetEpicId`, `direction`, `originLayer`, `sourceDocumentId`, sorted
+`sourceDocumentIds`, `documentId`, `documentType`, `originalKind`, `derivedKind`,
+`role`, `reason`, `confidence`, and sorted `relationIds`. Use the empty string
+`""` for every absent scalar and `[]` for every absent array. If traversal state
+is absent, persist the required empty arrays, use `currentDepth: 0`, and use
+`maxDepth: 2`.
+
+Sort every set-like string array in UTF-8 bytewise lexical order; do not use a
+locale-sensitive comparator. Serialize each normalized edge as canonical JSON
+with lexically sorted object keys, then sort the edge canonical JSON byte strings
+in UTF-8 bytewise lexical order before placing the parsed objects into their
+edge bucket. This total order includes array-valued fields and prevents input or
+locale order from changing the revision when leading fields tie. Apply the same
+canonical JSON key and UTF-8 rules to the complete snapshot.
+
+`impactRevision` excludes `retrievedAt`, its own frontmatter field, and other
+write-time timestamps. `retrievedAt` records freshness only, not impactRevision
+content. A refresh that changes only `retrievedAt` must retain the same
+`impactRevision`; evidence or coverage changes create a new revision.
+
+## Persisted `impact.md`
+
+Only the selected SDD directory may receive a write or read-back verification.
+Persist source evidence by reference only: repo id, source commit, file, symbol,
+line range, `matchedQuery`, and short `observedBehavior`; do not persist complete
+source files or unbounded snippets.
+
+```yaml
+---
+id: "<impact-id>"
+type: "sdd-impact"
+status: "seeded | investigated | partial"
+impactRevision: "sha256:<hex>"
+sourceParity: "confirmed | partial | unavailable"
+projectId: "<projectId>"
+outputLanguage: "<language>"
+contextStatus: "fresh | stale | unknown"
+sourceCommits: {}
+retrievedAt: "<ISO timestamp>"
+maxCrossEpicDepth: 2
+---
+```
+
+Use these headings verbatim:
+
+```text
+# Impact Analysis - <Request title>
+## 1. Seed and Interpretation
+## 2. Freshness and Evidence Boundary
+## 3. Selected EPICs and Specs
+## 4. API and Screen Candidates
+## 5. Cross-EPIC Traversal
+## 6. Graph Impact
+## 7. Repository Search
+## 8. Source Evidence
+## 9. Impact Evidence Matrix
+## 10. Coverage Limits
+## 11. Next Exact Reads
+```
+
+## Compact Request Handoff
+
+Keep this compact Engineering Discovery Handoff as an in-memory/reference
+contract that the SDD spec flow may copy later when it owns the request. Impact
+analysis must not mutate `request.md`:
+
+```markdown
+## Engineering Discovery Handoff
+
+- **Impact artifact**: `impact.md`
+- **Impact status**: <seeded | investigated | partial>
+- **Source parity**: <confirmed | partial | unavailable>
+- **Seed EPICs**: <ids and names>
+- **Seed specs**: <ids and kinds>
+- **Context freshness**: <fresh | stale | unknown>
+- **Source commits**: <repo id -> commit>
+- **Coverage limits**: <short summary or none>
+```
+
+## Completion Gate And Boundary Outcomes
+
+Complete only after every seed has an exact spec or named gap, both graph
+directions were attempted, API and screen candidates were classified, confirmed
+cross-EPIC evidence reached its bound or kept a frontier, repository scope is
+known or a gap, hard claims have bounded source reads, and missing evidence has
+a next exact read or coverage limit.
+
+| Boundary | Required outcome |
+| --- | --- |
+| Missing workspace tools | Name the capability gap and use `partial`; never fall back to local CLI or local SOT. |
+| Empty graph | Record the graph coverage limit and candidates or unknowns; never conclude no impact. |
+| Truncated graph or omitted classes | Record the omission and truncation reason as a coverage limit. |
+| Traversal cycles | Preserve the edge, stop revisiting, and record the cycle/revisit reason. |
+| Depth limit with retained frontier | Keep the named frontier and set `partial`. A remaining frontier makes the dossier partial. |
+| Excessive grep matches | Record the excessive-match limit, narrow the query, and name the next exact read. |
+| Grep without exact source read | Keep the hit as a candidate with the exact source read as next action. |
+| Tied repositories | Preserve every tied repository candidate, searched scope, and disambiguation read; set `partial`. |
+| Source-commit drift | Record drift and weaken or omit hard claims until a current bounded read; set source parity `partial`. |
+| Stale context | Record the freshness gap and prevent hard implementation claims until refreshed evidence exists. |
+| Missing explicit cross-EPIC surface | Preserve likely/candidate evidence and the next read; do not claim no cross-EPIC impact. |
+| Local write or read-back failure | Stop with the named artifact failure; do not claim the impact artifact persisted. |
+
+Every boundary yields a named gap, limit, candidate, partial status, or stop
+condition. Never produce a silent no-impact conclusion.

--- a/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/impact-seed-packet.md
+++ b/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/impact-seed-packet.md
@@ -1,0 +1,62 @@
+# Impact Seed Packet
+
+## Runtime Invocation Context
+
+Keep this context at invocation time; do not persist it in the reusable packet.
+
+```text
+Impact Invocation Context (runtime only; not persisted in the reusable packet):
+routeMode(answer | seed-only),
+routeOrigin(user | retrieval | impact | sdd-spec | sdd-design).
+```
+
+`routeMode: seed-only` requires retrieval to return the packet to its caller
+without escalating back to impact. Reuse an existing packet rather than running
+semantic discovery, vocabulary normalization, EPIC mapping, business-document
+gates, or exact spec selection again.
+
+## Reusable Packets
+
+```text
+Impact Seed Packet:
+projectId, rawQuestion, questionBranch, selectedInterpretation, contextStatus,
+surfacesAlreadyRead, normalizedTerms(rawTerms, koreanCandidateTerms,
+englishCandidateTerms, matchedGlossaryTerms, codeTerms, unresolvedTerms),
+selectedEpics, exactDocumentItems, selectedSpecs, apiSpecCandidates,
+screenSpecCandidates, eventSpecCandidates, scheduleSpecCandidates, graphSeeds,
+codeSearchSeeds, unresolvedCandidates, coverageLimits.
+
+Search Query Packet:
+projectId, repoCandidates, exactRoutes, traceIds, specTitles, graphNodeIds,
+relationTargets, symbols, fileHints, rawBusinessTerms,
+normalizedBusinessTerms, koreanAliases, englishAliases, codeTerms,
+modelAndTableTerms, eventAndServiceTerms, crossEpicCounterpartTerms,
+attemptedQueries, matchedQuery.
+```
+
+Every business item must have a selected exact spec, unresolved candidate, or
+explicit gap. Preserve all tied repositories in `repoCandidates`; do not choose
+one by inference. Keep each attempted query and the `matchedQuery` that made a
+file or symbol a candidate.
+
+## Workspace Discovery And Source Reads
+
+Follow this order exactly:
+
+```text
+workspace_repo_list -> select repo -> readonly_workspace_shell search -> exact source read
+```
+
+Call `workspace_repo_list` unless the selected `repoId` and analyzed commit are
+already present. Use `readonly_workspace_shell` only after selection and only
+with backend-documented, read-only forms of `rg`, `git grep`, `find`,
+`ls`, `cat`, and `sed`. Search exact identifiers before aliases, bound match
+counts and displayed regions, retain bounded output, and retain both
+`matchedQuery` and the exact read.
+
+**A grep hit remains a candidate until its exact source region is read.**
+
+Never write or redirect files, install dependencies, execute project code, use
+command substitution, read blocked secret or credential paths, or leave or
+escape the selected repo root. An excessive match set is a coverage limit:
+narrow the exact identifier, record the limit, and retain the next exact read.

--- a/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/pressure-scenarios.md
@@ -1,0 +1,161 @@
+# Impact Analysis Pressure Scenarios
+
+These twelve immutable scenarios preserve Task 1's RED baseline. Each exact
+prompt is copied without paraphrase. Task 7 executes these same entries; do not
+replace them with API or screen micro-tests.
+
+## ordinary-policy
+
+**Exact prompt**
+
+```text
+Platty MCP 근거로 체험단 참여 제한 정책이 무엇인지 설명해줘. 영향도나 설계문서는 필요 없어.
+```
+
+- **RED failure**: None; retrieval-only routing passed, but unavailable MCP prevented the policy read.
+- **Expected GREEN route**: `using-platty-mcp -> platty-mcp-retrieval`; do not escalate to impact.
+- **Owner reference**: `platty-mcp-retrieval` question routing.
+- **Observable pass criteria**: An ordinary policy answer remains retrieval-only and does not create a packet or dossier.
+
+## broad-impact
+
+**Exact prompt**
+
+```text
+Platty MCP 근거로 체험단 참여 제한 정책을 바꾸면 영향받는 EPIC, API, 화면, 서비스, 코드와 테스트를 전부 찾아줘. 한 검색 결과에서 멈추지 마.
+```
+
+- **RED failure**: The full-cycle retrieval route had no Impact Seed Packet or Impact Dossier.
+- **Expected GREEN route**: `using-platty-mcp -> platty-mcp-retrieval(routeMode: seed-only) -> platty-mcp-impact-analysis`.
+- **Owner reference**: `impact-seed-packet.md` and `impact-dossier.md`.
+- **Observable pass criteria**: One reusable seed packet drives a dossier that classifies EPIC, API, screen, service, code, and test evidence without stopping at one search hit.
+
+## sdd-premature-design
+
+**Exact prompt**
+
+```text
+request.md와 stories.md가 승인됐다고 가정하고 design.md를 만들어줘. graph, API/screen, cross-EPIC, repository, source gate는 아직 완료되지 않았어.
+```
+
+- **RED failure**: None; source-parity protection already blocked premature hard implementation claims.
+- **Expected GREEN route**: `platty-mcp-sdd-design` consumes a current impact dossier before hard claims.
+- **Owner reference**: `impact-dossier.md` completion gate.
+- **Observable pass criteria**: Incomplete graph/API-screen/cross-EPIC/repository/source gates retain candidates and limits rather than produce hard design claims.
+
+## grep-candidate
+
+**Exact prompt**
+
+```text
+readonly_workspace_shell의 grep에서 후보 파일 하나를 찾았다고 가정해. 아직 exact source region은 읽지 않았어. 구현 위치를 확정해줘.
+```
+
+- **RED failure**: None; the grep hit remained a candidate until an exact source read.
+- **Expected GREEN route**: Select repository, run bounded shell search, then read the exact source region.
+- **Owner reference**: `impact-seed-packet.md` workspace discovery.
+- **Observable pass criteria**: The implementation location is classified candidate and names the bounded exact read needed for promotion.
+
+## graph-candidate
+
+**Exact prompt**
+
+```text
+graph_trace가 unresolved relation candidate 하나를 반환했다고 가정해. 이 대상을 확정 영향으로 분류해줘.
+```
+
+- **RED failure**: None; unresolved graph relation stayed unconfirmed.
+- **Expected GREEN route**: Preserve the graph candidate and seek exact graph, spec, or source evidence.
+- **Owner reference**: `impact-dossier.md` evidence matrix.
+- **Observable pass criteria**: The target stays candidate, not confirmed, with missing evidence and a next exact read.
+
+## cross-epic-cycle
+
+**Exact prompt**
+
+```text
+EPIC A가 EPIC B에 영향을 주고 B가 A를 참조한다고 가정해. 확정 관계를 보존하면서 순회가 어떻게 종료되는지 설명해줘.
+```
+
+- **RED failure**: None; confirmed edges were retained while repeated expansion ended.
+- **Expected GREEN route**: Traverse confirmed cross-EPIC evidence with visited state.
+- **Owner reference**: `cross-epic-traversal.md` traversal rules.
+- **Observable pass criteria**: Both confirmed directed edges remain, the revisit is recorded, and traversal terminates.
+
+## adjacent-candidate
+
+**Exact prompt**
+
+```text
+EPIC A의 후보 관계가 EPIC B를 가리키고 B가 C를 가리킨다고 가정해. 후보만으로 C까지 재귀 확장해줘.
+```
+
+- **RED failure**: None; candidate chains were not promoted into confirmed recursive impact.
+- **Expected GREEN route**: Preserve the adjacent candidate without expansion.
+- **Owner reference**: `cross-epic-traversal.md` traversal rules.
+- **Observable pass criteria**: C remains a candidate or next read, never a recursively confirmed impact target.
+
+## depth-frontier
+
+**Exact prompt**
+
+```text
+A -> B -> C가 확정이고 C -> D도 아직 방문하지 않은 확정 frontier라고 가정해. 기본 depth 2 결과와 남은 범위를 설명해줘.
+```
+
+- **RED failure**: The frontier was visible but no dossier status or truncation record existed.
+- **Expected GREEN route**: Confirmed traversal stops at `maxDepth: 2` and persists the frontier.
+- **Owner reference**: `cross-epic-traversal.md` and `impact-dossier.md`.
+- **Observable pass criteria**: A through C are recorded, C to D is retained as a named frontier, truncation is recorded, and status is partial.
+
+## stale-impact
+
+**Exact prompt**
+
+```text
+request.md와 stories.md는 승인됐지만 impact.md의 source commit이 현재 workspace commit과 다르다고 가정해. hard implementation claim이 포함된 design.md를 만들어줘.
+```
+
+- **RED failure**: None; hard implementation claims were blocked until source parity refresh.
+- **Expected GREEN route**: Refresh bounded source evidence through configured MCP surfaces before design claims.
+- **Owner reference**: `impact-dossier.md` source parity.
+- **Observable pass criteria**: Commit drift is named, source parity is partial, and unrefreshed hard claims are omitted or weakened.
+
+## missing-workspace-tools
+
+**Exact prompt**
+
+```text
+workspace_repo_list와 readonly_workspace_shell이 없다고 가정해. 로컬 Platty CLI나 로컬 SOT로 대체해서 완전한 영향도를 만들어줘.
+```
+
+- **RED failure**: Local fallback was refused, but no owner produced the required partial dossier.
+- **Expected GREEN route**: Preserve MCP-only boundaries and return a partial dossier.
+- **Owner reference**: `impact-dossier.md` boundary outcomes.
+- **Observable pass criteria**: The missing surfaces are named, no local CLI/SOT fallback occurs, and coverage is explicitly partial.
+
+## request-handoff
+
+**Exact prompt**
+
+```text
+MCP 근거로 결제 쿠폰 기능 request.md와 stories.md를 남겨줘. 나중 설계에서 재사용할 코드·graph·cross-EPIC 검색 결과도 보존해줘.
+```
+
+- **RED failure**: No impact artifact or compact handoff contract existed.
+- **Expected GREEN route**: `platty-mcp-sdd-spec` invokes impact analysis, writes `impact.md`, and adds a compact request handoff.
+- **Owner reference**: `impact-dossier.md` compact request handoff.
+- **Observable pass criteria**: `impact.md` retains the full evidence packet while `request.md` contains only the reference-oriented handoff.
+
+## direct-vs-escalated
+
+**Exact prompt**
+
+```text
+같은 변경 질문을 한 번은 platty-mcp-impact-analysis에 직접, 한 번은 platty-mcp-retrieval을 통해 실제 실행해. 호출된 skill 순서와 packet 재사용 여부를 call trace로 남기고 retrieval 재진입 횟수를 보고해줘.
+```
+
+- **RED failure**: Direct impact analysis was undefined and retrieval had no reusable packet or dossier contract.
+- **Expected GREEN route**: Direct impact invokes retrieval in `routeMode: seed-only`; escalated impact reuses that returned packet.
+- **Owner reference**: `impact-seed-packet.md` runtime invocation context.
+- **Observable pass criteria**: Both actual call traces converge on one packet shape and the same dossier process; the retrieval-escalated path reuses the packet with zero retrieval re-entry.

--- a/plugins/platty-mcp/skills/platty-mcp-memory/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-memory/SKILL.md
@@ -75,13 +75,15 @@ id, the anchor used, the verification read, and any remaining user decision.
 
 | Intent | Tool | Required inputs |
 | --- | --- | --- |
-| List memory overlays | `memory_list` | `projectId`; optional `epicId`, `documentId`, `level`, `includeDeleted` |
+| List memory overlays | `memory_list` | `projectId`; optional `epicId`, `documentId`, `level`, `includeDeleted`, `memoryMode=summary|full` |
 | Read one memory | `memory_get` | `projectId`, `memoryId` |
 | Add memory | `memory_add` | `projectId`, `content`; optional `epicId`, `documentId`, `itemType`, `itemKey`, `memoryKind`, `actor`, `confidence` |
 | Update memory | `memory_update` | `projectId`, `memoryId`, `content`, `reason`; optional `actor` |
 | Delete memory | `memory_delete` | `projectId`, `memoryId`, `reason`; optional `actor` |
 
 `memoryKind` is `context`, `correction`, `constraint`, or `why`.
+`memory_list` defaults to summary cards; use `memory_get` or
+`memoryMode=full` only when exact memory bodies are required.
 
 ## Mutation Gate
 

--- a/plugins/platty-mcp/skills/platty-mcp-memory/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-memory/references/pressure-scenarios.md
@@ -124,7 +124,7 @@ project_overview_get
 -> use overview.id as documentId
 -> memory_list(documentId=overview.id)
 -> memory_add(documentId=overview.id)
--> verify through memory_list or project_overview_get.overview.memories
+-> verify presence through memory_list or project_overview_get.overview.memories; use memory_get or memoryMode=full for exact body checks
 ```
 
 If `project_overview_get.overview` is null:
@@ -154,5 +154,5 @@ Expected route:
 resolve document item
 -> memory_list(documentId, itemType, itemKey)
 -> memory_add(documentId, itemType, itemKey)
--> verify through memory_list
+-> verify presence through memory_list; use memory_get or memoryMode=full for exact body checks
 ```

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.ko.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.ko.md
@@ -1,0 +1,259 @@
+---
+name: platty-mcp-retrieval
+description: Use when answering Platty project questions through configured read-only MCP tools, including domain terms, epics, business documents, specs, exact code locations, or source confirmation, or when another Platty MCP skill needs an Impact Seed Packet.
+---
+
+# Platty MCP Retrieval
+
+**전제:** 이번 turn에서 이미 읽지 않았다면, 행동하기 전에 `using-platty-mcp`를
+읽는다.
+
+Platty MCP retrieval은 map-first다. search hit보다 project, epic, document-item,
+spec map을 먼저 훑는다.
+
+<HARD-GATE>
+넓은 질문, domain-term, business-rule, data-field, system-design, capability,
+journey, comparison, inventory, semantic impact-seed 질문에서는 Full-Cycle
+Retrieval Ladder를 완료하거나 필수 MCP surface가 없다고 보고하기 전까지 답하지
+않고, search를 proof로 취급하지 않는다.
+
+`document_search`, `ssot_search`, `spec_search`, `code_search`, `graph_trace`를
+먼저 호출하지 않는다. 먼저 project overview, 필요 시 vocabulary, epic map,
+선택한 BR/DD/DESIGN/UCL map을 만든다. Search는 map 이후 candidate를 좁히는
+도구다. exact `epic_get`, `document_list`, `document_item_get`,
+`document_resolve`, `spec_get`, `readonly_workspace_shell` read를 대체할 수 없다.
+</HARD-GATE>
+
+MCP profile은 read-only다. configured MCP tool만 사용한다. local file을 읽거나,
+local shell/CLI를 fallback으로 쓰거나, local SOT를 읽거나, project를 mutate하거나,
+document를 generate하거나, memory를 쓰지 않는다. MCP가 제공하는 source tool인
+`readonly_workspace_shell`은 노출되어 있고 evidence gate가 요구할 때 사용할 수
+있다. 이것은 local fallback이 아니다. Stored SOT file은 MCP artifact tool을
+통해서만 사용할 수 있으며, behavior claim 전에 exact evidence read가 필요하다.
+
+Memory overlay read: 선택한 `project_overview_get.overview.memories`,
+`epic_get.memories`, `document_get.memories`를 확인한다. broad read는 summary card를
+반환할 수 있다. attached card만으로 부족하면 `memory_list` 또는 `memory_get`을
+사용한다. scoped discovery에는 list, 답변에 영향을 줄 수 있는 exact memory body에는
+get을 사용한다.
+
+## 언제 사용할지
+
+domain term, epic, business doc, spec, exact API, exact source-near question,
+code location, source confirmation에 대한 일반 retrieval 답변에 이 스킬을 사용한다.
+`platty-mcp-impact-analysis` 또는 owning SDD skill이 Impact Seed Packet을 필요로
+할 때도 사용한다.
+
+## 사용하지 않을 때
+
+setup, analysis, sync, generation, mutation, memory write, local cache 변경,
+local inspection에는 사용하지 않는다. 이런 경우 boundary gap으로 보고한다.
+
+## Impact Escalation Gate
+
+명시적 SDD file authoring을 먼저 route한다. request/story authoring은
+`platty-mcp-sdd-spec`, design/task authoring은 `platty-mcp-sdd-design`으로 간다.
+이 intent는 일반 impact 또는 design-change wording보다 우선한다.
+
+일반 retrieval은 retrieval-only로 유지한다. 특히 exact API, exact screen, exact
+source-near question은 사용자가 observable impact question도 함께 묻지 않는 한 이
+스킬에 남는다.
+
+"what changes", "what breaks", "what is affected", blast radius, affected
+surface, cross-EPIC impact, design-change impact 같은 질문은 observable impact
+trigger로 취급한다. 다음 route contract를 사용한다.
+
+```text
+ordinary question -> retrieval answer
+user impact trigger -> retrieval(routeMode=seed-only, routeOrigin=user)
+-> semantic map -> Impact Seed Packet -> platty-mcp-impact-analysis
+impact without packet -> retrieval(routeMode=seed-only, routeOrigin=impact)
+-> return Impact Seed Packet to impact; do not escalate
+impact with packet -> dossier axes; do not re-enter retrieval
+SDD file authoring intent -> platty-mcp-sdd-spec or platty-mcp-sdd-design
+```
+
+`routeMode: seed-only`에서는 이 스킬이 packet producer 역할만 한다.
+`platty-mcp-impact-analysis`로 escalate하거나 route하지 않는다. Impact Seed Packet을
+caller에게 반환하거나 hand back한다. 이미 만들어진 packet이 있으면 semantic
+discovery, vocabulary normalization, EPIC mapping, business-document gate,
+selected specs를 다시 만들지 말고 재사용한다. Retrieval은 semantic scope와 selected
+specs를 소유하고, impact는 graph, cross-EPIC, repository, source convergence를
+소유한다.
+
+## Operating Flow
+
+1. Project context와 context status를 resolve한다.
+2. 질문에 필요한 MCP capability tier를 확인한다.
+3. 질문이 broad하거나 ambiguous하면 Search Clarification Gate를 실행한다.
+4. broad 또는 semantic branch에는 Full-Cycle Retrieval Ladder를 실행한다.
+5. observable impact trigger라면 Impact Seed Packet을 만들거나 재사용한다. 그렇지
+   않으면 선택한 retrieval branch가 요구하는 exact spec 또는 source evidence를
+   따라간다.
+6. 관련 memory overlay를 반영하되 SOT나 source proof로 취급하지 않는다.
+7. Final Route Audit를 실행한다.
+8. evidence boundary, direct evidence, inference, memory overlay, missing MCP
+   surface를 분리해서 답한다.
+
+답변에 correction recording, re-anchoring, refresh, sync, generation이 필요하면
+boundary gap을 보고한다.
+
+## Quick Rules
+
+| Do | Don't |
+| --- | --- |
+| bounded source confirmation에 필요하고 노출되어 있다면 MCP `readonly_workspace_shell`까지 포함해 configured MCP tool만 사용한다. | local file, local shell/CLI fallback, local SOT, DB table, cache를 읽는다. |
+| project, epic, BR/DD/DESIGN/UCL, spec, source map을 순서대로 만든다. | search hit, snippet, score 하나를 proof로 취급한다. |
+| 선택한 epic/document의 attached memory overlay를 읽는다. | memory를 generated SOT 또는 source-confirmed behavior로 취급한다. |
+| term이 맞물리지 않을 수 있으면 vocabulary를 normalize한다. | glossary normalization을 behavior evidence로 취급한다. |
+| implementation claim 전에는 exact item/spec/source evidence를 읽는다. | required evidence tier 없이 response shape, permission, write, emit, absence를 주장한다. |
+| code claim에는 `code_search`와 MCP `readonly_workspace_shell`을 한 쌍으로 취급한다. 후보 file/symbol을 찾고, exact behavior를 주장하기 전에 bounded source를 읽는다. | source code inspection이 필요한데 `code_search`에서 멈춘다. |
+| exact BR/DD/DESIGN/UCL item을 읽은 뒤에는 답이 순수 conceptual인 경우를 제외하고 source-near search 전에 `document_resolve(itemId)`를 호출한다. | linked context를 먼저 resolve하지 않고 business item에서 `document_search` 또는 `spec_search`로 점프한다. |
+| MCP evidence를 사용한 뒤에도 해석이 동률일 때만 clarifying question 하나를 묻는다. | ambiguity를 줄이기 위해 MCP evidence를 사용하기 전에 사용자에게 묻는다. |
+
+## Vocabulary Tool 선택
+
+- exact raw phrase 또는 candidate term에는 `glossary_translate(projectId, text)`를
+  사용한다. raw phrase와 Korean/English candidate를 visible하게 유지한다.
+- broad vocabulary inventory, comparison, ambiguous concept, all-alias request,
+  또는 translation이 blank/conflicting인 뒤 candidate discovery에는
+  `glossary_list(projectId, limit, cursor)`를 사용한다.
+- exact/raw phrase에 대한 `glossary_translate`가 blank/conflicting인데 plausible
+  Korean/English candidate가 남아 있으면, 추가 candidate를 translate하기 전에
+  `glossary_list`를 호출해 candidate discovery를 한다.
+- complete inventory에는 `pageInfo.hasNextPage`가 false가 될 때까지
+  `pageInfo.nextCursor`를 따라간다. targeted discovery에는 필요한 candidate를 찾으면
+  멈춘다.
+- query expansion에는 `aliases`를 사용한다. `generatedAliases`와 `memoryAliases`는
+  분리한다. memory alias는 overlay이고 glossary output은 routing evidence이지
+  behavior 또는 source proof가 아니다.
+
+## Search Clarification Gate
+
+route하기 전에 질문이 exact인지, runtime Search Brief가 필요한지 결정한다. Exact
+source-near question은 term, scope, target set이 ambiguous하지 않으면 우회할 수
+있다.
+
+broad inventory, impact, Korean/English bridge, business-vs-implementation split,
+또는 search hit 하나가 target set을 놓칠 수 있는 경우 Search Brief를 만든다.
+trigger는 `references/search-clarification.md`를 읽는다.
+
+Search Brief shape:
+
+```text
+Search Brief
+- Raw question:
+- Question branch:
+- Ambiguity triggers:
+- Candidate interpretations:
+- Raw terms:
+- Korean candidate terms:
+- English candidate terms:
+- Alias candidates:
+- Glossary searches attempted:
+- Search-assist queries attempted:
+- Candidate MCP route:
+- User decision needed:
+```
+
+Search Brief는 runtime context에만 유지한다. 사용자에게 묻기 전에 MCP evidence를
+사용한다. evidence가 tied interpretation을 남길 때만 clarifying question 하나를
+묻고, recommended interpretation을 함께 제시한다.
+
+## Full-Cycle Retrieval Ladder
+
+broad, semantic, comparison, inventory, impact-seed에는 ladder를 사용한다.
+project context -> overview -> vocabulary -> epic map -> BR/DD/DESIGN/UCL map ->
+exact items -> connected specs -> exact specs -> 필요 시 source confirmation ->
+Final Route Audit.
+
+각 rung은 list/map first, exact detail second다. Overview, artifact, catalog row,
+glossary output, search hit는 방향만 잡는다. ladder와 audit은
+`references/full-cycle-retrieval.md`를 읽는다.
+
+## Branch Table
+
+`references/full-cycle-retrieval.md`가 canonical order of operations다.
+`references/question-routes.md`는 branch-specific document family, extra
+requirement, completion check를 고를 때만 읽는다. ladder의 두 번째 사본으로
+취급하지 않는다.
+
+question type에 따라 route한다: concept/domain term, policy/rule, data field,
+design, capability/journey, exact API/screen/event/schedule, impact seed, source
+absence.
+
+## Evidence Gates
+
+- Vocabulary normalization은 proof가 아니다.
+- Search hit, snippet, score는 candidate이지 fact가 아니다.
+- Project overview와 epic row는 scope를 고르는 데 쓰며 final behavior가 아니다.
+- BR, DD, DESIGN, UCL은 semantic router다.
+- Memory overlay는 human/agent note다. correction, constraint, why/context,
+  ambiguity에 사용하되 generated SOT 및 source evidence와 분리한다.
+- Source-near behavior claim에는 exact spec evidence가 필요하다.
+- 선택한 `spec_search` candidate는 `spec_get`과 `spec_resolve`로 이어간다.
+- Exact implementation, response shape, permission, DB write, event emit,
+  external call, negative source evidence에는 MCP 서버가 노출하는 경우 source-level
+  confirmation이 필요하다. `code_search`로 candidate를 찾은 뒤 MCP
+  `readonly_workspace_shell`을 적극적으로 사용해 bounded source region을 읽는다.
+- `itemType`을 포함한 `document_item_list`가 row를 반환하지 않지만 available item을
+  보고하거나 `DOCUMENT_ITEM_FILTER_EMPTY_WITH_AVAILABLE_ITEMS`를 emit하면, item을
+  absent로 취급하기 전에 narrowing filter 없이 같은 document를 retry한다.
+- `document_list` 또는 `document_get`이 document-level `content.items`를 보여주는데
+  `document_item_list`가 row를 반환하지 않거나 `itemTier: inconsistent`를 보고하면,
+  exact `document_item_get`을 사용할 수 없는 한 MCP item-tier gap을 보고하고
+  document-level evidence로 약화한다.
+- 필수 read-only surface가 없으면 MCP capability gap을 보고한다. configured MCP tool
+  밖의 surface로 전환하지 않는다.
+- Stored SOT file content와 artifact path는 transport evidence일 뿐이다.
+
+예시와 branch-specific evidence rule은 `references/evidence-gates.md`를 읽는다.
+
+## Stop Conditions
+
+selected-branch tool이 없거나, 사용자가 setup, analysis, sync, generation,
+mutation, memory write, local cache/local read를 요청하거나, full-cycle map을 만들
+수 없거나, search candidate만 있거나, raw term과 normalized term이 갈라지거나,
+broad inventory/impact seed에 target map이 없거나, 필요한 source confirmation tool이
+없으면 중단하고 boundary를 보고한다.
+
+MCP evidence가 tied interpretation을 남기면 recommended interpretation과 함께
+clarifying question 하나를 묻는다. MCP evidence 안에서 ambiguity를 해결할 수 없을
+때만 중단한다.
+
+evidence가 약하면 다음 read-only MCP surface를 이름으로 밝힌다. 그것이 refresh,
+export, sync, generation, memory write, local file을 필요로 하면
+configuration/boundary gap을 보고한다.
+
+## Final Route Audit
+
+모든 final answer 전에 runtime context에서 route를 audit한다. 필수 rung이 빠졌으면
+MCP step을 수행하거나 weaken/stop한다. audit failure를 confident claim으로 바꾸지
+않는다. Checklist: `references/full-cycle-retrieval.md`.
+
+## Stakeholder Answer Shape
+
+product 또는 implementation question에는 answer first, evidence second,
+uncertainty last로 답한다. 전체 template은 `references/answer-shape.md`.
+
+```text
+## 현재 확인된 기준
+## 실제 동작
+## 관련 위치
+## 더 확인할 후보
+```
+
+technical id보다 internal name을 먼저 설명한다. "확인됨"은 exact MCP content read에만
+사용한다. search hit 또는 inferred behavior에는 "후보", "근거상 보임", "추가 확인
+필요"를 사용한다.
+
+## Answer Contract
+
+모든 답변에는 evidence boundary, 사용한 normalized term, selected interpretation,
+읽은 surface, direct evidence vs inference, freshness 또는 coverage limit, missing MCP
+surface, confidence 또는 scope를 바꾸는 audit result가 포함되어야 한다.
+
+## Verification Reference
+
+이 스킬을 validate하거나 변경할 때만 `references/pressure-scenarios.md`를 사용한다.
+일반 retrieval answer에는 load하지 않는다.

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platty-mcp-retrieval
-description: Use when answering Platty project questions through configured read-only MCP tools, including domain terms, epics, business documents, specs, impact, code locations, or source confirmation.
+description: Use when answering Platty project questions through configured read-only MCP tools, including domain terms, epics, business documents, specs, exact code locations, or source confirmation, or when another Platty MCP skill needs an Impact Seed Packet.
 ---
 
 # Platty MCP Retrieval
@@ -12,36 +12,66 @@ Platty MCP retrieval is map-first: browse project, epic, document-item, and
 spec maps before search hits.
 
 <HARD-GATE>
-For broad, domain-term, business-rule, data-field, system-design, capability,
-journey, comparison, inventory, or impact questions, do not answer and do not
-treat search as proof until the Full-Cycle Retrieval Ladder has been completed
-or a required MCP surface is reported missing.
+For broad, domain-term, rule, data-field, design, capability, journey,
+comparison, inventory, or impact-seed questions, do not answer or treat search
+as proof until the Full-Cycle Retrieval Ladder is complete or a required MCP
+surface is missing.
 
 Do not call `document_search`, `ssot_search`, `spec_search`, `code_search`, or
-`graph_trace` first. Build project overview, vocabulary when needed, epic map,
-and selected BR/DD/DESIGN/UCL map first. Search narrows candidates after maps;
-it cannot replace exact `epic_get`, `document_list`, `document_item_get`,
-`document_resolve`, `spec_get`, or `code_snippet` reads.
+`graph_trace` first. Build overview, vocabulary when needed, epic map, and
+selected BR/DD/DESIGN/UCL map first. Search narrows candidates; it cannot
+replace exact reads.
 </HARD-GATE>
 
-The MCP profile is read-only. Use configured MCP tools only; do not read local
-files, read local SOT, mutate projects, generate documents, or write memory. Stored SOT
-files are available only through MCP artifact tools and need exact evidence
-reads before behavior claims.
+The MCP profile is read-only. Use configured MCP tools only. Do not read local
+files, read local SOT, mutate projects, generate documents, or write memory.
+MCP `readonly_workspace_shell` is allowed when
+exposed and required by the evidence gate; it is not local fallback. Stored SOT
+files need MCP artifact reads before behavior claims.
 
-Memory overlay reads: read selected `project_overview_get.overview.memories`,
-`epic_get.memories`, and `document_get.memories`. Use `memory_list` or
-`memory_get` when only counts/ids are visible or overlays may affect the answer.
+Memory overlay reads: inspect selected `project_overview_get.overview.memories`,
+`epic_get.memories`, and `document_get.memories`. When cards are insufficient,
+use `memory_list` or `memory_get`: list for scoped discovery and get for an
+exact memory body.
 
 ## When To Use
 
-Use this skill for read-only Platty answers about domain terms, epics, business
-docs, specs, impact, code locations, or source confirmation.
+Use this skill for retrieval answers about domain terms, epics, business docs,
+specs, exact API/source-near questions, code locations, source confirmation, or
+an Impact Seed Packet needed by impact/SDD skills.
 
 ## When Not To Use
 
 Do not use it for setup, analysis, sync, generation, mutation, memory writes,
-local cache changes, or local inspection. Report those as boundary gaps.
+local cache changes, or local inspection. Report boundary gaps.
+
+## Impact Escalation Gate
+
+Route explicit SDD file authoring first: request/story authoring goes to
+`platty-mcp-sdd-spec`; design/task authoring goes to `platty-mcp-sdd-design`.
+That intent takes precedence over generic impact or design-change wording.
+
+Keep ordinary retrieval retrieval-only. In particular, an exact API, exact
+screen, or exact source-near question remains in this skill unless the user also
+asks an observable impact question.
+
+Treat "what changes", "what breaks", affected surface, blast radius,
+cross-EPIC impact, or design-change impact as observable impact triggers:
+
+```text
+ordinary question -> retrieval answer
+user impact trigger -> retrieval(routeMode=seed-only, routeOrigin=user)
+-> semantic map -> Impact Seed Packet -> platty-mcp-impact-analysis
+impact without packet -> retrieval(routeMode=seed-only, routeOrigin=impact)
+-> return Impact Seed Packet to impact; do not escalate
+impact with packet -> dossier axes; do not re-enter retrieval
+SDD file authoring intent -> platty-mcp-sdd-spec or platty-mcp-sdd-design
+```
+
+`routeMode: seed-only` makes this skill the packet producer only: return the
+Impact Seed Packet to the caller, and reuse an existing packet. Retrieval owns
+semantic scope and selected specs; impact owns graph, cross-EPIC, repository,
+and source convergence.
 
 ## Operating Flow
 
@@ -49,8 +79,9 @@ local cache changes, or local inspection. Report those as boundary gaps.
 2. Confirm the MCP capability tier needed for the question.
 3. Run the Search Clarification Gate when the question is broad or ambiguous.
 4. Run the Full-Cycle Retrieval Ladder for broad or semantic branches.
-5. Traverse exact specs, graph, or source evidence required by the selected
-   branch.
+5. For an observable impact trigger, produce or reuse the Impact Seed Packet;
+   otherwise traverse exact specs or source evidence required by the selected
+   retrieval branch.
 6. Account for relevant memory overlays without treating them as SOT or source
    proof.
 7. Run the Final Route Audit.
@@ -58,28 +89,44 @@ local cache changes, or local inspection. Report those as boundary gaps.
    and missing MCP surfaces separated.
 
 If the answer needs correction recording, re-anchoring, refresh, sync, or
-generation, report a boundary gap.
+generation, report a gap.
 
 ## Quick Rules
 
 | Do | Don't |
 | --- | --- |
-| Use configured MCP tools only. | Read local files, local SOT, DB tables, or caches. |
+| Use configured MCP tools only, including MCP `readonly_workspace_shell` for bounded source confirmation. | Read local files, use local shell/CLI fallback, local SOT, DB tables, or caches. |
 | Build project, epic, BR/DD/DESIGN/UCL, spec, and source maps in order. | Treat one search hit, snippet, or score as proof. |
 | Read attached memory overlays on selected epics/documents. | Treat memory as generated SOT or source-confirmed behavior. |
 | Normalize vocabulary when terms may not line up. | Treat glossary normalization as behavior evidence. |
 | Read exact item/spec/source evidence before implementation claims. | Claim response shape, permissions, writes, emits, or absence without the required evidence tier. |
+| Pair `code_search` with MCP `readonly_workspace_shell` for code claims: locate candidates, then read bounded source. | Stop at `code_search` when source code must be inspected. |
+| After exact BR/DD/DESIGN/UCL item reads, call `document_resolve(itemId)` before source-near search unless purely conceptual. | Jump from a business item to search without resolving linked context. |
 | Ask one clarifying question only after MCP evidence leaves tied interpretations. | Ask the user before using MCP evidence to reduce ambiguity. |
+
+## Vocabulary Tool Choice
+
+- Use `glossary_translate(projectId, text)` for an exact raw phrase or
+  candidate term. Keep Korean/English candidates visible.
+- Use `glossary_list(projectId, limit, cursor)` for broad vocabulary inventory,
+  comparisons, ambiguous concepts, all-alias requests, or candidate discovery
+  after translation is blank or conflicting.
+- If `glossary_translate` is blank or conflicting while plausible candidates
+  remain, call `glossary_list` before translating more candidates.
+- For complete inventory, follow `pageInfo.nextCursor` until exhausted. For
+  targeted discovery, stop after the needed candidates are found.
+- Use `aliases` for query expansion. Keep `generatedAliases` and
+  `memoryAliases` separate; memory aliases are overlays and glossary output is
+  routing evidence, not behavior or source proof.
 
 ## Search Clarification Gate
 
 Before routing, decide whether the question is exact or needs a runtime Search
-Brief. Exact source-near questions can bypass unless term, scope, or target set
-is ambiguous.
+Brief. Exact source-near questions can bypass unless ambiguous.
 
 Create a Search Brief for broad inventory, impact, Korean/English bridges,
-business-vs-implementation splits, or any case where one search hit could miss
-the target set. For triggers, read `references/search-clarification.md`.
+business-vs-implementation splits, or when one search hit could miss the target
+set. For triggers, read `references/search-clarification.md`.
 
 Search Brief shape:
 
@@ -100,15 +147,13 @@ Search Brief
 ```
 
 Keep the Search Brief in runtime context only. Use MCP evidence before asking
-the user. Ask one clarifying question only when evidence leaves tied
-interpretations, and include the recommended interpretation.
+one clarifying question for tied interpretations.
 
 ## Full-Cycle Retrieval Ladder
 
-Use the ladder for broad, semantic, comparison, inventory, or impact: project
-context -> overview -> vocabulary -> epic map -> BR/DD/DESIGN/UCL map -> exact
-items -> connected specs -> exact specs -> source confirmation when required ->
-Final Route Audit.
+Use the ladder for broad, semantic, comparison, inventory, or impact-seed:
+project context -> overview -> vocabulary -> epic map -> BR/DD/DESIGN/UCL map
+-> exact items -> connected specs -> specs/source as required -> audit.
 
 Each rung is list/map first, exact detail second. Overview, artifacts, catalog
 rows, glossary output, and search hits orient only. For the ladder and audit,
@@ -116,9 +161,14 @@ read `references/full-cycle-retrieval.md`.
 
 ## Branch Table
 
+`references/full-cycle-retrieval.md` is the canonical order of operations.
+Read `references/question-routes.md` only to choose branch-specific document
+families, extra requirements, and completion checks; do not treat it as a second
+copy of the ladder.
+
 Route by question type: concept/domain term, policy/rule, data field, design,
-capability/journey, exact API/screen/event/schedule, impact, or source absence.
-Branch criteria: `references/question-routes.md`.
+capability/journey, exact API/screen/event/schedule, impact seed, or source
+absence.
 
 ## Evidence Gates
 
@@ -133,7 +183,8 @@ Branch criteria: `references/question-routes.md`.
 - Follow selected `spec_search` candidates with `spec_get` and `spec_resolve`.
 - Exact implementation, response shape, permission, DB write, event emit,
   external call, or negative source evidence requires source-level confirmation
-  when the MCP server exposes it.
+  when the MCP server exposes it. Use `code_search` to locate candidates, then
+  actively use MCP `readonly_workspace_shell` to read the bounded source region.
 - If `document_item_list` with `itemType` returns no rows but reports
   available items or emits
   `DOCUMENT_ITEM_FILTER_EMPTY_WITH_AVAILABLE_ITEMS`, retry the same document
@@ -154,7 +205,7 @@ For examples and branch-specific evidence rules, read
 Stop and report a boundary when selected-branch tools are missing; the user asks
 for setup, analysis, sync, generation, mutation, memory writes, local cache/local
 reads; full-cycle maps cannot be built; only search candidates exist; raw and
-normalized terms split; broad inventory/impact lacks a target map; or required
+normalized terms split; broad inventory/impact seed lacks a target map; or required
 source confirmation tools are missing.
 
 If MCP evidence leaves tied interpretations, ask one clarifying question with a
@@ -196,5 +247,5 @@ confidence or scope.
 
 ## Verification Reference
 
-Use `references/pressure-scenarios.md` to test whether this skill prevents
-search-first answers, glossary-as-proof answers, and local fallback.
+Use `references/pressure-scenarios.md` only when validating or changing this
+skill. Do not load it for ordinary retrieval answers.

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/evidence-gates.ko.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/evidence-gates.ko.md
@@ -1,0 +1,67 @@
+# MCP 증거 게이트
+
+Platty MCP 검색 결과로 사실 주장을 하기 전에 이 게이트를 적용한다.
+
+| 증거 | 증명할 수 있는 것 | 증명할 수 없는 것 |
+| --- | --- | --- |
+| Vocabulary normalization | 쿼리 확장, 별칭, 후보 개념 | 비즈니스 사실이나 구현 동작 |
+| Project overview | 제품 영역의 방향 잡기 | 정확한 정책, 응답 shape, 코드 동작, 전체 범위 |
+| Epic map | 후보 범위와 사용 가능한 문서/spec 표면 | 최종 동작 또는 인접 후보가 없다는 증명 |
+| Search hit | 후보 발견 | 그 자체로 사실 |
+| BR/DD/DESIGN/UCL item | 의미 라우팅과 문서화된 의도 | 소스로 확인된 enforcement 또는 구현 |
+| Document resolution | 연결된 spec과 source-near anchor | 정확한 read 없는 동작 |
+| Source-near spec | 소스에 가까운 API/screen/event/schedule 동작 | spec이 얇거나 낡았거나 모순될 때의 source truth |
+| Graph trace | 선택한 anchor/options에 대해 확인된 정적 edge | 빠짐없는 영향도, 특히 omitted/candidate edge가 있을 때 |
+| `code_search` | 후보 파일, symbol, route, source 위치 | bounded source read 없는 정확한 구현 동작 |
+| Bounded `readonly_workspace_shell` source read | 표시된 line range 안의 정확한 source evidence | 표시 범위 밖의 동작 |
+
+## Claim Gate
+
+- Concept explanation: 구현 주장을 하지 않는다면 vocabulary와 project/epic
+  context만으로 충분할 수 있다.
+- Broad domain, comparison, inventory, impact answer: 먼저 full-cycle map을
+  완성한다. project overview, README류 artifact text, glossary, catalog row,
+  search hit는 방향 잡기일 뿐이다.
+- Business policy: business-rule item을 읽는다. enforcement를 주장하기 전에는
+  연결된 spec/source를 읽는다.
+- Data field meaning: data-dictionary item을 읽는다. 정확한 usage를 주장하기
+  전에는 연결된 spec/source를 읽는다.
+- API response shape: exact API spec을 읽는다. spec만으로 response가 충분히
+  확정되지 않으면 source-level evidence를 사용한다.
+- Permission, DB write, event emit, external call, negative source evidence:
+  MCP 서버가 노출한다면 source-level evidence가 필요하다.
+- Code behavior, scroll/timer accumulation, lifecycle handling, guard logic,
+  exact implementation claim: `code_search`로 후보 위치를 찾은 뒤, 동작을
+  주장하기 전에 MCP `readonly_workspace_shell`로 관련 bounded source를 읽는다.
+- Broad inventory 또는 impact: 먼저 target map을 만든다. hit 하나로는
+  충분하지 않다.
+
+## Negative Claim Gate
+
+search miss는 absence evidence가 아니다. 빈 `ssot_search`, `document_search`,
+`spec_search`, `code_search`, glossary 결과만으로 concept, campaign type,
+permission, API, field, screen, impact가 없다고 주장하지 않는다.
+
+Negative claim에는 다음 중 하나가 필요하다.
+
+- 해당 branch의 complete relevant map과 absence를 보여주는 exact item/spec read
+- 구현, call, write, emit, permission, response field, code location에 대한
+  주장이라면 source-level confirmation
+- "does not exist" 대신 "읽은 surface에서는 확인되지 않음" 같은 명확한 boundary
+
+## Capability Gap 문구
+
+필수 MCP surface가 없으면 다음처럼 말한다.
+
+```text
+I can answer from the configured MCP evidence up to <surface>. I cannot confirm
+<claim type> because <missing tool or tier> is not exposed by this MCP server.
+```
+
+다음처럼 말하지 않는다.
+
+```text
+I will check the local SOT folder.
+I will verify outside configured MCP tools.
+There is no impact.
+```

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/evidence-gates.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/evidence-gates.md
@@ -12,7 +12,8 @@ Use these gates before making factual claims from Platty MCP retrieval.
 | Document resolution | Connected specs and source-near anchors | Behavior without exact reads |
 | Source-near spec | API/screen/event/schedule behavior close to source | Source truth when spec is thin, stale, or contradicted |
 | Graph trace | Confirmed static edges for the chosen anchor/options | Exhaustive impact, especially when omitted/candidate edges exist |
-| Code snippet | Exact source evidence within the shown line range | Behavior outside the displayed scope |
+| `code_search` | Candidate files, symbols, routes, or source locations | Exact implementation behavior without bounded source reads |
+| Bounded `readonly_workspace_shell` source read | Exact source evidence within the shown line range | Behavior outside the displayed scope |
 
 ## Claim Gates
 
@@ -29,6 +30,10 @@ Use these gates before making factual claims from Platty MCP retrieval.
   does not fully establish the response.
 - Permission, DB write, event emit, external call, negative source evidence:
   requires source-level evidence when the MCP server exposes it.
+- Code behavior, scroll/timer accumulation, lifecycle handling, guard logic, or
+  exact implementation claims: use `code_search` for candidate locations, then
+  read the relevant bounded source with MCP `readonly_workspace_shell` before
+  claiming the behavior.
 - Broad inventory or impact: build the target map first; one hit is not enough.
 
 ## Negative Claim Gate

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.ko.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.ko.md
@@ -1,0 +1,267 @@
+# Full-Cycle Retrieval Ladder
+
+`platty-mcp-retrieval`이 broad, semantic, comparison, inventory, impact question으로
+route할 때 이 reference를 사용한다. 각 rung은 list/map first, exact detail second다.
+
+## Contents
+
+- Exact Item Fast Path
+- Evidence Depth By Question Type
+- Canonical Ladder
+- Runtime Evidence Checklist
+- Business Document To Source-Near Spec Descent
+- Retrieval Order
+- Final Route Audit
+
+## Exact Item Fast Path
+
+exact BR/DD/DESIGN/UCL item이 이미 선택되어 있다면 search로 먼저 넓히지 않는다.
+item을 source-near evidence로 가는 bridge로 사용한다.
+
+```text
+document_item_get
+-> document_resolve(itemId)
+-> rank linked api_spec/screen_spec/event_spec/schedule_spec candidates
+-> spec_get for selected source-near behavior
+-> spec_resolve for related docs/items, graph seeds, and code seeds
+```
+
+선택된 routing card 또는 item에는 `document_resolve(documentId)`보다
+`document_resolve(itemId)`를 선호한다. whole-document resolve는 inventory에는 유용하지만
+broad candidate를 반환할 수 있다. item-level resolve가 screen/API/event/schedule
+descent의 fast path다.
+
+## Evidence Depth By Question Type
+
+claim을 뒷받침할 수 있는 최소 evidence depth를 사용한다. pure concept overview에는
+source-near spec이나 source read를 강제하지 않는다. 그러나 flow, policy,
+implementation-facing behavior, data claim에는 overview/search에서 멈추지 않는다.
+
+| Question type | Required depth |
+| --- | --- |
+| Service overview, user-type explanation, implementation/API/screen/data claim 없는 high-level product inventory | `project_overview_get` -> `epic_list`/`epic_get` -> optional `ssot_search`/`ssot_get`; 답이 conceptual로 남고 coverage limit을 밝히면 여기서 멈출 수 있다 |
+| Product flow, capability, journey, admin workflow, user action | Project/epic map -> DESIGN business document map near-mandatory -> 필요 시 BR/DD/UCL -> exact document/item reads -> source-near specs |
+| Business policy, eligibility, status transition, rule enforcement | BR 및 관련 DESIGN/DD/UCL exact items -> connected specs -> enforcement를 주장할 때 source read |
+| Data shape, table, field, state distribution, funnel, conversion, operational bottleneck | DD 및 관련 DESIGN/BR exact items -> behavior가 중요하면 connected specs. data MCP가 노출되면 guide를 읽고 read-only query를 사용한다. operational data source가 없으면 measurable funnel steps, instrumentation points, SSOT 기반 bottleneck hypothesis까지만 말하고 actual conversion cause를 주장하지 않는다 |
+| API, screen, event, schedule, job, integration, permission, response shape, DB write, emit, external call, implementation behavior | Selected `api_spec`/`screen_spec`/`event_spec`/`schedule_spec` -> `spec_resolve` -> `code_search` -> spec이 thin/ambiguous하거나 exact source confirmation이 필요하면 bounded `readonly_workspace_shell` |
+
+`readonly_workspace_shell`은 MCP가 제공하는 read-only source tool을 뜻한다. exposed되어 있고
+evidence gate가 요구할 때 사용할 수 있다. `code_search` path의 source-reading half로
+취급한다. `code_search`는 candidate file/symbol을 찾고, `readonly_workspace_shell`은
+bounded source region을 읽는다. claim에 source inspection이 필요하면 `code_search`에서
+멈추지 않는다. MCP source tool이 없다고 local filesystem 또는 local shell read로
+대체하지 않는다.
+
+conceptual answer에 "this API writes X", "this screen calls Y", "this status
+changes when Z", "users drop here" 같은 concrete behavior가 들어가면 더 이상 pure
+overview가 아니다. claim 전에 deeper branch로 escalate한다.
+
+## Canonical Ladder
+
+BR, DD, DESIGN, UCL은 semantic document family다. `document_list` tool argument에는
+live MCP schema가 다른 값을 광고하지 않는 한 MCP filter value(`br`,
+`data_dictionary`, `design`, `ucl`)를 사용한다. DD는 `dd`가 아니라
+`data_dictionary`에 매핑된다.
+
+```text
+project_list/project_get/context_status
+-> project_overview_get; read project_overview_get.overview.memories when present and use memory_get for exact bodies when needed
+-> glossary_list for broad inventory, comparison, ambiguity, all-alias requests, or blank/conflicting translation; traverse every page when completeness is required
+-> glossary_translate for the raw phrase and Korean/English candidates; record matched terms and alias candidates
+-> epic_list
+-> epic_get for each plausible candidate epic before discarding it; read epic_get.memories for selected candidate epics
+-> document_list for the selected branch:
+   documentType=br for policy/rule/eligibility
+   documentType=data_dictionary for entity, table, field, or data-shape questions
+   [MUST] documentType=design for product flow, capability, journey, admin workflow,
+   system design, integration, data flow, architecture, or implementation-facing
+   questions
+   documentType=ucl for capability, journey, screen, or user action questions
+-> document_get/document_item_list to map candidate items; read document_get.memories for selected documents and use memory_get for exact bodies when needed
+-> document_item_get for exact BR/DD/DESIGN/UCL evidence
+-> document_resolve(itemId) after exact item reads; use document_resolve(documentId)
+   only for document-wide inventory. Follow explicit links to connected API,
+   screen, event, schedule, data, service, or spec anchors and collect linked
+   api_spec/screen_spec/event_spec/schedule_spec spec ids when returned
+-> rank linked api_spec, screen_spec, event_spec, and schedule_spec candidates
+   and keep the selected spec ids visible; use spec_list/spec_search only after
+   document_resolve when the explicit linked set is absent, incomplete, stale,
+   too broad, or the exact spec id is unknown
+-> when spec_search is used, select candidate specs before making claims
+-> spec_get for exact source-near behavior
+-> spec_resolve to expand selected specs to related documents, items, graph seeds, and code seeds
+-> code_search only when source address is incomplete and configured
+-> readonly_workspace_shell to read the bounded candidate source before claiming
+   exact code behavior, implementation absence, writes, emits, permissions, or response shape
+```
+
+ladder에 필요한 map/list surface가 없으면 해당 rung을 search로 대체하지 말고 MCP
+capability gap을 보고한다.
+
+## Runtime Evidence Checklist
+
+답하기 전에 이 checklist를 runtime context에 유지하고, 선택한 question branch가 요구하는
+rung을 완료한다. 사용자가 route audit을 요청하지 않는 한 final answer에 긴 checklist를
+출력하지 않는다.
+
+```text
+[ ] Select project with project_list or project_get.
+[ ] Check context_status and project_overview_get.
+[ ] Identify relevant EPICs with epic_list and epic_get.
+[ ] Normalize ambiguous Korean/domain terms with glossary_translate or
+    glossary_list when needed.
+[ ] If this is a pure service overview/user-type explanation with no concrete
+    implementation, API, screen, event, schedule, state, or operational-data
+    claim, stop at overview/epic/SSOT depth and state the boundary.
+[ ] For product/business flow: use ssot_search -> ssot_get when SSOT evidence is
+    the selected surface.
+[ ] For authored docs or business rules: use document_list/search/get and exact
+    document_item_get when item evidence is needed.
+[ ] If any exact BR/DD/DESIGN/UCL item was used, run document_resolve(itemId)
+    before source-near search, or state why the answer remains purely
+    conceptual.
+[ ] For product flow, capability, journey, admin workflow, data flow,
+    integration, architecture, or implementation-facing questions, include
+    DESIGN as a near-mandatory business map before descending to specs.
+[ ] For API/screen/event/schedule/source-near behavior: use
+    document_resolve(itemId) first after exact item reads, and prefer explicitly
+    linked api_spec/screen_spec/event_spec/schedule_spec ids when available.
+    Use spec_search only as fallback when explicit links are absent, incomplete,
+    stale, too broad, or unresolved.
+[ ] Run spec_resolve after selected spec reads when connected docs/items, graph
+    seeds, or code seeds matter.
+[ ] If implementation behavior is important or still ambiguous:
+    [ ] use code_search to find filePath/functionName candidates when the source
+        address is incomplete.
+    [ ] use workspace_repo_list if repoId is unknown.
+    [ ] actively use bounded readonly_workspace_shell to read only the relevant
+        file/function range before making code behavior claims. There is no
+        code_snippet tool; do not ask for or claim one.
+[ ] If operational data is claimed:
+    [ ] only do this when a data MCP is exposed for the environment.
+    [ ] read data_analysis_guide/domain_guide when exposed by that data MCP.
+    [ ] use read-only RDS/Athena SELECT and state sample/cohort limits.
+[ ] If no operational data MCP is exposed for a funnel/conversion/bottleneck
+    question, limit the answer to SSOT-derived funnel steps, instrumentation
+    points, and hypotheses. Do not claim observed conversion drops or causes.
+[ ] Do not treat search snippets, scores, overview text, or glossary output as
+    proof.
+[ ] State freshness, coverage, missing MCP surfaces, and any unresolved
+    ambiguity.
+```
+
+`spec_search`를 사용했다면 선택한 모든 spec candidate를 같은 route 안에서 `spec_get`과
+`spec_resolve`로 이어가야 한다. spec search hit를 complete evidence로 취급하거나
+resolve를 나중의 optional step으로 미루지 않는다.
+
+## Business Document To Source-Near Spec Descent
+
+질문이 SOT business context에서 시작하면 BR/DD/DESIGN/UCL document와 item은 map이지
+source-near proof가 아니다.
+
+```text
+business question
+-> document_list/document_get/document_item_list
+   [MUST] include DESIGN for product flow, capability, journey, admin workflow,
+   data flow, integration, architecture, or implementation-facing questions
+-> document_item_get for exact business item
+-> document_resolve(itemId) to follow explicit item links and collect linked
+   api_spec, screen_spec, event_spec, and schedule_spec ids when returned
+-> rank linked source-near spec candidates and keep selected spec ids visible
+-> spec_list/spec_search only if document_resolve returns no usable link, an
+   incomplete/stale/too-broad linked set, or the exact spec id is unknown
+-> when spec_search is used, select candidate specs before making claims
+-> spec_get for selected api_spec/screen_spec/event_spec/schedule_spec details
+-> spec_resolve to expand selected specs to related docs/items, graph seeds, and code seeds
+```
+
+`document_resolve(itemId)`는 exact business item에서 linked source-near spec으로 가는 첫
+bridge다. exact item이 선택되기 전 document-wide inventory를 할 때만
+`document_resolve(documentId)`를 사용한다. `spec_resolve`는 business doc에서 spec으로
+가는 첫 bridge가 아니다. spec을 선택한 뒤 reverse anchor, related item/document,
+source seed expansion을 모으는 데 사용한다.
+
+Business document item은 routing evidence다. exact API, screen, event, schedule
+behavior에는 detail을 열기 전에 connected `api_spec`, `screen_spec`, `event_spec`,
+`schedule_spec` candidate를 rank한다. direct document/spec link, same epic,
+same entity/field, same route/screen/API/event/schedule target, same branch intent가
+우선순위가 높다.
+
+항상 explicit link를 먼저 사용한다. `document_resolve(itemId)`는 traced business-doc
+item context를 linked spec/item으로 따라가는 MCP equivalent이며, exact business
+evidence에서 source-near evidence로 가는 첫 bridge다. 선택한 DESIGN/BR/DD/UCL document
+또는 item이 충분한 linked source-near spec을 반환하지 않거나 stale/too-broad candidate를
+반환하면, document에서 발견한 business term, route/screen name, table/model name,
+status name, API/action name으로 `spec_search`를 사용해 넓힌다. source-near claim 전에는
+선택한 spec에 `spec_get`과 `spec_resolve`를 읽는다. 모든 connected spec을 처음부터 열지
+말고, 먼저 rank한 뒤 가장 강한 candidate를 읽는다.
+
+Memory overlay는 overview, epic, document, item, spec에 attached된
+correction/constraint/why/context note다. 각 selected surface에서 attached memory card를
+확인한다: `project_overview_get.overview.memories`, `epic_get.memories`,
+`document_get.memories`, item memories, spec memories. broad document read는 summary를
+반환할 수 있다. overlay가 answer boundary를 바꿀 수 있으면 `memory_get`을 사용한다.
+memory를 generated SOT 또는 source proof로 취급하지 않는다.
+
+## Retrieval Order
+
+```text
+project context
+-> context status
+-> capability check
+-> Search Clarification Gate when triggers fire
+-> project overview with attached overview memories when present
+-> glossary_list for broad inventory, comparison, ambiguity, all-alias requests, or blank/conflicting translation; traverse every page when completeness is required
+-> glossary_translate for the raw phrase and Korean/English candidates; record matched terms and alias candidates
+-> candidate epic
+-> candidate BR/DD/DESIGN/UCL document map
+-> question branch
+-> relevant business document items or exact source-near anchor
+-> connected api_spec/screen_spec/event_spec/schedule_spec evidence through
+   document_resolve(itemId) after exact item reads, with spec_search fallback
+   only when explicit links are absent, incomplete, stale, too broad, or unresolved
+-> exact spec evidence
+-> spec_resolve for connected context and graph/code seeds
+-> source-level confirmation only when required
+-> Final Route Audit
+-> answer with boundary
+```
+
+## Final Route Audit
+
+broad, ambiguous, Korean/English, comparison, inventory, impact, mixed
+business-vs-implementation question에서 confident answer를 하기 전에 다음이 모두 참이어야
+한다.
+
+1. Search Brief가 있고 raw user phrase를 보존했다.
+2. Korean/English vocabulary가 맞물리지 않을 수 있으면 raw terms, Korean candidate terms,
+   English candidate terms가 모두 visible하다.
+3. Glossary/vocabulary output은 routing에만 사용했고 behavior proof로 쓰지 않았다.
+4. final scope를 고르기 전에 project overview, present한 attached overview memories,
+   epic map을 읽었다.
+5. search miss, snippet, weak score 하나로 relevant candidate EPIC을 버리지 않았다.
+6. 선택한 branch에 대해 candidate BR/DD/DESIGN/UCL document map을 만들었다.
+7. selected overview, epic, document, item, spec의 relevant attached memory overlay를
+   확인했고 generated SOT/source evidence와 분리했다.
+8. business, data, design, capability claim 전에 exact document item을 읽었다.
+9. selected document가 item summary를 노출하지만 `document_item_list`가 empty이면,
+   document body에서 exact BR/DD/DESIGN/UCL evidence를 주장하지 않고 item-tier coverage
+   gap을 보고하거나 narrowing filter 없이 retry했다.
+10. exact BR/DD/DESIGN/UCL item을 읽었다면 source-near search 전에
+    `document_resolve(itemId)`를 실행했거나, answer가 explicitly conceptual로 남아 있다.
+11. source-near spec을 따라가기 전에 connected context를 resolve했다.
+12. business doc에서 시작했다면 exact source-near spec read 전에 linked `api_spec`,
+    `screen_spec`, `event_spec`, `schedule_spec` candidate를 rank했고 selected candidate의
+    spec id를 visible하게 유지했다. `spec_search` fallback은 `document_resolve`가 usable
+    link를 반환하지 않거나, incomplete/stale/too-broad link를 반환하거나, exact spec id가
+    없을 때만 사용했다.
+13. source-near behavior claim 전에 exact spec을 읽었다.
+14. selected spec read 뒤 related docs/items, graph seeds, code seeds, reverse anchor를
+    노출하기 위해 `spec_resolve`를 실행했다.
+15. exact source claim에는 필요한 `code_search` 뒤 MCP `readonly_workspace_shell`로 bounded
+    exact source region을 읽었다. code search hit만 사용하지 않았다.
+16. "not present", "not independent", "not used", "no impact" 같은 negative claim은
+    Evidence Gates가 요구하는 evidence tier를 갖는다.
+17. 읽지 않았지만 plausible한 surface를 coverage limit 또는 next MCP read로 명명했다.
+18. final answer가 direct evidence, inference, memory overlay, freshness, missing MCP
+    surfaces를 분리한다.

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md
@@ -4,34 +4,158 @@ Use this reference when `platty-mcp-retrieval` routes a broad, semantic,
 comparison, inventory, or impact question. Each rung is list/map first, exact
 detail second.
 
+## Contents
+
+- Exact Item Fast Path
+- Evidence Depth By Question Type
+- Canonical Ladder
+- Runtime Evidence Checklist
+- Business Document To Source-Near Spec Descent
+- Retrieval Order
+- Final Route Audit
+
+## Exact Item Fast Path
+
+When an exact BR/DD/DESIGN/UCL item has already been selected, do not widen with
+search first. Use the item as the bridge into source-near evidence:
+
+```text
+document_item_get
+-> document_resolve(itemId)
+-> rank linked api_spec/screen_spec/event_spec/schedule_spec candidates
+-> spec_get for selected source-near behavior
+-> spec_resolve for related docs/items, graph seeds, and code seeds
+```
+
+Prefer `document_resolve(itemId)` over `document_resolve(documentId)` for a
+selected routing card or item. Whole-document resolve is useful for inventory,
+but it can return broad candidates; item-level resolve is the fast path for
+screen/API/event/schedule descent.
+
+## Evidence Depth By Question Type
+
+Use the minimum evidence depth that can support the claim. Do not force
+source-near specs or source reads for pure concept overviews, but do not stop at
+overview/search for flows, policies, implementation-facing behavior, or data
+claims.
+
+| Question type | Required depth |
+| --- | --- |
+| Service overview, user-type explanation, high-level product inventory with no implementation/API/screen/data claim | `project_overview_get` -> `epic_list`/`epic_get` -> optional `ssot_search`/`ssot_get`; stop here if the answer remains conceptual and states coverage limits. |
+| Product flow, capability, journey, admin workflow, or user action | Project/epic map -> DESIGN business document map as near-mandatory -> BR/DD/UCL as needed -> exact document/item reads -> source-near specs. |
+| Business policy, eligibility, status transition, or rule enforcement | BR and relevant DESIGN/DD/UCL exact items -> connected specs -> source read when claiming enforcement. |
+| Data shape, table, field, state distribution, funnel, conversion, or operational bottleneck | DD and relevant DESIGN/BR exact items -> connected specs when behavior matters. If a data MCP is exposed, read its guide and use read-only queries for observed metrics. If no operational data source is exposed, stop at measurable funnel steps, instrumentation points, and SSOT-based bottleneck hypotheses; do not claim actual conversion causes. |
+| API, screen, event, schedule, job, integration, permission, response shape, DB write, emit, external call, or implementation behavior | Selected `api_spec`/`screen_spec`/`event_spec`/`schedule_spec` -> `spec_resolve` -> `code_search` -> bounded `readonly_workspace_shell` when exact source confirmation is required or the spec is thin/ambiguous. |
+
+`readonly_workspace_shell` means the MCP-provided read-only source tool. It is
+allowed when exposed and required by the evidence gate. Treat it as the
+source-reading half of the `code_search` path: `code_search` locates candidate
+files/symbols, then `readonly_workspace_shell` reads the bounded source region.
+Do not stop at `code_search` when the claim requires source inspection. Do not
+replace a missing MCP source tool with local filesystem or local shell reads.
+
+If a conceptual answer would include concrete behavior such as "this API writes
+X", "this screen calls Y", "this status changes when Z", or "users drop here",
+the route is no longer a pure overview. Escalate to the deeper branch before
+making that claim.
+
+## Canonical Ladder
+
+BR, DD, DESIGN, and UCL are semantic document families. For `document_list`
+tool arguments, use MCP filter values (`br`, `data_dictionary`, `design`,
+`ucl`) unless the live MCP schema advertises a different value set. DD maps to
+`data_dictionary`, not `dd`.
+
 ```text
 project_list/project_get/context_status
--> project_overview_get; read project_overview_get.overview.memories when present
--> glossary_translate when raw terms, Korean/English bridges, aliases, or ambiguity matter; record matched terms and alias candidates
+-> project_overview_get; read project_overview_get.overview.memories when present and use memory_get for exact bodies when needed
+-> glossary_list for broad inventory, comparison, ambiguity, all-alias requests, or blank/conflicting translation; traverse every page when completeness is required
+-> glossary_translate for the raw phrase and Korean/English candidates; record matched terms and alias candidates
 -> epic_list
 -> epic_get for each plausible candidate epic before discarding it; read epic_get.memories for selected candidate epics
 -> document_list for the selected branch:
-   BR for policy/rule/eligibility
-   DD for entity, table, field, or data-shape questions
-   [MUST] DESIGN for system design, integration, data flow, or architecture questions
-   UCL for capability, journey, screen, or user action questions
--> document_get/document_item_list to map candidate items; read document_get.memories for selected documents
+   documentType=br for policy/rule/eligibility
+   documentType=data_dictionary for entity, table, field, or data-shape questions
+   [MUST] documentType=design for product flow, capability, journey, admin workflow,
+   system design, integration, data flow, architecture, or implementation-facing
+   questions
+   documentType=ucl for capability, journey, screen, or user action questions
+-> document_get/document_item_list to map candidate items; read document_get.memories for selected documents and use memory_get for exact bodies when needed
 -> document_item_get for exact BR/DD/DESIGN/UCL evidence
--> document_resolve to find connected API, screen, event, data, service, or spec anchors and collect linked api_spec/screen_spec spec ids when returned
--> rank linked api_spec and screen_spec candidates and keep the selected spec ids visible; use spec_list/spec_search only when the linked set is incomplete or the exact spec id is unknown
+-> document_resolve(itemId) after exact item reads; use document_resolve(documentId)
+   only for document-wide inventory. Follow explicit links to connected API,
+   screen, event, schedule, data, service, or spec anchors and collect linked
+   api_spec/screen_spec/event_spec/schedule_spec spec ids when returned
+-> rank linked api_spec, screen_spec, event_spec, and schedule_spec candidates
+   and keep the selected spec ids visible; use spec_list/spec_search only after
+   document_resolve when the explicit linked set is absent, incomplete, stale,
+   too broad, or the exact spec id is unknown
 -> when spec_search is used, select candidate specs before making claims
 -> spec_get for exact source-near behavior
 -> spec_resolve to expand selected specs to related documents, items, graph seeds, and code seeds
--> code_search only when source-level confirmation is required and configured
--> code_snippet before claiming exact code behavior, implementation absence, writes, emits, permissions, or response shape
+-> code_search only when source address is incomplete and configured
+-> readonly_workspace_shell to read the bounded candidate source before claiming
+   exact code behavior, implementation absence, writes, emits, permissions, or response shape
 ```
 
 If a map/list surface required by the ladder is missing, report an MCP
 capability gap instead of replacing the rung with search.
 
+## Runtime Evidence Checklist
+
+Before answering, keep this checklist in runtime context and complete the rungs
+required by the selected question branch. Do not print a long checklist in the
+final answer unless the user asks for the route audit.
+
+```text
+[ ] Select project with project_list or project_get.
+[ ] Check context_status and project_overview_get.
+[ ] Identify relevant EPICs with epic_list and epic_get.
+[ ] Normalize ambiguous Korean/domain terms with glossary_translate or
+    glossary_list when needed.
+[ ] If this is a pure service overview/user-type explanation with no concrete
+    implementation, API, screen, event, schedule, state, or operational-data
+    claim, stop at overview/epic/SSOT depth and state the boundary.
+[ ] For product/business flow: use ssot_search -> ssot_get when SSOT evidence is
+    the selected surface.
+[ ] For authored docs or business rules: use document_list/search/get and exact
+    document_item_get when item evidence is needed.
+[ ] If any exact BR/DD/DESIGN/UCL item was used, run document_resolve(itemId)
+    before source-near search, or state why the answer remains purely
+    conceptual.
+[ ] For product flow, capability, journey, admin workflow, data flow,
+    integration, architecture, or implementation-facing questions, include
+    DESIGN as a near-mandatory business map before descending to specs.
+[ ] For API/screen/event/schedule/source-near behavior: use
+    document_resolve(itemId) first after exact item reads, and prefer explicitly
+    linked api_spec/screen_spec/event_spec/schedule_spec ids when available.
+    Use spec_search only as fallback when explicit links are absent, incomplete,
+    stale, too broad, or unresolved.
+[ ] Run spec_resolve after selected spec reads when connected docs/items, graph
+    seeds, or code seeds matter.
+[ ] If implementation behavior is important or still ambiguous:
+    [ ] use code_search to find filePath/functionName candidates when the source
+        address is incomplete.
+    [ ] use workspace_repo_list if repoId is unknown.
+    [ ] actively use bounded readonly_workspace_shell to read only the relevant
+        file/function range before making code behavior claims. There is no
+        code_snippet tool; do not ask for or claim one.
+[ ] If operational data is claimed:
+    [ ] only do this when a data MCP is exposed for the environment.
+    [ ] read data_analysis_guide/domain_guide when exposed by that data MCP.
+    [ ] use read-only RDS/Athena SELECT and state sample/cohort limits.
+[ ] If no operational data MCP is exposed for a funnel/conversion/bottleneck
+    question, limit the answer to SSOT-derived funnel steps, instrumentation
+    points, and hypotheses. Do not claim observed conversion drops or causes.
+[ ] Do not treat search snippets, scores, overview text, or glossary output as
+    proof.
+[ ] State freshness, coverage, missing MCP surfaces, and any unresolved
+    ambiguity.
+```
+
 When `spec_search` is used, every selected spec candidate must be followed by `spec_get` and `spec_resolve` in the same route. Do not treat a spec search hit as complete evidence or defer resolve to a later optional step.
 
-## Business Document To API/Screen Spec Descent
+## Business Document To Source-Near Spec Descent
 
 When the question starts from SOT business context, treat BR/DD/DESIGN/UCL
 documents and items as the map, not as source-near proof:
@@ -39,34 +163,49 @@ documents and items as the map, not as source-near proof:
 ```text
 business question
 -> document_list/document_get/document_item_list
+   [MUST] include DESIGN for product flow, capability, journey, admin workflow,
+   data flow, integration, architecture, or implementation-facing questions
 -> document_item_get for exact business item
--> document_resolve to expose linked specs and collect linked api_spec/screen_spec spec ids when returned
--> rank linked api_spec and screen_spec candidates and keep selected spec ids visible
--> spec_list/spec_search only if linked specs are incomplete or the exact spec id is unknown
+-> document_resolve(itemId) to follow explicit item links and collect linked
+   api_spec, screen_spec, event_spec, and schedule_spec ids when returned
+-> rank linked source-near spec candidates and keep selected spec ids visible
+-> spec_list/spec_search only if document_resolve returns no usable link, an
+   incomplete/stale/too-broad linked set, or the exact spec id is unknown
 -> when spec_search is used, select candidate specs before making claims
--> spec_get for selected api_spec/screen_spec details
+-> spec_get for selected api_spec/screen_spec/event_spec/schedule_spec details
 -> spec_resolve to expand selected specs to related docs/items, graph seeds, and code seeds
 ```
 
-`document_resolve` is the first bridge from a business document or item to
-linked source-near specs. `spec_resolve` is not the first bridge from business
-docs to specs; use it after selecting a spec to collect reverse anchors,
-related items/documents, and source seed expansion.
+`document_resolve(itemId)` is the first bridge from an exact business item to
+linked source-near specs. Use `document_resolve(documentId)` only when doing
+document-wide inventory before an exact item is selected. `spec_resolve` is not
+the first bridge from business docs to specs; use it after selecting a spec to
+collect reverse anchors, related items/documents, and source seed expansion.
 
-Business document items are routing evidence. For exact API or screen behavior,
-rank connected `api_spec` and `screen_spec` candidates before opening details.
-Direct document/spec links, same epic, same entity/field, same route/screen/API
-target, and same branch intent rank first. Do not open every connected spec up front;
-read `spec_get` and then `spec_resolve` for the selected specs before
-source-near claims.
+Business document items are routing evidence. For exact API, screen, event, or
+schedule behavior, rank connected `api_spec` and `screen_spec` candidates before opening details,
+along with `event_spec` and `schedule_spec` when relevant. Direct document/spec
+links, same epic, same entity/field, same route/screen/API/event/schedule
+target, and same branch intent rank first.
+
+Always use explicit links first. `document_resolve(itemId)` is the MCP
+equivalent of following traced business-doc item context into linked specs/items;
+it is the first bridge from exact business evidence to source-near evidence. If
+the selected DESIGN/BR/DD/UCL document or item does not return enough linked
+source-near specs, or returns stale/too-broad candidates, widen with
+`spec_search` using the business terms, route/screen names, table/model names,
+status names, and API/action names discovered from the document. Then read
+`spec_get` and `spec_resolve` for the selected specs before source-near claims.
+Do not open every connected spec up front; rank first, then read the strongest
+candidates.
 
 Memory overlays are correction/constraint/why/context notes attached to the
-overview, epics, documents, items, or specs. Read attached memories at each
-selected surface: `project_overview_get.overview.memories`,
+overview, epics, documents, items, or specs. Inspect attached memory cards at
+each selected surface: `project_overview_get.overview.memories`,
 `epic_get.memories`, `document_get.memories`, item memories, and spec memories
-when those surfaces return them. If only `memoryCount` or `memoryId` is visible,
-use `memory_list` or `memory_get` when the overlay could change the answer
-boundary. Do not treat memory as generated SOT or source proof.
+when those surfaces return them. Broad document reads may return summaries; use
+`memory_get` when the overlay could change the answer boundary. Do not treat
+memory as generated SOT or source proof.
 
 ## Retrieval Order
 
@@ -76,12 +215,15 @@ project context
 -> capability check
 -> Search Clarification Gate when triggers fire
 -> project overview with attached overview memories when present
--> vocabulary normalization when raw terms, Korean/English bridges, aliases, or ambiguity matter; include alias candidates
+-> glossary_list for broad inventory, comparison, ambiguity, all-alias requests, or blank/conflicting translation; traverse every page when completeness is required
+-> glossary_translate for the raw phrase and Korean/English candidates; record matched terms and alias candidates
 -> candidate epic
 -> candidate BR/DD/DESIGN/UCL document map
 -> question branch
 -> relevant business document items or exact source-near anchor
--> connected api_spec/screen_spec evidence through document_resolve
+-> connected api_spec/screen_spec/event_spec/schedule_spec evidence through
+   document_resolve(itemId) after exact item reads, with spec_search fallback
+   only when explicit links are absent, incomplete, stale, too broad, or unresolved
 -> exact spec evidence
 -> spec_resolve for connected context and graph/code seeds
 -> source-level confirmation only when required
@@ -113,19 +255,25 @@ confident answer:
    empty, the answer reports an item-tier coverage gap or retries without
    narrowing filters instead of claiming exact BR/DD/DESIGN/UCL evidence from
    the document body.
-10. Connected context was resolved before following source-near specs.
-11. Linked `api_spec` and `screen_spec` candidates were ranked before exact
-    source-near spec reads when starting from business docs, and returned spec
-    ids were kept visible for the selected candidates.
-12. Exact specs were read before source-near behavior claims.
-13. `spec_resolve` was run after selected spec reads to expose related
+10. If any exact BR/DD/DESIGN/UCL item was read, `document_resolve(itemId)` was
+    run before source-near search, or the answer explicitly remains conceptual.
+11. Connected context was resolved before following source-near specs.
+12. Linked `api_spec`, `screen_spec`, `event_spec`, and `schedule_spec`
+    candidates were ranked before exact source-near spec reads when starting
+    from business docs, and returned spec ids were kept visible for the selected
+    candidates. `spec_search` fallback was used only after `document_resolve`
+    returned no usable links, incomplete/stale/too-broad links, or no exact spec
+    id.
+13. Exact specs were read before source-near behavior claims.
+14. `spec_resolve` was run after selected spec reads to expose related
     docs/items, graph seeds, code seeds, and reverse anchors.
-14. Code snippets, not only code search hits, were read before exact source
-    claims.
-15. Negative claims such as "not present", "not independent", "not used", or
+15. Bounded exact source regions were read with MCP `readonly_workspace_shell`
+    after any needed `code_search`; code search hits alone were not used for
+    exact source claims.
+16. Negative claims such as "not present", "not independent", "not used", or
     "no impact" have the evidence tier required by Evidence Gates.
-16. Unread but plausible surfaces are named as coverage limits or next MCP
+17. Unread but plausible surfaces are named as coverage limits or next MCP
     reads.
-17. The final answer separates direct evidence, inference, memory overlay,
+18. The final answer separates direct evidence, inference, memory overlay,
     freshness, and
     missing MCP surfaces.

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.ko.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.ko.md
@@ -1,20 +1,18 @@
 # MCP Retrieval Pressure Scenarios
 
-Validation-only reference. Read this file when changing or evaluating
-`platty-mcp-retrieval`; do not load it for ordinary retrieval answers.
+Validation-only reference다. `platty-mcp-retrieval`을 변경하거나 평가할 때 읽고,
+일반 retrieval answer에는 load하지 않는다.
 
-Use these scenarios to test `platty-mcp-retrieval` as process documentation.
-Run a baseline before changing the skill when feasible, then run the same
-scenario with the renewed skill loaded. Record whether the agent followed the
-expected route.
+이 scenario들은 `platty-mcp-retrieval`을 process documentation으로 테스트하기 위한
+압력 케이스다. 가능하면 skill을 바꾸기 전에 baseline을 실행하고, renewed skill을 load한 뒤
+같은 scenario를 다시 실행한다. agent가 expected route를 따랐는지 기록한다.
 
 ## Contents
 
-- Scenarios 1-8: retrieval routing, ambiguity, source boundaries, impact seeds
-- Executable Call-Trace Pressures: impact/SDD transition traces
-- Scenarios 9-12A: answer shape, full-cycle ladder, item-level resolve
-- Scenarios 13-15: coupon ambiguity, complete glossary inventory, older server
-  exact-spec route
+- Scenario 1-8: retrieval routing, ambiguity, source boundary, impact seed
+- Executable Call-Trace Pressures: impact/SDD transition trace
+- Scenario 9-12A: answer shape, full-cycle ladder, item-level resolve
+- Scenario 13-15: coupon ambiguity, complete glossary inventory, older server exact-spec route
 
 ## Scenario 1: Korean Domain Term
 
@@ -24,11 +22,11 @@ User asks:
 응원친구가 뭐야? 관련 기능이 어디에 있어?
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- guessing an English term before vocabulary normalization;
-- treating glossary output as proof;
-- answering from one search hit.
+- vocabulary normalization 전에 English term을 추측함
+- glossary output을 proof로 취급함
+- search hit 하나로 답함
 
 Expected route:
 
@@ -49,11 +47,11 @@ User asks:
 purchaseCampaignSubmission.status 필드 의미랑 어디서 쓰이는지 알려줘.
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- reading a whole document or search result and stopping;
-- skipping item-level DD evidence;
-- claiming usage without source-near or source evidence.
+- whole document 또는 search result만 읽고 멈춤
+- item-level DD evidence를 건너뜀
+- source-near 또는 source evidence 없이 usage를 주장함
 
 Expected route:
 
@@ -72,11 +70,11 @@ User asks:
 결제에서 쿠폰기능을 도입하려고해. 결제 쿠폰 할인 쿠폰 코드 프로모션 주문 결제 금액 적용 환불
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- stopping after `glossary_translate(raw Korean phrase)` returns no terms;
-- hiding the Korean candidate terms or English candidate terms;
-- searching only Korean text when the generated SOT vocabulary is English-heavy.
+- `glossary_translate(raw Korean phrase)`가 빈 결과를 반환했을 때 멈춤
+- Korean candidate term 또는 English candidate term을 숨김
+- generated SOT vocabulary가 English-heavy인데 Korean text만 search함
 
 Expected route:
 
@@ -100,11 +98,11 @@ User asks:
 체험단 참여 정책을 바꾸면 영향이 뭐야?
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- answering from one `ssot_search`, `document_search`, or `spec_search` hit;
-- treating one spec as the full impact map;
-- converting empty graph evidence into "no impact".
+- `ssot_search`, `document_search`, `spec_search` hit 하나로 답함
+- spec 하나를 full impact map으로 취급함
+- empty graph evidence를 "no impact"로 변환함
 
 Expected route:
 
@@ -127,10 +125,10 @@ User asks:
 GET /api/campaigns/:id 응답 shape이 뭐야?
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- answering from API title, business prose, or search snippet;
-- omitting source confirmation when spec evidence is thin.
+- API title, business prose, search snippet으로 답함
+- spec evidence가 thin한데 source confirmation을 생략함
 
 Expected route:
 
@@ -150,10 +148,10 @@ User asks:
 이 API 실제 구현 코드 위치랑 호출하는 화면까지 확인해줘.
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- falling back to local SOT files or surfaces outside configured MCP tools;
-- pretending source confirmation is possible without configured tools.
+- local SOT file 또는 configured MCP 밖 surface로 fallback함
+- configured tool 없이 source confirmation이 가능하다고 가장함
 
 Expected route:
 
@@ -172,11 +170,11 @@ User asks:
 이 BR 원문 파일 그대로 받아볼 수 있어?
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- reading local `~/.platty` files directly from the client;
-- running SOT export, sync, or generation from MCP;
-- treating stored artifact content as policy proof.
+- client에서 local `~/.platty` file을 직접 읽음
+- MCP에서 SOT export, sync, generation을 실행함
+- stored artifact content를 policy proof로 취급함
 
 Expected route:
 
@@ -195,13 +193,12 @@ User asks:
 응원친구가 뭐야? 관련 기능이 어디에 있어?
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- treating the first vocabulary or search hit as the selected concept;
-- hiding that the term could be a user-facing label, business concept, enum/model
-  value, or implementation branch;
-- asking the user before configured MCP tools have been used to reduce the
-  ambiguity.
+- 첫 vocabulary 또는 search hit를 selected concept으로 취급함
+- term이 user-facing label, business concept, enum/model value, implementation branch일 수
+  있음을 숨김
+- ambiguity를 줄이기 위해 configured MCP tool을 쓰기 전에 사용자에게 물음
 
 Expected route:
 
@@ -224,12 +221,11 @@ User asks:
 체험단 참여 정책을 바꾸면 영향이 뭐야?
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- answering from one `spec_search`, `document_search`, `graph_trace`, or
-  `code_search` hit;
-- treating one connected spec as the complete impact map;
-- losing the selected policy-impact interpretation during a long investigation.
+- `spec_search`, `document_search`, `graph_trace`, `code_search` hit 하나로 답함
+- connected spec 하나를 complete impact map으로 취급함
+- 긴 조사 중 selected policy-impact interpretation을 잃음
 
 Expected route:
 
@@ -254,13 +250,12 @@ User asks:
 앞에서 만든 영향도 seed packet으로 쿠폰 정책 변경의 API, 화면, cross-EPIC 영향을 계속 조사해줘.
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- rerunning glossary, EPIC, business-document, or exact-spec discovery after a
-  matching Impact Seed Packet already exists;
-- returning from impact to retrieval when the packet identifies its semantic
-  scope and selected specs;
-- treating a packet as a final impact answer before graph/source convergence.
+- matching Impact Seed Packet이 이미 있는데 glossary, EPIC, business-document, exact-spec
+  discovery를 다시 실행함
+- packet이 semantic scope와 selected specs를 식별하는데 impact에서 retrieval로 되돌아감
+- graph/source convergence 전에 packet을 final impact answer로 취급함
 
 Expected route:
 
@@ -273,10 +268,9 @@ existing Impact Seed Packet
 
 ## Executable Call-Trace Pressures
 
-Each pressure records the runtime-only `routeMode`, `routeOrigin`, skill
-transitions, packet identity, and local write attempts. Execute the sequence as
-written and compare its observable transitions; prose without the trace does
-not pass.
+각 pressure는 runtime-only `routeMode`, `routeOrigin`, skill transition, packet identity,
+local write attempt를 기록한다. sequence를 그대로 실행하고 observable transition을
+비교한다. trace 없는 prose는 pass가 아니다.
 
 ### Trace 1: Direct Impact Creates One Seed Packet
 
@@ -316,13 +310,12 @@ User asks:
 후기 작성 가능 시점 차이는 어떻게 봐야 해?
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- starting with a long evidence dump before the answer;
-- listing internal symbols before explaining what they mean;
-- saying "확인됨" for search candidates or partial specs;
-- splitting into planning/engineering sections when the user did not ask for
-  that split.
+- answer 전에 긴 evidence dump로 시작함
+- 의미를 설명하기 전에 internal symbol을 나열함
+- search candidate 또는 partial spec에 "확인됨"을 사용함
+- 사용자가 요청하지 않았는데 planning/engineering section으로 나눔
 
 Expected route:
 
@@ -341,11 +334,11 @@ User asks:
 catalog/epics.md 원문을 읽어서 캠페인 제외 그룹 정책이 확정인지 말해줘
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- reading the file with `sot_file_get` and treating catalog text as proof;
-- skipping `document_item_get`, `spec_get`, or `readonly_workspace_shell`;
-- using local filesystem fallback when the artifact path is rejected.
+- `sot_file_get`으로 file을 읽고 catalog text를 proof로 취급함
+- `document_item_get`, `spec_get`, `readonly_workspace_shell`을 건너뜀
+- artifact path가 reject될 때 local filesystem fallback을 사용함
 
 Expected route:
 
@@ -364,16 +357,14 @@ User asks:
 체험단이 일반 체험단, 팀 체험단, 검증단처럼 나뉘는 것 같은데 각각 뭐가 다른 거야?
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- skipping the Search Brief because several search tools are available;
-- treating `검증단` exact-term misses as proof that verification campaigns are not
-  independent;
-- reading one team-campaign item and concluding that verification is only a
-  mission status;
-- answering before candidate EPICs and BR/UCL/DESIGN/DD items are mapped;
-- using `document_search`, `spec_search`, or `code_search` as a substitute for
-  the full-cycle map/list/detail ladder.
+- search tool이 있어서 Search Brief를 생략함
+- `검증단` exact-term miss를 verification campaign이 independent하지 않다는 proof로 취급함
+- team-campaign item 하나를 읽고 verification은 mission status일 뿐이라고 결론냄
+- candidate EPIC과 BR/UCL/DESIGN/DD item map 전에 답함
+- `document_search`, `spec_search`, `code_search`를 full-cycle map/list/detail ladder의
+  substitute로 사용함
 
 Expected route:
 
@@ -409,14 +400,12 @@ User asks:
 후기 작성 가능 시점 차이는 어떻게 봐야 해? 일반 체험단/검증단/팀 체험단별로 알려줘.
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- starting with `document_search` or `code_search` because `reviewUnlockDays`
-  seems like an obvious code term;
-- reading a code hit and skipping BR/DD/UCL evidence for what the labels mean;
-- claiming the type split is complete without an EPIC and document-type map;
-- claiming exact calculation or response shape without `spec_get` or
-  `readonly_workspace_shell`.
+- `reviewUnlockDays`가 obvious code term처럼 보여 `document_search` 또는 `code_search`로 시작함
+- code hit를 읽고 label 의미에 대한 BR/DD/UCL evidence를 건너뜀
+- EPIC/document-type map 없이 type split이 complete하다고 주장함
+- `spec_get` 또는 `readonly_workspace_shell` 없이 exact calculation 또는 response shape를 주장함
 
 Expected route:
 
@@ -449,16 +438,15 @@ User asks:
 그거 어떤 조건에 시작되고 받는 조건이 뭔지, 다른 페이지 이동해도 되는지 조사해줘봐.
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- reading a DESIGN or UCL item about the time-deal/store-explore flow and then
-  jumping to `document_search`, `spec_search`, or `code_search`;
-- treating broad `document_resolve(documentId)` candidates as enough after an
-  exact item is known;
-- making screen/API behavior claims from BR/DESIGN prose without ranking linked
-  `screen_spec` and `api_spec` candidates;
-- hiding that exact scroll thresholds remain unconfirmed when no linked screen
-  spec or source read proves them.
+- time-deal/store-explore flow에 대한 DESIGN 또는 UCL item을 읽고 `document_search`,
+  `spec_search`, `code_search`로 점프함
+- exact item을 알고도 broad `document_resolve(documentId)` candidate면 충분하다고 취급함
+- linked `screen_spec`과 `api_spec` candidate를 rank하지 않고 BR/DESIGN prose로
+  screen/API behavior를 주장함
+- linked screen spec 또는 source read가 exact scroll threshold를 증명하지 않는데 그 미확정
+  상태를 숨김
 
 Expected route:
 
@@ -486,16 +474,16 @@ User asks:
 쿠폰 결제를 붙이려는데 기존 쿠폰/결제/할인 흐름 영향부터 찾아줘.
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- using `glossary_translate` alone for a term that spans coupon issuance, point
-  spending, checkout payment, and discount accounting candidates;
-- choosing only the checkout/payment epic because discount/order evidence is easy to find;
-- saying coupon is a new feature before checking point/coupon issuance candidates;
-- treating `ShoppingOrderDiscountLine` as proof that coupon purchase behavior is absent;
-- treating empty `document_item_list` results from narrow `itemType`
-  filters as proof that the document has no matching item;
-- continuing confidently after `document_item_list` reports an item-tier gap.
+- coupon issuance, point spending, checkout payment, discount accounting 후보를 모두 거치는
+  term에 `glossary_translate`만 사용함
+- discount/order evidence가 찾기 쉽다는 이유로 checkout/payment epic만 선택함
+- point/coupon issuance 후보를 확인하기 전에 coupon이 new feature라고 말함
+- `ShoppingOrderDiscountLine`을 coupon purchase behavior absence의 proof로 취급함
+- narrow `itemType` filter의 empty `document_item_list` 결과를 document에 matching item이
+  없다는 proof로 취급함
+- `document_item_list`가 item-tier gap을 보고했는데 confident하게 계속함
 
 Expected route:
 
@@ -526,13 +514,13 @@ User asks:
 생성 alias와 사람이 추가한 memory alias도 구분해줘.
 ```
 
-Failure to prevent:
+막아야 할 실패:
 
-- calling `glossary_translate` once and treating it as a complete inventory;
-- reading only the first `glossary_list` page;
-- dropping memory-only canonical terms;
-- merging memory aliases into generated aliases without provenance;
-- treating glossary or memory alias output as behavior or source proof.
+- `glossary_translate` 한 번을 complete inventory로 취급함
+- 첫 `glossary_list` page만 읽음
+- memory-only canonical term을 누락함
+- memory alias를 generated alias와 provenance 없이 합침
+- glossary 또는 memory alias output을 behavior/source proof로 취급함
 
 Expected route:
 
@@ -554,25 +542,21 @@ User asks:
 이미 알고 있는 API spec id `spec:checkout:get`의 응답을 확인해줘.
 ```
 
-Runtime tool listing contains the minimum retrieval tools and the exact-spec
-route tools, but the older server does not expose `glossary_list`.
+runtime tool listing에는 minimum retrieval tool과 exact-spec route tool이 있지만 older
+server가 `glossary_list`를 노출하지 않는다.
 
-Failure to prevent:
+막아야 할 실패:
 
-- failing the unconditional capability gate only because `glossary_list` is
-  absent;
-- inventing a glossary inventory call for an unrelated exact spec id;
-- weakening the stop condition if the user later asks for a complete vocabulary
-  inventory, comparison, ambiguity resolution, every alias, or blank/conflict
-  candidate discovery.
+- exact spec id가 있는데 missing `glossary_list` 때문에 멈춤
+- broad semantic route가 아닌데 vocabulary inventory를 요구함
+- exact `spec_get`/`spec_resolve` route를 capability gap으로 오판함
 
 Expected route:
 
 ```text
-capability gate classifies glossary_list as conditional and confirms the exact-spec route tools are present
--> project context/context_status
--> spec_get(projectId, id=spec:checkout:get)
--> spec_resolve(projectId, id=spec:checkout:get) when exposed by the listed exact-spec route tools
--> answer from exact spec evidence with the normal evidence boundary
--> if the request changes to a route that requires glossary_list, stop and report that conditional capability gap
+recognize exact API spec id
+-> bypass vocabulary inventory because route does not require ambiguity/comparison/every-alias discovery
+-> spec_get
+-> spec_resolve
+-> answer with missing glossary_list noted only if relevant to broader discovery
 ```

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.ko.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.ko.md
@@ -1,0 +1,207 @@
+# MCP Question Routes
+
+`platty-mcp-retrieval`이 branch를 선택한 뒤 이 reference를 사용한다. 이 문서는
+`full-cycle-retrieval.md`의 canonical ladder에 branch-specific document family,
+requirement, completion check를 더한다. ladder를 복제하거나 대체하지 않는다.
+
+Tool name은 `../../using-platty-mcp/references/tool-mapping.md`의 intent를 가리킨다.
+
+## Contents
+
+- Routing Precedence
+- Concept Or Domain Term
+- Policy, Rule, Permission, Eligibility
+- Data Entity Or Field
+- System Design Or Integration
+- Capability, Journey, User Action
+- Exact API, Screen, Event, Schedule
+- Impact Or Blast Radius
+- Code Location Or Source Absence
+- Mixed Questions
+
+Search Clarification Gate가 발동하면 Search Brief를 선택한 branch로 가져간다. branch
+route는 `Question branch`, `Candidate MCP route`, `User decision needed`를 다듬을 수
+있지만, raw question과 gate를 발동시킨 ambiguity trigger는 보존해야 한다.
+
+semantic answer를 확정하기 전에 선택한 `project_overview_get.overview.memories`,
+`epic_get.memories`, `document_get.memories` result에 attached memory를 읽는다. broad
+document read는 full body 대신 summary card를 노출할 수 있다. memory overlay가 answer
+boundary에 영향을 줄 수 있으면 `memory_get`을 사용한다. memory는 SOT/spec/source proof와
+분리한다.
+
+BR, DD, DESIGN, UCL 같은 document family name은 이 guide의 semantic label이다.
+`document_list.documentType`에 전달할 때는 live tool schema가 다르게 말하지 않는 한
+MCP filter value(`br`, `data_dictionary`, `design`, `ucl`)를 사용한다. DD는 `dd`가
+아니라 `data_dictionary`다.
+
+## Routing Precedence
+
+SDD file authoring intent는 request/story creation을 `platty-mcp-sdd-spec`으로,
+design/task creation을 `platty-mcp-sdd-design`으로 route한다. 이 intent는 generic impact
+또는 design-change wording보다 우선한다. owning SDD skill은 impact를 sub-route로 호출할
+수 있지만, retrieval은 file-authoring owner를 우회하면 안 된다.
+
+일반 exact API, screen, event, schedule, source-near question은 retrieval-only에 남긴다.
+질문이 what changes, what breaks, affected surface, blast radius, cross-EPIC effect,
+design-change impact를 묻지 않는 한 impact analysis를 호출하지 않는다.
+
+## Concept Or Domain Term
+
+Full-Cycle Retrieval Ladder를 사용한다. concept이 요구하는 경우에만 BR/DD/DESIGN/UCL을
+포함하고, source-near behavior를 주장할 때만 connected specs로 내려간다.
+
+Completion:
+
+- raw user phrase를 보존한다.
+- normalized term을 사용했다면 밝힌다.
+- normalized candidate가 다른 concept을 가리키면 ambiguity를 드러낸다.
+- term이 user-facing label, business concept, enum/model value, implementation branch일 수
+  있으면 답하기 전에 split을 이름 붙이고 selected interpretation을 Search Brief에
+  유지한다.
+- normalized concept이 absent 또는 not independent라고 말하기 전에 Final Route Audit를
+  실행한다.
+- raw term이 Korean이고 likely system term이 English라면 answer boundary에 두 term을 모두
+  유지한다.
+
+## Policy, Rule, Permission, Eligibility
+
+Full-Cycle Retrieval Ladder를 사용한다. Required document family: policy/rule/eligibility
+map에는 BR. rule이 system flow, data shape, user journey에 의존하면 DESIGN/DD/UCL을
+포함한다. Enforcement claim에는 connected spec evidence가 필요하고, exact permission,
+validation, write, emit, absence claim에는 노출된 경우 source-level confirmation이
+필요하다.
+
+Completion:
+
+- rule item을 식별한다.
+- documented intent와 confirmed enforcement를 구분한다.
+- permission, validation, response shape, DB write, event emit behavior를 주장하기 전에
+  connected spec 또는 source-level evidence를 읽는다.
+- enforcement, permission, eligibility, negative claim 전에는 Final Route Audit를 실행한다.
+- vocabulary routing이 branch를 바꿨다면 raw term, normalized term, selected
+  interpretation을 보존한다.
+- 버린 interpretation이 answer boundary를 바꾼다면 discarded interpretation을 보존한다.
+- 읽지 않았지만 relevant한 policy, rule, spec, source surface를 coverage limit 또는 next
+  MCP read로 보존한다.
+- "not allowed", "not eligible", "not enforced" 같은 claim은 search miss가 아니라 exact
+  item/spec/source evidence에서 negative boundary를 확인한다.
+
+## Data Entity Or Field
+
+Full-Cycle Retrieval Ladder를 사용한다. Required document family:
+entity/table/field meaning에는 `data_dictionary`. API/screen/source-near usage를 주장할
+때만 connected spec을 포함한다.
+
+Completion:
+
+- 읽은 entity 또는 field item을 이름 붙인다.
+- usage가 documented, source-near, source-confirmed 중 무엇인지 밝힌다.
+- whole-document search hit를 field-level proof로 취급하지 않는다.
+- exact API 또는 screen usage에는 detail을 열기 전에 connected `api_spec`과
+  `screen_spec` candidate를 rank한다. direct document/spec link, same entity, same field,
+  same route/screen/API target, same branch intent가 우선순위가 높다.
+
+## System Design Or Integration
+
+Full-Cycle Retrieval Ladder를 사용한다. Required document family: DESIGN. selected design
+item에는 search 전에 `document_resolve(itemId)`를 사용하고, exact spec read 전에 linked
+API/screen/event/schedule candidate를 rank한다.
+
+Completion:
+
+- design item 또는 connection read를 밝힌다.
+- design item이 선택되었다면 `document_resolve(documentId)` 또는 search보다 item-level
+  `document_resolve`를 선호한다.
+- exact implementation을 주장하기 전에 connected source-near evidence를 resolve한다.
+
+## Capability, Journey, User Action
+
+Full-Cycle Retrieval Ladder를 사용한다. Required document families: user action/journey에는
+UCL. 질문이 product flow, screen behavior, admin workflow, data flow, integration,
+architecture, implementation-facing behavior를 묻는다면 DESIGN이 필수다. selected
+DESIGN/UCL item에는 source-near search 전에 `document_resolve(itemId)`를 사용한다.
+
+Completion:
+
+- 질문이 product flow, capability, journey, screen, admin workflow,
+  implementation-facing behavior를 묻는다면 UCL 전에 DESIGN을 product/system map으로
+  포함한다.
+- selected design/UCL item에서 screen/API spec으로 가는 첫 bridge로
+  `document_resolve(itemId)`를 사용한다. linked context가 absent, incomplete, stale,
+  too broad이거나 exact spec id를 알 수 없을 때만 `spec_search`를 사용한다.
+- user action 또는 capability item을 식별한다.
+- journey evidence와 implementation evidence를 분리한다.
+- exact API 또는 screen behavior에는 detail을 열기 전에 connected `api_spec`과
+  `screen_spec` candidate를 rank하고, source-near claim 전에 exact spec을 읽는다.
+- "difference between A/B/C" 질문은 relevant EPIC/document map이 세워질 때까지 inventory로
+  취급한다.
+- adjacent candidate EPIC이 unresolved인 상태에서 첫 matching UCL item만으로 답하지 않는다.
+
+## Exact API, Screen, Event, Schedule
+
+Full-Cycle Retrieval Ladder의 exact source-near branch를 사용한다. exact spec id를 알고
+있으면 `spec_get`에서 시작한다. exact spec id를 모를 때만 `spec_list/spec_search`를
+사용한다. 선택한 spec 뒤에는 `spec_resolve`를 실행한다.
+
+Completion:
+
+- exact spec을 읽는다.
+- unsupported field는 not confirmed로 표시한다.
+- spec이 thin하거나 contradicted면 source-level evidence를 사용한다.
+
+## Impact Or Blast Radius
+
+먼저 Full-Cycle Retrieval Ladder로 semantic target을 map한다. 그 뒤 connected spec을
+resolve하고 selected source-near spec을 읽고 `spec_resolve`를 실행한 다음,
+`platty-mcp-impact-analysis`용 Impact Seed Packet을 만든다.
+
+Completion:
+
+- broad inventory question에 답하기 전에 target map을 만든다.
+- broad impact에는 graph/source evidence를 읽기 전에 Search Brief에
+  `Question branch: impact/blast radius`와 expected map source를 기록한다.
+- packet은 `platty-mcp-impact-analysis`에 넘긴다. graph, cross-EPIC, repository, source
+  convergence는 그 skill이 소유한다.
+- 기존 packet이 있으면 semantic discovery로 돌아가지 말고 재사용한다.
+- empty graph evidence를 "no impact"로 바꾸지 않는다.
+
+## Code Location Or Source Absence
+
+Full-Cycle Retrieval Ladder의 source-near branch를 사용한다. known spec id가 있으면
+선호한다. 그렇지 않으면 semantic route가 target scope를 확정한 뒤에만 code search를
+사용한다.
+
+Completion:
+
+- repo, file, line scope를 밝힌다.
+- 검색한 exact term을 밝힌다.
+- source absence 또는 negative location claim 전에는 Final Route Audit를 실행한다.
+- searched scope 밖의 absence를 주장하지 않는다.
+- business term을 code term으로 번역했다면 searched scope, exact term, selected
+  interpretation, discarded interpretation을 보존한다.
+- search miss를 absence boundary로 바꾸기 전에 unread-but-relevant MCP surface와 missing MCP
+  surface를 보존한다.
+- exact code absence, lack of writes/emits/calls, permission/validation path not present를
+  주장할 때는 source-level confirmation을 요구한다.
+- 질문이 source-location request와 business term을 섞으면 Search Brief에 두 route를 모두
+  visible하게 유지한다: semantic route first, source-near confirmation second.
+
+## Mixed Questions
+
+필요하다면 Full-Cycle Retrieval Ladder를 두 번 사용한다. 먼저 semantic branch로
+vocabulary, EPIC, document scope를 잡고, 두 번째로 source-near branch에서 exact spec,
+graph, code, snippet confirmation을 한다.
+
+Completion:
+
+- 답하기 전에 business meaning과 implementation fact를 분리한다.
+- 사용자에게 묻기 전에 MCP evidence로 branch order를 선택한다.
+- MCP evidence가 tied interpretation을 남기고 하나를 선택하면 다른 해석이 숨겨질 때만
+  clarifying question 하나를 묻는다.
+- 두 branch 전체에서 raw term, normalized term, unread-but-relevant surface를 보존한다.
+- route를 바꾸는 경우 answer에 selected interpretation을 밝힌다.
+- discarded interpretation이 없으면 source 또는 semantic branch가 complete해 보일 때는
+  discarded interpretation을 밝힌다.
+- semantic branch 뒤, source-near claim 전에는 Final Route Audit를 실행한다.
+- audit에서 missing semantic candidate가 발견되면 더 많은 code/search hit를 읽기 전에 map으로
+  돌아간다.

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md
@@ -1,7 +1,24 @@
 # MCP Question Routes
 
-Use this reference after `platty-mcp-retrieval` chooses a branch. Tool names
-refer to intents in `../../using-platty-mcp/references/tool-mapping.md`.
+Use this reference after `platty-mcp-retrieval` chooses a branch. It adds
+branch-specific document families, requirements, and completion checks to the
+canonical ladder in `full-cycle-retrieval.md`. Do not duplicate or replace that
+ladder here.
+
+Tool names refer to intents in `../../using-platty-mcp/references/tool-mapping.md`.
+
+## Contents
+
+- Routing Precedence
+- Concept Or Domain Term
+- Policy, Rule, Permission, Eligibility
+- Data Entity Or Field
+- System Design Or Integration
+- Capability, Journey, User Action
+- Exact API, Screen, Event, Schedule
+- Impact Or Blast Radius
+- Code Location Or Source Absence
+- Mixed Questions
 
 When the Search Clarification Gate fires, carry the Search Brief into the
 chosen branch. The branch route may refine `Question branch`, `Candidate MCP
@@ -10,26 +27,33 @@ the ambiguity trigger that caused the gate to fire.
 
 Read attached memories on selected `project_overview_get.overview.memories`,
 `epic_get.memories`, and `document_get.memories` results before finalizing
-semantic answers. If only `memoryCount` or a `memoryId` is visible, use
-`memory_list` or `memory_get` when the memory overlay could affect the answer
+semantic answers. Broad document reads may expose summary cards instead of full
+bodies; use `memory_get` when the memory overlay could affect the answer
 boundary. Keep memory separate from SOT/spec/source proof.
+
+Document family names such as BR, DD, DESIGN, and UCL are semantic labels in
+this guide. When passing them to `document_list.documentType`, use the MCP
+filter values (`br`, `data_dictionary`, `design`, `ucl`) unless the live tool
+schema says otherwise. DD maps to `data_dictionary`, not `dd`.
+
+## Routing Precedence
+
+SDD file authoring intent routes request/story creation to
+`platty-mcp-sdd-spec` and design/task creation to `platty-mcp-sdd-design`; it
+takes precedence over generic impact or design-change wording. The owning SDD
+skill may invoke impact as a sub-route, but retrieval must not bypass the
+file-authoring owner.
+
+Ordinary exact API, screen, event, schedule, and source-near questions remain
+retrieval-only. Do not invoke impact analysis unless the question asks what
+changes, what breaks, an affected surface, blast radius, cross-EPIC effect, or
+design-change impact.
 
 ## Concept Or Domain Term
 
-Route:
-
-```text
-project context
--> project overview and attached overview memories when present
--> vocabulary normalization, including alias candidates
--> epic_list
--> epic_get for each plausible concept epic
--> document_list for BR/DD/DESIGN/UCL candidates as the concept requires
--> document_item_list
--> document_item_get for exact concept evidence
--> document_resolve; collect linked api_spec/screen_spec spec ids when returned
--> spec_get when asserting source-near behavior
-```
+Use the Full-Cycle Retrieval Ladder. Include BR/DD/DESIGN/UCL only as the
+concept requires, then descend to connected specs only when asserting
+source-near behavior.
 
 Completion:
 
@@ -46,23 +70,11 @@ Completion:
 
 ## Policy, Rule, Permission, Eligibility
 
-Route:
-
-```text
-project context
--> vocabulary normalization when needed
--> epic_list
--> epic_get for policy candidate epics
--> document_list(documentType=BR, epicId=<candidate>)
--> document_get/document_item_list for rule maps
--> document_item_get for exact business-rule items
--> document_resolve
--> rank linked api_spec and screen_spec candidates
--> spec_list/spec_search only if the linked set is incomplete or the exact spec id is unknown
--> spec_get before claiming enforcement
--> spec_resolve for related docs/items, graph seeds, and code seeds
--> code_search then code_snippet when claiming exact permission, validation, writes, emits, or absence
-```
+Use the Full-Cycle Retrieval Ladder. Required document families: BR for the
+policy/rule/eligibility map; include DESIGN/DD/UCL when the rule depends on
+system flow, data shape, or user journey. Enforcement claims require connected
+spec evidence, and exact permission, validation, writes, emits, or absence
+claims require source-level confirmation when exposed.
 
 Completion:
 
@@ -84,22 +96,9 @@ Completion:
 
 ## Data Entity Or Field
 
-Route:
-
-```text
-project context
--> vocabulary normalization when needed
--> epic_list
--> epic_get for data candidate epics
--> document_list(documentType=DD, epicId=<candidate>)
--> document_get/document_item_list for entity maps
--> document_item_get for exact entity or field evidence
--> document_resolve
--> rank linked api_spec and screen_spec candidates
--> spec_get for source-near usage
--> spec_resolve for related docs/items, graph seeds, and code seeds
--> code_search then code_snippet when claiming exact source usage
-```
+Use the Full-Cycle Retrieval Ladder. Required document family:
+`data_dictionary` for entity/table/field meaning. Include connected specs only
+when claiming API/screen/source-near usage.
 
 Completion:
 
@@ -112,49 +111,33 @@ Completion:
 
 ## System Design Or Integration
 
-Route:
-
-```text
-project context
--> epic_list
--> epic_get for design candidate epics
--> document_list(documentType=DESIGN, epicId=<candidate>) [MUST] for system design questions
--> document_get/document_item_list for design maps
--> document_item_get for exact design items
--> document_resolve; collect linked api_spec/screen_spec spec ids when returned
--> rank linked api_spec and screen_spec candidates for API/screen claims
--> spec_list/spec_search only if the linked set is incomplete or the exact spec id is unknown
--> spec_get
--> spec_resolve for related docs/items, graph seeds, and code seeds
--> code_search then code_snippet when asserting exact implementation behavior
-```
+Use the Full-Cycle Retrieval Ladder. Required document family: DESIGN. For
+selected design items, use `document_resolve(itemId)` before search and rank
+linked API/screen/event/schedule candidates before exact spec reads.
 
 Completion:
 
 - state the design item or connection read;
+- prefer item-level `document_resolve` before `document_resolve(documentId)` or
+  search when a design item has been selected;
 - resolve connected source-near evidence before asserting exact implementation.
 
 ## Capability, Journey, User Action
 
-Route:
-
-```text
-project context
--> vocabulary normalization when needed
--> epic_list
--> epic_get for capability candidate epics
--> document_list(documentType=UCL, epicId=<candidate>)
--> document_get/document_item_list for capability maps
--> document_item_get for exact UCL items
--> document_resolve
--> rank linked api_spec and screen_spec candidates
--> spec_get for source-near behavior claims
--> spec_resolve for related docs/items, graph seeds, and code seeds
--> code_search then code_snippet when source-level confirmation is required
-```
+Use the Full-Cycle Retrieval Ladder. Required document families: UCL for user
+action/journey; DESIGN is required when the question asks about product flow,
+screen behavior, admin workflow, data flow, integration, architecture, or
+implementation-facing behavior. For selected DESIGN/UCL items, use
+`document_resolve(itemId)` before source-near search.
 
 Completion:
 
+- include DESIGN as the product/system map before UCL when the question asks
+  about product flow, capability, journey, screen, admin workflow, or
+  implementation-facing behavior;
+- use `document_resolve(itemId)` as the first bridge from selected design/UCL
+  items to screen/API specs; use `spec_search` only when linked context is
+  absent, incomplete, stale, too broad, or leaves the exact spec id unknown;
 - identify the user action or capability item;
 - separate journey evidence from implementation evidence.
 - for exact API or screen behavior, rank connected `api_spec` and `screen_spec`
@@ -167,15 +150,9 @@ Completion:
 
 ## Exact API, Screen, Event, Schedule
 
-Route:
-
-```text
-exact anchor
--> spec_list/spec_search only if the exact spec id is unknown
--> spec_get for exact source-near spec
--> spec_resolve for related docs/items, graph seeds, and code seeds
--> code_search then code_snippet when response shape, permission, writes, emits, or absence matters
-```
+Use the exact source-near branch of the Full-Cycle Retrieval Ladder. Start from
+`spec_get` when the exact spec id is known; use `spec_list/spec_search` only
+when the exact spec id is unknown. Follow selected specs with `spec_resolve`.
 
 Completion:
 
@@ -185,38 +162,25 @@ Completion:
 
 ## Impact Or Blast Radius
 
-Route:
-
-```text
-Search Brief
--> semantic branch to map the policy/rule/data/design/capability target
--> document_resolve for connected specs
--> rank linked api_spec and screen_spec candidates for API/screen impact
--> spec_list/spec_search only if the linked set is incomplete or the exact spec id is unknown
--> spec_get for source-near target map
--> spec_resolve for graph/code seeds and reverse anchors
--> graph_trace/code_search only after the target map exists
--> code_snippet when source-level impact evidence is required
-```
+Use the Full-Cycle Retrieval Ladder to map the semantic target first. Then
+resolve connected specs, read selected source-near specs, run `spec_resolve`,
+and produce an Impact Seed Packet for `platty-mcp-impact-analysis`.
 
 Completion:
 
 - build the target map before answering broad inventory questions;
 - for broad impact, record `Question branch: impact/blast radius` and the
   expected map source in the Search Brief before reading graph/source evidence;
-- report graph/source omissions and missing capability tiers;
+- hand the packet to `platty-mcp-impact-analysis`, which owns graph, cross-EPIC,
+  repository, and source convergence;
+- reuse an existing packet rather than returning to semantic discovery;
 - never convert empty graph evidence into "no impact".
 
 ## Code Location Or Source Absence
 
-Route:
-
-```text
-source-near spec or code term
--> spec_get when a source-near spec is known
--> code_search
--> code_snippet when configured
-```
+Use the source-near branch of the Full-Cycle Retrieval Ladder. Prefer a known
+spec id when available; otherwise use code search only after the semantic route
+has fixed the target scope.
 
 Completion:
 
@@ -237,13 +201,9 @@ Completion:
 
 ## Mixed Questions
 
-Route:
-
-```text
-Search Brief
--> semantic branch for vocabulary, EPIC, and document scope
--> source-near branch for exact spec, graph, code, or snippet confirmation
-```
+Use the Full-Cycle Retrieval Ladder twice as needed: semantic branch first for
+vocabulary, EPIC, and document scope; source-near branch second for exact spec,
+graph, code, or snippet confirmation.
 
 Completion:
 

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/search-clarification.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/search-clarification.md
@@ -29,11 +29,18 @@ still applies.
   search both Korean candidate terms and English candidate terms, and record
   which glossary/search-assist queries were attempted. A blank Korean
   `glossary_translate` result is not a stop condition while plausible English
-  candidates remain.
+  candidates remain; call `glossary_list` for candidate discovery before
+  translating additional Korean/English candidates.
+- Use `glossary_list` before asking the user when the request is a vocabulary
+  inventory, needs every alias, remains ambiguous after translation, or a
+  plausible `glossary_translate` query is blank. Traverse all pages only when
+  completeness is required; otherwise stop after the candidate set is clear.
 - Use configured read-only MCP tools to reduce ambiguity before asking the
-  user. Start with `glossary_translate`, `project_overview_get`, `epic_list` /
-  `epic_get`, `document_list` / `document_item_list`, `spec_list`, or
-  `spec_get` as the branch requires.
+  user. For vocabulary, choose `glossary_list` for inventory, every-alias,
+  unresolved ambiguity, broad comparison, or blank/conflicting translation; use
+  `glossary_translate` for an exact raw phrase or candidate term. Then continue
+  with `project_overview_get`, `epic_list` / `epic_get`, `document_list` /
+  `document_item_list`, `spec_list`, or `spec_get` as the branch requires.
 - Ask exactly one clarifying question only when MCP evidence leaves two or
   more equally plausible interpretations, choosing one would hide a meaningful
   answer branch, and the choice is product/user intent rather than a fact

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platty-mcp-sdd-design
-description: Use when creating locally saved MCP-grounded SDD technical design and implementation-task drafts from existing request.md and stories.md.
+description: Use when creating locally saved MCP-grounded SDD technical design and implementation-task drafts from existing request.md, stories.md, and impact.md.
 ---
 
 # Platty MCP SDD Design
@@ -8,45 +8,110 @@ description: Use when creating locally saved MCP-grounded SDD technical design a
 **Prerequisite:** Read `using-platty-mcp` before acting unless it has already
 been read in this turn.
 
-Create MCP-grounded technical SDD drafts and persist them locally. This skill
-uses `using-platty-mcp` for capability checks, `platty-mcp-retrieval` for
-evidence, then writes `design.md` and, after the task gate, `tasks.md` under the
-same SDD directory as the product spec.
+Create an evidence-gated technical design from the approved product inputs and
+the persisted Impact Dossier. The design owns technical decisions and the
+canonical change map; impact analysis owns impact discovery and `impact.md`.
+Use `references/design-shape.md` for the design and
+`references/tasks-shape.md` for the approval-gated task plan.
 
 ## Required Sub-Skills
 
 1. Use `using-platty-mcp` for MCP capability and project context.
-2. Use `platty-mcp-retrieval` for SOT, spec, graph, and source evidence.
+2. Use `platty-mcp-impact-analysis` for impact, graph, cross-EPIC, repository,
+   and source convergence. It invokes `platty-mcp-retrieval` with `routeMode:
+   seed-only` when a packet is missing, then owns dossier-entry changes. In SDD
+   context it alone writes or refreshes only `impact.md`. Do not invoke retrieval
+   directly for that path.
 
 ## Inputs
 
 - Platty project context.
-- SDD directory id or spec slug containing `request.md` and `stories.md`.
+- SDD directory id or spec slug containing `request.md`, `stories.md`, and an
+  existing or refreshable `impact.md`.
 - Optional target repo, API, screen, table, event, or job areas.
 
 ## Operating Flow
 
 1. Confirm MCP tools, project context, and context freshness.
-2. Read the selected local `request.md` and `stories.md` from the SDD directory,
-   then re-ground their claims through MCP surfaces.
+2. Read the selected local `request.md`, `stories.md`, and `impact.md` when it
+   exists. Confirm all artifacts belong to the selected project and spec.
+   Build `productInputMetadata` from their persisted metadata: validate canonical
+   product metadata directly; adapt legacy product metadata only in this input
+   packet and retain its source form. Never rewrite `request.md` or `stories.md`
+   merely to migrate legacy metadata. The reader mapping is exact:
+   `spec-request -> sdd-request`, `spec-stories -> sdd-stories`, and
+   `derived_from -> derivedFrom`. Apply aliases only in `productInputMetadata`;
+   preserve both input files byte-for-byte and hash their original persisted
+   content. When both canonical and legacy keys exist, both must have the same normalized value;
+   then use the canonical key in `productInputMetadata`. A conflicting pair
+   is a `NEEDS_WORK` input conflict; stop without choosing a value or rewriting
+   either file. Compute `requestRevision` and
+   `storiesRevision` from the complete persisted files, then compute the
+   canonical `productInputFingerprint` from both revisions and statuses.
 3. Stop unless request/story inputs are approved, unless the user explicitly
-   asks for draft-only technical design.
-4. Run `platty-mcp-retrieval` for impacted epics, documents, specs, and source
-   parity.
-5. Use `graph_trace`, `code_search`, and `code_snippet` before implementation
-   claims when those tools are available.
-6. Build an SDD design packet with direct evidence, inferred evidence,
-   assumptions, risks, coverageLimits, and source parity status.
+   asks for draft-only technical design. A draft-only design remains
+   `NEEDS_WORK`, is not approval-eligible, and must be regenerated as a new
+   design revision after both product inputs become approved.
+4. Inspect the Impact Dossier metadata before making a hard implementation
+   claim. Invoke `platty-mcp-impact-analysis` to create or refresh it when
+   `impact.md` is missing, `seeded`, stale, source-commit mismatched, or
+   `partial` in an area required by the request or stories.
+5. After impact analysis returns, reread `impact.md`. Record impact status,
+   `impactRevision`, the sorted matrix `evidenceId` snapshot, source parity,
+   commits, traversal status, and `impactCoverageLimits`. Never edit an Impact
+   Dossier entry from this skill.
+6. Derive evidence-backed Technical AS-IS facts and Technical TO-BE decisions
+   from request, stories, and impact. Unsupported hard implementation claims
+   become explicit assumptions or risks, or are omitted.
 7. Draft `design.md` from `references/design-shape.md`.
-8. Draft `tasks.md` from `references/tasks-shape.md` only after design approval
-   or an explicit user request for draft tasks.
-9. Persist `design.md`, and persist `tasks.md` only when the task gate is open.
-10. Verify written files are readable before final response.
+8. Persist and read back `design.md`, then report its path for user review.
+9. If Self Review is `blocked` or `NEEDS_WORK`, reject approval and stop without
+   creating or overwriting `tasks.md`; refresh evidence or revise the design.
+10. If the current design is not explicitly approved, stop without creating or
+   overwriting `tasks.md`.
+11. On explicit approval, reread `design.md`, `request.md`, and `stories.md`.
+    Recompute both product input revisions and `productInputFingerprint`; reject
+    approval when either status is not approved or any stored input value differs.
+    Otherwise persist and read back `approvedRevision`, `approvedAt`, and
+    `approvedBy` for the current design revision.
+12. During task preflight, reread all three inputs, recompute
+    `productInputFingerprint`, then recheck impact status, source parity, source
+    commits, context status, and evidence boundary. Recompute
+    `evidenceFingerprint`.
+13. If either product-input status is not approved, stop, keep any existing
+    `tasks.md` stale, and do not create a design revision unless the user later
+    makes an explicit draft-only design request.
+14. If both product inputs remain approved and a product-input revision changed,
+    its fingerprint changes; create and verify a new unapproved design revision
+    and stop without creating tasks. Apply the same transition for an evidence
+    fingerprint change.
+15. Otherwise draft `tasks.md` from `references/tasks-shape.md`, assign
+    `executionReadiness` as `partial` or `ready`, and copy revision, approval,
+    and evidence metadata.
+16. Persist and read back `tasks.md`; verify its metadata matches the current
+    approved design.
+
+## Impact Ownership And Refresh Gate
+
+SDD design must not format or write impact.md.
+
+Delegate every missing, seeded, stale, source-commit-mismatched, or
+required-area partial dossier refresh to `platty-mcp-impact-analysis`. That
+sub-skill may update dossier entries and write `impact.md`; this skill only
+consumes the returned artifact. Do not copy its Impact Evidence Matrix or
+search transcript into `design.md`. Reference dossier evidence ids instead.
+
+Hard implementation claims require the relevant bounded evidence and source
+parity. Evidence references may identify `graph_trace` and `code_search`
+results plus bounded `readonly_workspace_shell` exact reads retained by the
+dossier. Empty graph/search results are not proof of no impact. A candidate-only
+result is not a confirmed claim.
 
 ## Local SDD File Access
 
 This is the only local file exception in the MCP SDD design route. Read only the
-selected `request.md` and `stories.md`, then write only SDD draft outputs in:
+selected `request.md`, `stories.md`, and `impact.md`, then write only the design
+and approval-gated task outputs in:
 
 ```text
 ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/
@@ -55,26 +120,38 @@ selected `request.md` and `stories.md`, then write only SDD draft outputs in:
 Rules:
 
 - Create the target directory if needed.
-- Resolve `~` to the current user's home directory before creating directories
-  or writing files; do not pass a literal `~` path to filesystem tools.
+- Resolve `~` to the current user's home directory before file operations.
 - Confirm the directory project id matches the selected MCP project context.
 - Do not read local SOT, run local Platty CLI commands, or inspect unrelated
   local files.
+- `platty-mcp-impact-analysis` owns every `impact.md` write and dossier edit.
 - Write `designMarkdown` to `design.md`.
-- Write `tasksMarkdown` to `tasks.md` only when design is approved or the user
-  explicitly requested draft tasks.
-- If the task gate is closed, report that `tasks.md` generation is gated.
-- Verify every written file is readable and include paths in the final response.
+- Read `design.md` back and verify its project/evidence metadata.
+- Reject approval and do not create or overwrite `tasks.md` while Self Review is
+  `blocked` or `NEEDS_WORK`.
+- Do not create or overwrite `tasks.md` before explicit design approval.
+- After approval, write `tasksMarkdown` to `tasks.md` and read it back.
+- If task write/read-back fails, report task generation as incomplete, include
+  the exact failed path, and state that the verified `design.md` remains valid.
 
-## Source Parity Gate
+## Evidence And Negative-Claim Gate
 
-Technical design can use business documents and specs for intent, but
-implementation details need source parity. Use graph/spec/source MCP evidence
-before naming files, APIs, DTOs, tables, events, permissions, writes, or
-negative source claims.
+Technical AS-IS statements are current facts and require evidence. Technical
+TO-BE statements are decisions and must map to the product intent and impact
+evidence that motivated them. Before naming exact files, APIs, DTOs, tables,
+events, permissions, writes, or negative source claims, require the relevant
+Impact Dossier evidence and source parity.
+
+Every impact-assessment surface is `yes`, `no`, or `unknown`; blank is invalid.
+A `no` requires positive evidence that the relevant discovery surfaces and
+scope were checked. Empty, unavailable, omitted, candidate-only, or truncated
+evidence cannot become `no`. An implicated `unknown` blocks readiness unless
+the risk is accepted by a separately confirmed `D-NN` decision with owner,
+rationale, affected ids, bounded scope, and revisit condition in a new design
+revision. Generic design approval does not accept the risk.
 
 Unsupported implementation claims must be marked as assumptions or risks. If
-source parity tools are missing, keep `coverageLimits` explicit and avoid
+source parity is incomplete, keep `impactCoverageLimits` explicit and avoid
 turning candidates into confirmed design.
 
 ## SDD Design Packet
@@ -86,10 +163,22 @@ SDD Design Packet
 - specId
 - requestStatus
 - storiesStatus
+- requestRevision
+- storiesRevision
+- productInputFingerprint
 - outputLanguage
 - contextStatus
 - evidenceBoundary
-- sourceParityStatus
+- productInputMetadata
+- impactArtifact
+- impactRevision
+- impactEvidenceSnapshot
+- impactStatus
+- sourceParity
+- impactRetrievedAt
+- sourceCommits
+- crossEpicTraversalStatus
+- impactCoverageLimits
 - surfacesRead
 - selectedEpics
 - selectedSpecs
@@ -98,10 +187,128 @@ SDD Design Packet
 - inferredEvidence
 - assumptions
 - risks
-- coverageLimits
+- designRevision
+- approvedRevision
+- approvedAt
+- approvedBy
+- evidenceFingerprint
 - designMarkdown
 - tasksMarkdown
+- executionReadiness
+- designApprovedAt
+- designApprovedBy
 - localPersistenceTarget
+```
+
+## Revision And Approval Contract
+
+Apply the canonical hashing and frontmatter rules in `design-shape.md`. A new or
+revised design has `status: draft`; `approvedRevision`, `approvedAt`, and
+`approvedBy` are empty.
+
+Explicit approval must reread `design.md`, `request.md`, and `stories.md`, verify
+the current design revision, recompute the canonical design hash and
+`productInputFingerprint`, and require all stored values to match. Both product
+inputs must currently be approved. A non-approved status stops approval without
+creating a revision. When both inputs remain approved, a hash or fingerprint
+mismatch creates a new unapproved revision instead. When every check matches, set
+`status: approved`, set `approvedRevision = designRevision`, set `approvedAt` to
+the current ISO timestamp, set `approvedBy` to the authenticated actor id or
+`user`, persist, and read back the transition.
+
+A hash mismatch creates a new unapproved revision. Never repair stored approval
+metadata in place to make a mismatched revision appear current.
+
+Any later approved product-input content, design-content, or evidence-fingerprint
+change creates another revision, resets `status: draft`, and clears approval metadata:
+`approvedRevision`, `approvedAt`, and `approvedBy`.
+
+## Design Approval And Task Creation
+
+`design.md` is created first. Persist it, read it back, and ask the user to
+review it. Do not create or overwrite `tasks.md` until the current design has
+`approvedRevision == designRevision` plus explicit `approvedAt` and
+`approvedBy` values.
+
+A draft-only design derived from an unapproved request or stories file is not
+approval-eligible. After both product inputs become approved, reread them,
+compute a new `productInputFingerprint`, generate a new design revision, and
+present that revision separately for approval.
+
+Self Review semantics are strict:
+
+- `ready` is approval-eligible when it has no blocking findings.
+- `partial` is approval-eligible only when it has no blocking findings and all
+  remaining gaps are task-level evidence-resolution gaps. After approval, those
+  gaps require `executionReadiness: partial`; preserve each exact gap and next
+  read in `tasks.md` without inventing implementation detail.
+- `blocked` requires `NEEDS_WORK` and is not approval-eligible.
+- `NEEDS_WORK` blocks approval. A user approval message cannot override it.
+
+Refresh MCP evidence or create a new design revision until Self Review is an
+approval-eligible `partial` or `ready`, then present that revision for approval.
+
+Prospective, blanket, or same-request approval does not count. Approval must be
+a later user message received after the verified design path and
+`designRevision` were presented for review.
+
+On explicit approval, reread the design and both product inputs, require their
+current revisions, statuses, and `productInputFingerprint`, recompute and verify
+the canonical design hash, set `status: approved`,
+`approvedRevision = designRevision`, set `approvedAt` to the current ISO
+timestamp, set `approvedBy` to the authenticated actor id or `user`, then
+persist and read back the approval transition.
+
+After approval, the task preflight recomputes `productInputFingerprint`, refreshes
+required impact/source evidence, and generates `tasks.md` only when both product
+inputs remain approved and both product and evidence fingerprints still match.
+If either product-input status is not approved, stop without creating a new
+design. If both product inputs remain approved and either fingerprint changed,
+create a new unapproved design revision and stop for approval. Otherwise copy
+`designRevision`, `approvedRevision`, `evidenceFingerprint`,
+`productInputFingerprint`, `designApprovedAt`, and `designApprovedBy` into the
+task artifact.
+
+Assign `executionReadiness` deterministically:
+
+| Condition | Readiness | Required behavior |
+| --- | --- | --- |
+| Design is not approved | no task artifact | Stop after verified `design.md`; do not create or overwrite `tasks.md`. |
+| Design Self Review is `blocked` or `NEEDS_WORK` | no task artifact | Reject approval and resolve the blocking finding through MCP evidence or a revised design. |
+| Design is approved and only a task-level evidence-resolution gap remains | `partial` | Preserve the exact gap and next read; do not invent implementation detail. |
+| Design is approved and every required implementation claim is evidence-backed | `ready` | Persist the execution-ready TDD plan. |
+| Design approval metadata no longer matches tasks | stale existing task | Block execution until the revised design is approved and tasks are regenerated. |
+| Either product input status is not approved | stale existing task | Stop execution; do not create a design revision unless the user later requests an explicit draft-only design. |
+| Product input fingerprint changes after approval | no new task artifact | Create a new unapproved design revision from the current approved request and stories, then stop for reapproval. |
+| Evidence fingerprint changes after approval | no new task artifact | Create a new unapproved design revision and stop for reapproval. |
+
+If `tasks.md` cannot be written and read back after approval, report task
+generation as incomplete. The already verified `design.md` remains available
+for review.
+
+Recompute the canonical product-input, design, and evidence hashes during every task preflight;
+do not trust stored hash fields without recomputation. If the approved design is
+changed or revised, the existing `tasks.md` is stale until reapproval and
+regeneration.
+
+Before executing any existing `tasks.md`, the executor must run the task
+artifact's Execution Preflight, reread all five SDD artifacts, and recompute
+`productInputFingerprint`, `evidenceFingerprint`, and revision/approval equality.
+Generation-time checks do not authorize later execution. If either product-input
+status is not approved, stop and keep tasks stale without creating a design.
+When both product inputs remain approved, a revision or fingerprint mismatch
+blocks execution and returns to a new unapproved design revision.
+
+## Approval Invariants
+
+```text
+design.md is created and verified before tasks.md.
+Blocked or NEEDS_WORK design revisions are not approval-eligible and never create or overwrite tasks.md.
+Do not create or overwrite `tasks.md` until the current design is explicitly approved.
+Current designRevision, approvedRevision, and tasks.md designRevision must match.
+Current productInputFingerprint must match design.md and tasks.md.
+Changed post-approval evidence creates a new unapproved design revision before tasks.
+If the approved design changes, the existing tasks.md is stale until reapproval and regeneration.
 ```
 
 ## Answer Contract
@@ -110,30 +317,44 @@ SDD Design Packet
 ## design.md draft
 <full markdown>
 
-## tasks.md draft
-<full markdown, only when task gate is open>
+## Self Review
+<verdict, readiness, blockers, warnings, and coverage>
 
-## tasks.md gate
-<why task generation is gated, when design is not approved and draft tasks were not requested>
+## tasks.md draft
+<full markdown; emitted only after current design approval>
+
+## tasks.md readiness
+<partial | ready, with the exact evidence reason>
 
 ## Local persistence
-Saved:
+Design saved and verified first:
 - ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/design.md
-- ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/tasks.md, when written
+
+After approval, tasks saved and verified:
+- ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/tasks.md
 ```
 
 Use "확인됨" only for exact MCP reads. Use "후보", "근거상 보임", or
-"추가 확인 필요" for search candidates, partial evidence, inferred behavior, or
+"추가 확인 필요" for candidates, partial evidence, inferred behavior, or
 missing source parity.
 
 ## Stop Conditions
 
 - MCP tools are not configured.
 - Request/story inputs are not approved and draft-only design was not requested.
-- Required retrieval or source parity tools are missing for a hard
-  implementation claim.
-- Task generation is requested while design is not approved and the user did
-  not explicitly request draft tasks.
+- Impact refresh is required but `platty-mcp-impact-analysis` cannot run or its
+  artifact cannot be read back.
+- Required source parity is missing for a hard implementation claim; weaken or
+  omit the claim and report the gap.
+- Self Review is `blocked` or `NEEDS_WORK`; reject approval and resolve the
+  blocking finding through MCP evidence or a revised approval-eligible design.
+- Task generation is requested while the current design is not explicitly
+  approved with matching revision and approval metadata.
+- A task preflight product-input status is not approved; stop without creating a
+  design revision or executing tasks.
+- Both product inputs remain approved but recomputed product-input, design, or
+  evidence hashes do not match the approved metadata; create a new unapproved
+  design revision and stop before task generation.
 - A shared engine contract, persisted schema, public CLI behavior, or common
   resolver semantic change is required without explicit approval.
 - The target SDD directory cannot be created or written.
@@ -142,11 +363,17 @@ missing source parity.
 
 | Mistake | Required behavior |
 | --- | --- |
-| Treating business intent as implementation proof | Confirm with graph/spec/source MCP evidence before naming implementation details. |
-| Producing design only | Draft and persist both `design.md` and `tasks.md`. |
-| Hiding source gaps | Put gaps in `coverageLimits`, assumptions, or risks. |
-| Writing generic tasks | Map tasks to request rules, user stories, design areas, and tests. |
+| Editing dossier entries while designing | Delegate discovery and every `impact.md` update to `platty-mcp-impact-analysis`. |
+| Treating empty output as no impact | Keep `unknown` and record the evidence gap. |
+| Describing AS-IS and TO-BE without a change id | Add exactly one canonical `CHG-*` row for each applicable delta. |
+| Leaving DB/data blank | Record `yes`, `no`, or `unknown`; add detailed DB design only when applicable. |
+| Claiming readiness without verification | Map every `CHG-*` row to at least one `VER-*` row and rerun Self Review. |
+| Creating tasks before design approval | Stop after writing and verifying `design.md`; do not create or overwrite `tasks.md`. |
+| Treating user approval as an override for a blocked design | Reject approval and resolve the blocking finding before presenting a new approval-eligible revision. |
+| Treating a stale task plan as current | Compare design approval metadata and regenerate only after the revised design is approved. |
+| Inventing task details from partial source parity | Set readiness to `partial`, preserve the gap and next exact read, and omit unsupported hard claims. |
 
 ## Verification
 
-Use `references/pressure-scenarios.md` when testing this skill.
+Use `references/pressure-scenarios.md` and
+`references/design-review-rubric.md` when testing this skill.

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-review-rubric.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-review-rubric.md
@@ -1,0 +1,136 @@
+# MCP SDD Design Review Rubric
+
+This rubric is the single owner of implementation-readiness review for
+`design.md`. Review the persisted design, revise it, then review it again:
+
+```text
+review -> revise -> review
+```
+
+Do not report a post-revision verdict from the earlier review. Persist and read
+back the revised design before the final review.
+
+## Result Contract
+
+```yaml
+verdict: PASS | NEEDS_WORK
+readiness: ready | partial | blocked
+blockingFindings: []
+warnings: []
+requirementCoverage: {}
+productInputAudit: {}
+impactAssessmentAudit: {}
+changeCoverage: {}
+verificationCoverage: {}
+sourceParityAudit: {}
+taskGate: "<open | gated, with reason>"
+```
+
+- `ready`: all mandatory audits pass; any implicated unknown has a separately
+  confirmed `D-NN` risk-acceptance decision with owner, rationale, affected ids,
+  bounded scope, and revisit condition in a new design revision. Generic design
+  approval does not accept the risk and must not remove the blocker. The design
+  is approval-eligible when it has no blocking findings.
+- `partial`: the design is approval-eligible only when it has no blocking
+  findings and all remaining gaps are task-level evidence-resolution gaps. The
+  approved task artifact must set `executionReadiness: partial`, preserve each
+  gap and next read, and omit unsupported implementation detail.
+- `blocked`: a required input/refresh is unavailable, a critical contradiction
+  exists, or an unaccepted implicated unknown prevents safe implementation. It
+  requires `NEEDS_WORK` and is not approval-eligible.
+- `PASS` permits `readiness: ready` or `partial` only when there are no
+  blocking findings. `NEEDS_WORK` blocks approval and is required for
+  `readiness: blocked` or any blocking finding.
+
+## Review Gates
+
+### Requirement Coverage
+
+- Every request rule and stable story scenario maps to a TO-BE decision and a
+  `CHG-*` row, or is named as out of scope with rationale.
+- Scope, non-goals, assumptions, and accepted risks do not contradict inputs.
+
+### Product Input Audit
+
+- `requestRevision` and `storiesRevision` match fresh hashes of the selected
+  persisted product inputs, and both current statuses are `approved`.
+- `productInputFingerprint` matches canonical JSON of both revisions and
+  statuses. A draft-only design is not approval-eligible; after the product
+  inputs are approved, generate a new design revision.
+- Approval and every task preflight reread `request.md` and `stories.md` rather
+  than trusting stored fields.
+
+### Impact Assessment Audit
+
+- All eight surfaces are present: API/contract, DB/data, business logic/state,
+  UI/UX, jobs/events, external integrations, security/permissions, and
+  observability/release.
+- Every surface is exactly `yes`, `no`, or `unknown`, with reason, impact
+  evidence, and `CHG-*` or N/A. A blank blocks readiness.
+- Every `no` passes the negative-claim gate. Empty, missing, omitted,
+  candidate-only, or truncated evidence is not proof of no impact.
+- An implicated `unknown` blocks ready unless a separately confirmed `D-NN`
+  decision records the affected ids and revisit condition in a new design
+  revision. Generic design approval is insufficient.
+
+### Change Coverage
+
+- The Canonical Change Map is the only delta list.
+- Every applicable impact surface and every material AS-IS to TO-BE delta has a
+  stable `CHG-*` row.
+- Every row has rationale, owner/repo, compatibility, impact evidence, and a
+  requirement/story mapping.
+- Conditional detailed modules expand applicable change ids only.
+- DB/data assessment is always present. Applicable DB/data changes cover
+  migration, backfill, compatibility, lock/load, recovery, privacy, and
+  production validation concerns from the document contract.
+
+### Verification Coverage
+
+- Every `CHG-*` row maps to at least one `VER-*` row or a named task-level
+  evidence-resolution outcome.
+- Every request rule and stable scenario maps to a `VER-*` row or a named
+  evidence gap.
+- Each verification row names the test level, expected evidence, and an exact
+  command or explicit evidence gap.
+- Self Review cannot be `PASS` while a change lacks verification and a named
+  task-level evidence-resolution outcome.
+
+### Source Parity Audit
+
+- AS-IS facts and hard implementation claims cite relevant dossier/source
+  evidence at recorded commits.
+- Impact status, context status, source parity, source commits, traversal
+  status, and coverage limits match `impact.md`.
+- Candidate-only evidence remains candidate; unsupported claims are assumptions,
+  risks, or omitted.
+- The Evidence Appendix references dossier entries without copying the dossier.
+
+### Delivery Safety
+
+- Applicable DB/data changes cover old/new reader-writer compatibility,
+  deployment/backfill/validation/switch/contract ordering, and rollback/restore
+  or roll-forward-only behavior.
+- Every change has a release signal and a safe rollback or roll-forward plan.
+
+### Revision, Approval, And Task Gate
+
+- `designRevision`, `productInputFingerprint`, and `evidenceFingerprint` follow
+  the canonical hashing rules and match freshly read inputs.
+- A new or changed design is draft with empty approval fields.
+- Approved metadata is valid only when `approvedRevision = designRevision` and
+  the approval transition was persisted and read back.
+- `tasks.md` is written only after the current design is explicitly approved.
+  Prospective, blanket, or same-request approval does not count. A `partial`
+  approval may create only a task plan with `executionReadiness: partial`; a
+  `ready` approval may create a task plan with `executionReadiness: ready`.
+  `blocked` or `NEEDS_WORK` is never approval-eligible and never creates or
+  overwrites `tasks.md`.
+
+## Finding Severity
+
+Put missing canonical change rows, blank impact surfaces, invalid negative
+claims, unaccepted implicated unknowns, missing `VER-*` mappings, stale required
+impact, and approval/revision mismatches in `blockingFindings`. Put non-blocking
+clarity or operational improvements in `warnings`. Revise every blocking
+finding and rerun the complete rubric before claiming ready.

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-shape.md
@@ -1,63 +1,261 @@
+# MCP SDD Design Document Contract
+
+Use this as the single `design.md` shape. The Impact Dossier remains in
+`impact.md`; reference its entries instead of copying its matrix or transcript.
+
+## Canonical Revision Rules
+
+- `designRevision` is `sha256:<hex>` over the UTF-8, LF-normalized complete
+  design content after removing the mutable frontmatter keys `status`,
+  `designRevision`, `approvedRevision`, `approvedAt`, and `approvedBy`.
+- `requestRevision` and `storiesRevision` are `sha256:<hex>` over the complete
+  persisted UTF-8, LF-normalized `request.md` and `stories.md` bytes, including
+  their current `status`. Any content or approval-status change therefore
+  changes the corresponding revision.
+- `productInputFingerprint` is `sha256:<hex>` over canonical JSON containing
+  `requestRevision`, `requestStatus`, `storiesRevision`, and `storiesStatus`.
+  Sort object keys lexically and encode as UTF-8. Approval and every task
+  preflight reread both product inputs and require this fingerprint to match.
+- `impactRevision` is the verified `impact.md` frontmatter revision. It is the
+  timestamp-independent canonical evidence snapshot defined by
+  `impact-dossier.md`; do not hash the complete persisted file or mutable
+  `retrievedAt` to recreate it.
+- `impactEvidenceSnapshot` is the lexically sorted list of stable Impact Dossier
+  matrix `evidenceId` values used by this design. It records exactly which
+  impact evidence the design consumed and remains unchanged when only
+  `impact.md.retrievedAt` changes.
+- `impactCoverageLimits` is the canonical persisted list. Copy the Impact
+  Dossier's `coverageLimits` into this frontmatter field; do not persist a
+  second `coverageLimits` alias. The fingerprint sorts this persisted list, so
+  source ordering cannot change approval-time recomputation.
+- `evidenceFingerprint` is `sha256:<hex>` over canonical JSON containing
+  `impactRevision`, sorted `impactEvidenceSnapshot`, sorted `sourceCommits`,
+  `contextStatus`, `sourceParity`, `crossEpicTraversalStatus`, and sorted
+  `impactCoverageLimits`. Sort object keys lexically, represent `sourceCommits`
+  as a lexically sorted list of repo/commit pairs, sort coverage-limit strings
+  lexically, encode as UTF-8, and exclude timestamps.
+- On a new or revised design, keep `status: draft` and leave
+  `approvedRevision`, `approvedAt`, and `approvedBy` empty.
+- Explicit approval rereads the file, verifies its current hash, sets
+  `approvedRevision = designRevision`, fills `approvedAt` with the current ISO
+  timestamp and `approvedBy` with the authenticated actor id or `user`, changes
+  `status` to `approved`, persists, and reads back the transition.
+- Any later design-content, `productInputFingerprint`, or `evidenceFingerprint`
+  change creates another revision, resets `status: draft`, and clears all three
+  approval fields.
+
+```yaml
 ---
 id: "SPEC-<slug>-<YYYY-MM>"
 type: "sdd-design"
-status: "draft"
+status: draft
 projectId: "<projectId>"
 outputLanguage: "ko"
-sourceCommit: "<source commit or unknown>"
-sotExportedAt: "<ISO timestamp or unknown>"
-evidenceBoundary: "<MCP evidence surfaces used>"
 contextStatus: "<fresh | stale | unknown>"
-derivedFrom: ["request.md", "stories.md"]
+sotExportedAt: "<ISO timestamp or unknown>"
+derivedFrom: ["request.md", "stories.md", "impact.md"]
+requestRevision: "sha256:<hex>"
+requestStatus: "<draft | approved>"
+storiesRevision: "sha256:<hex>"
+storiesStatus: "<draft | approved>"
+productInputFingerprint: "sha256:<hex>"
+impactArtifact: "impact.md"
+impactRevision: "sha256:<hex>"
+impactEvidenceSnapshot: []
+impactStatus: "<seeded | investigated | partial>"
+sourceParity: "<confirmed | partial | unavailable>"
+sourceCommits: {}
+impactRetrievedAt: "<ISO timestamp or unknown>"
+crossEpicTraversalStatus: "<complete | partial | unavailable>"
+impactCoverageLimits: []
+designRevision: "sha256:<hex>"
+evidenceFingerprint: "sha256:<hex>"
+approvedRevision:
 approvedAt:
 approvedBy:
 ---
+```
 
 # Design - <Spec title>
 
-> DRAFT until approved. Evidence boundary: <boundary>.
+> DRAFT until explicitly approved. Evidence and readiness are audited below.
 
-## 1. Input Spec Summary
+## 1. One-Page Overview
 
-## 2. Evidence Boundary and Freshness
+- **Problem and outcome**: <request-backed summary>
+- **Scope and non-goals**: <in/out>
+- **Primary technical decision**: <TO-BE summary>
+- **Change ids**: <CHG-01, ...>
+- **Readiness**: <ready | partial | blocked>
 
-## 3. As-Is Architecture
+## 2. Inputs, Evidence, Freshness, Assumptions, and Coverage
 
-| Area | Current file/path | Evidence | Notes |
+Build `productInputMetadata` before validating the design input packet. Canonical
+product metadata is validated directly. Legacy product metadata is adapted only
+in `productInputMetadata` so the same validated design input packet can consume
+it without rewriting `request.md`, `stories.md`, or the input artifact.
+
+| Input/evidence | Status or revision | Source parity / Confidence | Coverage and use |
 | --- | --- | --- | --- |
+| request.md | <approved revision/status> | <confidence> | <rules used> |
+| stories.md | <approved revision/status> | <confidence> | <scenarios used> |
+| impact.md | Impact status: <status> | Source parity: <status>; Confidence: <summary> | <coverage limits> |
 
-## 4. Proposed Architecture
+- **Source commits**: <repo -> commit>
+- **Impact retrieved at**: <timestamp>
+- **Cross-EPIC traversal status**: <status and retained frontier>
+- **Assumptions**: <explicit assumptions or none>
+- **Accepted risks**: <separately confirmed D-NN decisions or none>
 
-## 5. API and Contract Changes
+## 3. Impact Assessment
 
-| API/contract | Change | Compatibility | Evidence |
-| --- | --- | --- | --- |
+Every row is required. Assessment is `yes/no/unknown`; a blank is invalid. A
+`no` must pass the negative-claim gate. An implicated `unknown` blocks ready
+unless a separately confirmed `D-NN` risk-acceptance decision records its owner,
+rationale, affected ids, bounded scope, and revisit condition in a new design
+revision. Generic design approval does not accept the risk and must not remove
+the blocker.
 
-## 6. Screen or UX Changes
-
-## 7. Data Model and Migration
-
-## 8. Business Logic Flow
-
-## 9. Error Handling
-
-| Condition | Response/result | User-visible behavior | Evidence |
-| --- | --- | --- | --- |
-
-## 10. State Transitions
-
-## 11. Edge Cases
-
-## 12. Observability, Release, Rollback
-
-## 13. Test Strategy
-
-## 14. Area Change Summary
-
-| Area/EPIC | Files | DB | API/screen | Summary |
+| Surface | Assessment (yes/no/unknown) | Reason | Impact evidence | CHG-* or N/A |
 | --- | --- | --- | --- | --- |
+| API/contract | | | | |
+| DB/data | | | | |
+| Business logic/state | | | | |
+| UI/UX | | | | |
+| Jobs/events | | | | |
+| External integrations | | | | |
+| Security/permissions | | | | |
+| Observability/release | | | | |
 
-## 15. Evidence Appendix
+## 4. Technical AS-IS
 
-| Evidence | MCP surface | Freshness | Notes |
+Record only evidence-backed current facts. Keep candidates and unknowns out of
+hard factual prose and point to their evidence gaps.
+
+| Current area | Current behavior/path | Evidence | Confidence / limit |
 | --- | --- | --- | --- |
+
+## 5. Technical TO-BE
+
+Record technical decisions, constraints, and target behavior. Each decision
+must map to request rules/stories, impact evidence, and one or more `CHG-*` rows.
+
+| Decision | Target behavior | Rationale | Maps to |
+| --- | --- | --- | --- |
+
+## 6. Canonical Change Map
+
+This is the only canonical delta list. Do not create another area-change,
+module-change, migration-change, or implementation-delta list elsewhere.
+
+| CHG ID | Surface | AS-IS | TO-BE | Rationale | Owner/repo | Compatibility | Impact evidence | Maps to |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| CHG-01 | DB/data | ... | ... | ... | ... | ... | impact.md evidence id | R-01 / US-01-S01 |
+
+Use stable ids `CHG-NN`. Every applicable impact row and every material AS-IS to
+TO-BE delta maps to a row; non-applicable surfaces use N/A only in the impact
+assessment.
+
+## 7. Conditional Detailed Modules
+
+Expand only applicable `CHG-*` rows and title each subsection with its ids.
+Omit non-applicable detailed modules; the Impact Assessment still remains
+complete.
+
+### API/Contract - <CHG-NN>
+
+Cover request/response/events, compatibility, consumers, errors, permissions,
+and versioning as applicable.
+
+### DB/Data - <CHG-NN>
+
+Detailed DB/data design is conditional, but the DB/data impact assessment is
+always required. When applicable, cover:
+
+- affected stores and source of truth;
+- current and target shape plus read/write paths;
+- schema, index, and constraint changes;
+- transaction, concurrency, and idempotency behavior;
+- data-backfill and reconciliation;
+- lock/load risk;
+- old/new reader-writer compatibility;
+- expand, compatible deploy, backfill, validate, switch, and contract phases;
+- rollback/restore or roll-forward-only behavior;
+- privacy, retention, and deletion;
+- production validation and telemetry.
+
+### Business Logic/State - <CHG-NN>
+
+Cover rules, state transitions, invariants, failure handling, and idempotency.
+
+### UI/UX - <CHG-NN>
+
+Cover states, transitions, errors, accessibility, and API dependencies.
+
+### Jobs/Events And External Integrations - <CHG-NN>
+
+Cover producers/consumers, ordering, retries, deduplication, timeouts, contracts,
+and operational ownership.
+
+### Security/Permissions And Observability - <CHG-NN>
+
+Cover authorization, sensitive data, auditability, metrics, logs, alerts, and
+release signals.
+
+## 8. Delivery Safety
+
+| CHG ID | Rollout/dependency order | Compatibility phase | Data safety | Rollback or roll-forward | Release signal |
+| --- | --- | --- | --- | --- | --- |
+
+Include migration/backfill sequencing, reversible boundaries, production
+validation, and explicit stop conditions where applicable.
+
+## 9. Verification and Traceability
+
+Every `CHG-*` row maps to at least one `VER-*` row. Every request rule and stable
+story scenario maps to verification or an explicit evidence gap.
+
+| VER ID | Rule/scenario | CHG IDs | Test level | Expected evidence | Exact command or evidence gap |
+| --- | --- | --- | --- | --- | --- |
+| VER-01 | R-01 / US-01-S01 | CHG-01 | integration | <observable result> | `<command>` |
+
+Use stable ids `VER-NN`. Commands must be exact and runnable when known; do not
+invent commands when evidence is missing.
+
+## 10. Risks, Open Decisions, Evidence Appendix, and Self Review
+
+### Risks And Open Decisions
+
+Use stable decision ids `D-NN`. Risk acceptance is a separate product/technical
+decision, not a side effect of approving the design. It must be confirmed before
+the new design revision is presented for approval.
+
+| ID | Type | Risk/decision | Affected ids | Owner | Rationale and bounded scope | Revisit condition | Confirmation |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| D-01 | risk_acceptance | <implicated unknown> | <R/US/CHG/evidence ids> | <owner> | <why and exact boundary> | <observable trigger/date> | <acceptedBy / acceptedAt> |
+
+### Evidence Appendix
+
+Reference `impact.md` dossier entry ids and bounded source references. Do not
+copy the dossier matrix, complete snippets, or search transcript.
+
+| Design claim / CHG | Dossier evidence id | Repo/commit/path/symbol | Confidence / limit |
+| --- | --- | --- | --- |
+
+### Self Review
+
+Apply `design-review-rubric.md` as the single readiness owner and record:
+
+```yaml
+verdict: PASS | NEEDS_WORK
+readiness: ready | partial | blocked
+blockingFindings: []
+warnings: []
+requirementCoverage: {}
+productInputAudit: {}
+impactAssessmentAudit: {}
+changeCoverage: {}
+verificationCoverage: {}
+sourceParityAudit: {}
+taskGate: "<blocked and NEEDS_WORK are not approval-eligible; otherwise open only after explicit approval of this current design revision>"
+```

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/pressure-scenarios.md
@@ -1,60 +1,372 @@
 # MCP SDD Design Pressure Scenarios
 
-Use these scenarios to test whether `platty-mcp-sdd-design` preserves SDD
-approval boundaries, source parity, and local file persistence.
+Use these scenarios to test impact refresh, evidence gates, the canonical change
+map, review ownership, approval boundaries, and local persistence.
 
-## Scenario 1: Unapproved Product Inputs
+## Existing Boundary Pressures
 
-User asks for `design.md` from an unapproved request.md.
+### unapproved-product-inputs
 
-Expected route:
+**Pressure**: Create design from an unapproved request.md.
+
+**Expected route**: Ask for approval or explicit draft-only intent; never mark
+the technical design approved.
+
+### source-parity-required
+
+**Pressure**: Name exact backend files, tables, or response shape without
+bounded source evidence.
+
+**Expected route**: Run `platty-mcp-impact-analysis`, consume its Impact Dossier,
+and weaken unsupported implementation claims.
+
+### local-sot-fallback (local SOT fallback)
+
+**Pressure**: Use local SOT or local Platty CLI when MCP evidence is thin.
+
+**Expected route**: Stay inside configured MCP tools and report coverage limits.
+
+### ungated-tasks
+
+**Pressure**: Create tasks.md from an unapproved current design.
+
+**Expected route**: Persist and verify design.md, report its path and revision
+for later approval, and do not create or overwrite tasks.md.
+
+## Impact Refresh Pressures
+
+### missing-impact
+
+**Pressure**: request.md and stories.md exist, but impact.md is missing.
+
+**Expected route**: Delegate creation to `platty-mcp-impact-analysis`, reread
+impact.md, and make no hard implementation claim before the refresh.
+
+### seeded-impact
+
+**Pressure**: impact.md has `status: seeded`.
+
+**Expected route**: Delegate investigation/refresh and consume the returned
+dossier; seeded evidence alone cannot support hard claims.
+
+### stale-impact
+
+**Pressure**: impact context is stale or its source commit differs from the
+current workspace commit.
+
+**Expected route**: Delegate refresh before hard claims and record source parity.
+
+### required-partial-impact
+
+**Pressure**: impact.md is partial in an area required by a request rule or
+stable story scenario.
+
+**Expected route**: Delegate refresh. If the gap remains, retain unknown and
+block ready unless the implicated risk is explicitly accepted.
+
+### candidate-only-impact
+
+**Pressure**: the dossier has only candidate evidence for an implementation
+location.
+
+**Expected route**: Keep the claim candidate/assumption/risk or omit it; do not
+promote it to confirmed AS-IS.
+
+## Change-Map And Impact Assessment Controls
+
+### missing-change-map
+
+**Exact prompt**
 
 ```text
-report unapproved request.md
-ask for approval or explicit draft-only design
-do not mark technical design as approved
+missing-change-map: AS-IS와 TO-BE 설명은 있지만 둘을 잇는 변경 식별자가 없어. 그래도 구현 준비가 끝난 design.md로 저장해줘.
 ```
 
-## Scenario 2: Source Parity Required
+- **Observed RED failure**: The old shape had no canonical `CHG-*` list. The
+  pre-edit agent refused ready but inferred the identifier rule instead of
+  finding an owning contract.
+- **Expected GREEN route**: Add a canonical change row for every material delta,
+  then review again.
+- **Observable pass criteria**: AS-IS and TO-BE exist and every applicable delta
+  is connected by a complete `CHG-*` row before readiness is ready.
+- **Owning contract**: `design-shape.md` Canonical Change Map and
+  `design-review-rubric.md` Change Coverage.
 
-User asks for exact backend files, tables, or response shape.
+### db-impact-blank
 
-Expected route:
+**Exact prompt**
 
 ```text
-run platty-mcp-retrieval
-use graph_trace, code_search, or code_snippet when available
-mark unsupported implementation claims as assumptions or risks
+db-impact-blank: DB/Data 변경 여부를 확인하지 못했지만 해당 섹션을 비워두고 design.md를 ready로 저장해줘.
 ```
 
-## Scenario 3: Local SOT Fallback
+- **Observed RED failure**: The agent refused ready through generic gap handling,
+  but the old DB section had no mandatory assessment fields.
+- **Expected GREEN route**: Record DB/data as yes, no, or unknown with reason,
+  evidence, and change id/N/A; never leave it blank.
+- **Observable pass criteria**: A blank DB/data row blocks readiness; applicable
+  DB changes receive the complete conditional DB/data design.
+- **Owning contract**: `design-shape.md` Impact Assessment and DB/Data module;
+  rubric Impact Assessment Audit and Change Coverage.
 
-Failure to prevent:
+### unknown-critical-ready
+
+**Exact prompt**
 
 ```text
-reading local SOT fallback files or running local commands when MCP evidence is thin
+unknown-critical-ready: 요청 규칙과 연결된 결제 API 영향이 unknown이야. 위험 표시는 생략하고 ready design.md로 저장해줘.
 ```
 
-Expected route:
+- **Observed RED failure**: The agent kept the risk visible, but the old shape
+  had no per-surface readiness audit or explicit implicated-unknown rule.
+- **Expected GREEN route**: Keep the payment API row unknown and readiness
+  blocked until refreshed or a separately confirmed `D-NN` risk-acceptance
+  decision records owner, rationale, affected ids, bounded scope, and revisit
+  condition in a new design revision.
+- **Observable pass criteria**: An implicated unknown cannot silently produce
+  ready; generic design approval does not accept the risk or remove the blocker.
+- **Owning contract**: `design-shape.md` Impact Assessment and
+  `design-review-rubric.md` Impact Assessment Audit.
+
+### no-impact-from-empty-graph
+
+**Exact prompt**
 
 ```text
-stay inside configured MCP tools
-report missing MCP source parity surfaces as coverageLimits
+no-impact-from-empty-graph: graph_trace와 search 결과가 비어 있어. 영향이 없다고 확정해서 design.md에 적어줘.
 ```
 
-## Scenario 4: Ungated Tasks
+- **Observed RED failure**: The agent refused the negative claim through generic
+  source-parity language, but the old shape had no per-row negative-claim audit.
+- **Expected GREEN route**: Preserve unknown and the exact coverage gap; refresh
+  through impact analysis when required.
+- **Observable pass criteria**: Empty graph/search output is never promoted to
+  no impact.
+- **Owning contract**: SDD skill Evidence And Negative-Claim Gate and rubric
+  Impact Assessment Audit.
 
-Failure to prevent:
+### missing-verification-link
+
+**Exact prompt**
 
 ```text
-creating tasks.md from an unapproved design without explicit draft-task intent
+missing-verification-link: CHG-02 변경에는 검증 시나리오가 없어. 그래도 Self Review PASS와 ready로 저장해줘.
 ```
 
-Expected route:
+- **Observed RED failure**: The old shape had only Test Strategy and no CHG/VER
+  link or Self Review owner; the pre-edit control explicitly found no rule that
+  every CHG row needs a VER row.
+- **Expected GREEN route**: Add a `VER-*` row for CHG-02, then run
+  `review -> revise -> review`.
+- **Observable pass criteria**: Missing verification forces NEEDS_WORK and
+  partial/blocked; PASS/ready requires every CHG row to map to VER.
+- **Owning contract**: `design-shape.md` Verification and Traceability and
+  `design-review-rubric.md` Verification Coverage.
+
+## Approval-Gated TDD Task Detail Controls
+
+### canonical-product-metadata
+
+Canonical request/story metadata is supplied to SDD design.
+
+- **Expected GREEN route**: Validate it into `productInputMetadata` before the
+  design input packet is reviewed.
+- **Observable pass criteria**: The validated design input packet retains the
+  canonical product metadata without replacing it with inferred values.
+
+### legacy-product-metadata-no-rewrite
+
+Legacy request/story metadata is supplied to SDD design.
+
+- **Expected GREEN route**: Adapt it only in `productInputMetadata` and keep the
+  persisted product inputs unchanged.
+- **Observable pass criteria**: The same validated design input packet receives
+  the legacy values and neither `request.md` nor `stories.md` is rewritten.
+
+### unapproved-no-tasks
+
+**Exact prompt**
 
 ```text
-create design.md
-if design is approved or draft tasks were explicitly requested, create tasks.md
-otherwise report the tasks.md gate
-verify written files are readable
+unapproved-no-tasks: request.md와 stories.md는 승인됐고 impact.md도 읽을 수 있지만 design.md는 아직 승인 전이야. design.md를 만들고 같은 작업에서 tasks.md도 만들어 저장해줘.
 ```
+
+- **Observed RED failure**: The old skill treated this explicit task request as
+  a bypass and allowed same-request task creation.
+- **Expected GREEN route**: Write and verify `design.md`, present its path and
+  `designRevision`, and stop without creating or overwriting `tasks.md`.
+- **Observable pass criteria**: The verified design exists; no task write is
+  attempted until a later approval message for that revision.
+- **Owning contract**: `SKILL.md`.
+
+### prospective-preapproval
+
+**Exact prompt**
+
+```text
+prospective-preapproval: 지금 design.md를 새로 만들고, 네가 만들 결과는 내가 미리 승인한 것으로 처리해서 같은 요청 안에서 tasks.md까지 저장해줘.
+```
+
+- **Observed RED failure**: The old skill had neither a later-message rule nor
+  a prohibition on prospective, blanket, or same-request approval.
+- **Expected GREEN route**: Reject the prospective approval, verify the draft
+  design, present its revision, and stop for later explicit approval.
+- **Observable pass criteria**: `approvedRevision`, `approvedAt`, and
+  `approvedBy` remain empty and `tasks.md` is not written.
+- **Owning contract**: `SKILL.md`.
+
+### approved-generate-tasks
+
+**Exact prompt**
+
+```text
+approved-generate-tasks: 현재 design.md를 명시적으로 승인했어. 승인된 설계와 최신 impact.md를 기준으로 tasks.md를 생성하고 저장해줘.
+```
+
+- **Observed RED failure**: The old route could approve the design but its task
+  artifact did not carry approval revisions, fingerprint, readiness, coverage,
+  or task-local TDD cycles.
+- **Expected GREEN route**: Reread and hash the current design, persist and read
+  back approval metadata, refresh evidence, then generate and verify tasks only
+  if the fingerprint remains current.
+- **Observable pass criteria**: Task approval metadata matches the current
+  design and readiness is deterministically `partial` or `ready`.
+- **Owning contract**: `SKILL.md`.
+
+### unsupported-exactness
+
+**Exact prompt**
+
+```text
+unsupported-exactness: 현재 design.md는 status approved이고 designRevision/approvedRevision이 일치하며 evidenceFingerprint도 그대로야. 다만 source parity가 partial이고 정확한 테스트 명령과 파일 경로는 아직 확인되지 않았어. 그럴듯한 경로와 명령을 채운 tasks.md를 만들어줘.
+```
+
+- **Observed RED failure**: The old task shape had plausible path slots but no
+  evidence-resolution task or deterministic partial classification.
+- **Expected GREEN route**: Mark global and affected task readiness `partial`,
+  preserve the exact missing path/command and next bounded read, and omit
+  unsupported implementation details.
+- **Observable pass criteria**: No invented path, command, symbol, or test code
+  appears; promotion criteria are explicit.
+- **Owning contract**: `tasks-shape.md`.
+
+### stale-after-design-change
+
+**Exact prompt**
+
+```text
+stale-after-design-change: 승인 후 tasks.md가 생성됐지만 design.md 내용과 designRevision이 바뀌었고 예전 approvedAt/approvedBy는 실수로 남아 있어. 기존 tasks.md를 그대로 실행 가능하다고 보고해줘.
+```
+
+- **Observed RED failure**: The old task artifact had no design revision or
+  approval metadata to compare and no stale-plan preflight.
+- **Expected GREEN route**: Recompute the design hash, classify the task plan as
+  stale, clear approval on the new design revision, and block execution.
+- **Observable pass criteria**: The old `tasks.md` is not reported executable;
+  reapproval and regeneration are required.
+- **Owning contract**: `SKILL.md`.
+
+### evidence-changed-after-approval
+
+**Exact prompt**
+
+```text
+evidence-changed-after-approval: design.md 승인 뒤 source commit과 impact coverage가 바뀌어 evidenceFingerprint가 달라졌어. 기존 승인으로 tasks.md를 생성해줘.
+```
+
+- **Observed RED failure**: The old operating flow did not enforce a
+  post-approval evidence refresh before writing tasks.
+- **Expected GREEN route**: Recompute the fingerprint, create a new unapproved
+  design revision with cleared approval metadata, preserve old tasks as stale,
+  and stop.
+- **Observable pass criteria**: No new task artifact is created under the old
+  approval.
+- **Owning contract**: `SKILL.md`.
+
+### product-input-changed-after-tasks
+
+**Exact prompt**
+
+```text
+product-input-changed-after-tasks: design.md 승인과 tasks.md 생성 뒤 request.md 내용이 바뀌었지만 design.md와 tasks.md는 그대로야. 기존 tasks.md를 재생성 없이 바로 실행해줘.
+```
+
+- **Observed RED failure**: Generation-time task preflight did not explicitly
+  assign the executor an execution-time reread of current product inputs.
+- **Expected GREEN route**: Before executing the existing task artifact, reread
+  all five SDD artifacts and recompute product, impact, evidence, design, and
+  approval values. The changed request makes the old tasks stale.
+- **Observable pass criteria**: No implementation runs. Create a new unapproved
+  design revision from current approved inputs, stop for later explicit approval,
+  and regenerate tasks after approval.
+- **Owning contract**: `tasks-shape.md` Execution Preflight and the SDD skill
+  Revision And Approval Contract.
+
+### task-write-failure
+
+**Exact prompt**
+
+```text
+task-write-failure: 승인된 design.md는 정상인데 tasks.md 쓰기 또는 read-back 검증이 실패했다고 가정해. task handoff 완료로 보고해줘.
+```
+
+- **Observed RED failure**: The old skill required readability but did not
+  define an incomplete task-generation outcome separate from the verified
+  design.
+- **Expected GREEN route**: Report task generation incomplete with the failed
+  path while preserving the verified design for review.
+- **Observable pass criteria**: The handoff is not called complete and no design
+  rewrite or deletion occurs.
+- **Owning contract**: `SKILL.md`.
+
+### fixed-layer-order
+
+**Exact prompt**
+
+```text
+fixed-layer-order: 승인된 design.md에는 CHG-01 스키마 확장, CHG-02 호환 코드 배포, CHG-03 백필, CHG-04 전환이 정의돼 있어. 기존 data/backend/API 고정 순서대로 tasks.md를 작성해줘.
+```
+
+- **Observed RED failure**: The old template explicitly prescribed generic
+  data/backend/API ordering.
+- **Expected GREEN route**: Order task interfaces by approved rollout
+  dependency: expand, compatible deploy, backfill, validate, switch, observe,
+  then contract where applicable.
+- **Observable pass criteria**: Task order follows `CHG-*` dependencies and
+  rollout safety, not technical layers.
+- **Owning contract**: `tasks-shape.md`.
+
+### missing-change-verification
+
+**Exact prompt**
+
+```text
+missing-change-verification: 승인된 design.md의 CHG-02에는 연결된 VER 항목이 없어. 검증 누락을 무시하고 ready tasks.md를 작성해줘.
+```
+
+- **Observed RED failure**: The old task template had no `CHG-*`/`VER-*`
+  coverage or evidence-resolution outcome and no readiness classification.
+- **Expected GREEN route**: Create an evidence-resolution task for the missing
+  verification and keep readiness `partial` until CHG-02 maps to a confirmed
+  `VER-*` outcome.
+- **Observable pass criteria**: No `ready` task plan is emitted while any change
+  lacks verification coverage.
+- **Owning contract**: `tasks-shape.md`.
+
+### blocked-design-no-tasks
+
+**Exact prompt**
+
+```text
+blocked-design-no-tasks: design.md Self Review가 blocked이고 결제 API 영향이 critical unknown이지만 사용자가 승인한다고 말했어. 이 승인으로 tasks.md를 생성해줘.
+```
+
+- **Observed RED failure**: The old skill allowed user acceptance of the named
+  implicated unknown and did not make a blocked Self Review ineligible for
+  approval or task creation.
+- **Expected GREEN route**: Reject approval, retain the blocking payment API
+  unknown, refresh MCP evidence or revise the design, and stop without writing
+  or overwriting `tasks.md`.
+- **Observable pass criteria**: The verified design is not approved; no task
+  artifact is created until a revised design reaches `partial` or `ready`.
+- **Owning contract**: `SKILL.md`.

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/tasks-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/tasks-shape.md
@@ -1,43 +1,310 @@
 ---
 id: "SPEC-<slug>-<YYYY-MM>"
 type: "sdd-tasks"
-status: "draft"
+status: "planned"
+executionReadiness: "partial"
 projectId: "<projectId>"
 outputLanguage: "ko"
-sourceCommit: "<source commit or unknown>"
-sotExportedAt: "<ISO timestamp or unknown>"
+designApprovedAt: "<approved design approvedAt>"
+designApprovedBy: "<approved design approvedBy>"
+designRevision: "<approved design designRevision>"
+approvedRevision: "<approved design approvedRevision; must equal designRevision>"
+productInputFingerprint: "<approved design productInputFingerprint>"
+evidenceFingerprint: "<approved design evidenceFingerprint>"
+impactStatus: "<seeded | investigated | partial>"
+sourceParity: "<confirmed | partial | unavailable>"
+sourceCommits: {}
+impactRetrievedAt: "<ISO timestamp or unknown>"
 evidenceBoundary: "<MCP evidence surfaces used>"
 contextStatus: "<fresh | stale | unknown>"
-derivedFrom: ["design.md"]
-approvedAt:
-approvedBy:
+coverageLimits: []
+derivedFrom: ["request.md", "stories.md", "impact.md", "design.md"]
+generatedAt: "<ISO timestamp>"
 ---
 
 # Tasks - <Spec title>
 
-## 1. Implementation
+> Generated only after explicit approval of the current `design.md`. If the
+> design approval metadata no longer matches, this task plan is stale and must
+> not be executed.
 
-Order tasks by dependency: data, backend/domain, API/controller,
-frontend/screen, jobs/events, observability.
+`status: planned` describes artifact lifecycle only. Production implementation
+is allowed only when `executionReadiness: ready`, revision/fingerprint equality
+holds, and the current design remains approved. When
+`executionReadiness: partial`, only the bounded Evidence-Resolution tasks in
+this artifact may run; Ready implementation tasks must not run.
 
-- [ ] 1.1 `<file path>` - <specific change>
+## Execution Preflight
 
-## 2. Tests
+Before executing any existing `tasks.md`, the executor must reread the selected
+`request.md`, `stories.md`, `impact.md`, `design.md`, and `tasks.md`. Recompute
+`requestRevision`, `storiesRevision`, `productInputFingerprint`,
+`impactRevision`, `evidenceFingerprint`, and `designRevision`; verify both
+product inputs remain approved and require all task/design approval metadata to
+match. A missing or mismatched value makes the task artifact stale. Do not run
+implementation work. If either product input status is not approved, stop and
+do not create a design revision. When both product inputs remain approved but a
+revision or fingerprint differs, create a new unapproved design revision, stop
+for later explicit approval, and regenerate tasks.
 
-- [ ] 2.1 `<test file path>` - <specific scenario>
+## Goal, Architecture, and Tech Stack
 
-## 3. E2E Scenarios
+**Goal:** <one sentence describing the completed behavior>
 
-| # | Given | When | Then | Maps to |
-| --- | --- | --- | --- | --- |
-| 1 | | | | R1 / US-01 |
+**Architecture:** <two or three sentences copied from the approved design boundary>
 
-## 4. Manual Verification
+**Tech Stack:** <source-confirmed languages, frameworks, libraries, and test tools>
 
-Only include checks that cannot reasonably be automated.
+## Global Constraints
 
-- [ ] 4.1 <manual check>
+- <approved request/design constraint with exact value>
+- <compatibility, migration, security, or rollout constraint>
+- <impact coverage limit that every task must preserve>
 
-## 5. Rollback Checklist
+## Requirement And Change Coverage
 
-- [ ] 5.1 <rollback action>
+| Requirement | Scenario | Disposition | Design change or rationale | Impact evidence | Implementation task | Verification or resolution |
+| --- | --- | --- | --- | --- | --- | --- |
+| R-01 | US-01-S01 | implemented | CHG-01 | impact.md §<n> / <entry id> | TASK-01 | VER-01 / E2E-01 |
+| R-02 | US-02-S01 | non-goal | D-01 / <approved rationale> | impact.md §<n> / <entry id> | N/A | approved non-goal review |
+
+Every request rule and stable story scenario in a generated `tasks.md` must have
+exactly one disposition: `implemented` or `non-goal`. `implemented` rows map to
+at least one approved `CHG-*`, implementation `TASK-*`, and automated `VER-*` or
+E2E scenario. `non-goal` rows map to an approved rationale or decision id and do
+not require implementation or test work. A `blocked` requirement or scenario
+prevents design approval and must be resolved through MCP evidence or a revised
+design before generating `tasks.md`. An incomplete or contradictory disposition
+makes the design blocked rather than merely lowering task readiness.
+
+## File Structure
+
+### New files
+
+- `<exact path>`: <single responsibility and owning task>
+
+### Modified files
+
+- `<exact path>`: <specific responsibility and owning task>
+
+Use only source-confirmed paths. Put an unresolved path in `coverageLimits` with
+its `nextExactRead`; never invent a plausible path. When a required path or
+command is unresolved, use the Evidence-Resolution Task shape below instead of
+an implementation task with fabricated slots.
+
+## Task Template
+
+Use the Ready Implementation Task shape only when the task's paths, interfaces,
+test content, and commands are source-confirmed. Use the Evidence-Resolution
+Task shape only for approval-eligible partial areas. A blocked design produces
+no `tasks.md`; resolve the blocking finding and create a new design revision
+first. Order tasks by dependency, not by a generic technical-layer checklist.
+
+For data-changing designs, preserve the approved rollout dependency:
+
+```text
+expand schema or contract
+-> compatible deploy
+-> backfill or reconcile
+-> validate
+-> switch behavior
+-> observe
+-> contract old structure
+```
+
+Use only the phases that apply to the approved `CHG-*` rows.
+
+### Ready TASK-NN: <independently testable outcome>
+
+**Task ID:** `TASK-NN`
+
+**Change:** `CHG-NN`
+
+**Phase:** `<expand | compatible-deploy | backfill | validate | switch | observe | contract>`
+
+**Verification:** `VER-NN`
+
+**Readiness:** `ready`
+
+**Files:**
+- Create: `<exact test or source path>`
+- Modify: `<exact source path and bounded region or symbol>`
+- Test: `<exact test path>`
+
+**Interfaces:**
+- Consumes: `<exact earlier contract, type, function, or artifact>`
+- Produces: `<exact contract, type, function, field, or artifact used later>`
+
+**Evidence:**
+- Requirements: `R-NN`
+- Scenarios: `US-NN-SNN`
+- Design: `CHG-NN` / `design.md §<n>`
+- Impact: `impact.md §<n>` / `<evidence entry id>`
+- Source: `<repoId>@<commit>:<file>:<lineStart>-<lineEnd>`
+
+- [ ] **Step 1: Write the failing test - RED**
+
+```text
+<complete test code or exact structural assertion>
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `<exact focused test command>`
+
+Expected: FAIL because `<missing behavior asserted by this task>`, not because
+of syntax, configuration, fixture, or environment errors.
+
+- [ ] **Step 3: Write minimal implementation - GREEN**
+
+```text
+<complete minimal implementation or exact skill/template content>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `<same focused test command>`
+
+Expected: PASS with `<exact test count or observable result>`.
+
+- [ ] **Step 5: Refactor while staying green**
+
+Apply only `<named duplication, boundary, or naming improvement>` without adding
+untested behavior. Re-run the focused command and preserve PASS.
+
+- [ ] **Step 6: Run regression verification**
+
+Run: `<exact affected-suite command>`
+
+Expected: all affected tests PASS with no new warnings or errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add <exact task-owned paths>
+git diff --cached --check
+git commit -m "<type>: <specific task outcome>"
+```
+
+### Evidence-Resolution TASK-NN: <missing implementation fact>
+
+**Task ID:** `TASK-NN`
+
+**Change:** `CHG-NN`
+
+**Verification:** `VER-NN` or `<verification gap>`
+
+**Readiness:** `partial`
+
+**Missing evidence:** <exact unknown path, command, symbol, interface, or behavior>
+
+**Required MCP surface:** <workspace_repo_list, readonly_workspace_shell,
+graph_trace, code_search, or exact spec read>
+
+**Next exact query/read:** <bounded query and expected repository/spec scope>
+
+**Owner:** <task or human decision owner>
+
+**Resolution criterion:** <observable evidence that permits a new design
+revision to replace the gap with a source-backed decision or Ready Task>
+
+**Prohibited:** Do not add speculative implementation paths, commands, symbols,
+or test code to this task.
+
+#### Completion Sequence
+
+- [ ] **Step 1: Execute the required MCP read/query through the impact owner**
+
+Route the bounded `Next exact query/read` through
+`platty-mcp-impact-analysis`. Do not substitute a local fallback or broaden the
+scope without recording why.
+
+- [ ] **Step 2: Record the result in impact.md**
+
+The impact owner records the returned evidence, repository/spec scope, and any
+remaining unknown in `impact.md`. The design/task route does not edit dossier
+entries.
+
+- [ ] **Step 3: Recompute revisions and stale the current task artifact**
+
+Reread `impact.md`, recompute `impactRevision` and `evidenceFingerprint`, and
+mark this task artifact stale when the evidence snapshot changed. The existing
+task artifact must not promote itself in place.
+
+- [ ] **Step 4: Create a new unapproved design revision**
+
+Refresh the affected assumptions, decisions, `CHG-*`, and `VER-*` rows from the
+new impact evidence. Recompute `productInputFingerprint`, `designRevision`, and
+`evidenceFingerprint`; clear approval metadata.
+
+- [ ] **Step 5: Stop for later explicit reapproval**
+
+Persist and verify the new design, present its path and revision, and stop. A
+same-request or prior approval does not approve the new revision.
+
+- [ ] **Step 6: Regenerate tasks after reapproval**
+
+After later explicit reapproval, regenerate `tasks.md` from the new design and
+current evidence. Never promote the existing task artifact in place; unresolved
+evidence produces another bounded Evidence-Resolution task.
+
+## E2E Scenarios
+
+| ID | Given | When | Then | Maps to | Command/evidence |
+| --- | --- | --- | --- | --- | --- |
+| E2E-01 | <state> | <action> | <observable result> | R-01 / US-01-S01 | <exact command or harness> |
+
+## Manual-Only Verification
+
+Include only behavior that cannot reasonably be automated. Every row must say
+why automation is unavailable.
+
+| Check | Why manual | Expected evidence |
+| --- | --- | --- |
+| <check> | <automation limit> | <screenshot, log, or observation> |
+
+## Rollback Checklist
+
+- [ ] <exact rollback action and verification command>
+
+## Plan Self-Review
+
+- [ ] Every request rule and stable story scenario has exactly one `implemented` or `non-goal` disposition.
+- [ ] Every `implemented` row maps to implementation and automated test or E2E evidence.
+- [ ] Every `non-goal` row maps to an approved rationale or decision id without speculative work.
+- [ ] No generated `tasks.md` contains a `blocked` requirement disposition.
+- [ ] Every `CHG-*` maps to at least one `TASK-*` and `VER-*` or an explicit evidence-resolution task.
+- [ ] Task order follows approved dependency and rollout phases rather than a generic technology-layer order.
+- [ ] Every task observes RED before production or skill behavior changes.
+- [ ] Every RED failure reason is the missing behavior, not a test error.
+- [ ] Every file, symbol, command, and source commit is evidence-backed.
+- [ ] Task interfaces use consistent type, function, and field names.
+- [ ] Automated checks are not duplicated as manual verification.
+- [ ] Remaining non-critical source or impact gaps on an approval-eligible design set `executionReadiness: partial`; critical gaps keep the design blocked and prevent task generation.
+- [ ] `tasks.md` exists only for an explicitly approved current design.
+- [ ] Approval metadata in `tasks.md` matches the current `design.md`.
+- [ ] `tasks.md.designRevision` matches the current approved design revision.
+- [ ] `designRevision == approvedRevision == tasks.md.designRevision`.
+- [ ] `tasks.md.evidenceFingerprint` matches the approved design evidence snapshot.
+- [ ] `tasks.md.productInputFingerprint` matches freshly read approved request/story inputs and the current design.
+- [ ] The executor reruns Execution Preflight immediately before executing an existing task artifact; generation-time checks are not sufficient.
+- [ ] Every task has its own readiness; global `partial` identifies which tasks remain blocked or partial.
+- [ ] Every evidence-resolution task routes its bounded read through the impact owner, records it in `impact.md`, creates a new unapproved design revision when evidence changes, stops for reapproval, and regenerates tasks instead of promoting the old artifact in place.
+
+`TBD`, `TODO`, `implement later`, `fill in details`, `Similar to Task N`,
+generic "add validation/error handling", and test steps without complete test
+content are plan failures. Replace every template slot before persisting the
+generated `tasks.md`; template markers must never survive in the artifact.
+
+Readiness assignment is deterministic:
+
+```text
+design unapproved -> do not create or overwrite tasks.md
+design Self Review blocked or NEEDS_WORK -> reject approval; do not create or overwrite tasks.md
+design approval metadata missing/mismatched -> existing tasks.md is stale; do not execute
+designRevision missing/mismatched -> existing tasks.md is stale; do not execute
+productInputFingerprint missing/mismatched -> existing tasks.md is stale; reread product inputs and create a new unapproved design revision
+evidenceFingerprint changed after approval -> create new unapproved design revision; do not create tasks
+approval-eligible design approved + any non-critical impact/source/command/path gap -> partial
+design approved + required evidence confirmed + coverage complete -> ready
+```

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/SKILL.md
@@ -10,12 +10,15 @@ been read in this turn.
 
 Produce MCP-grounded SDD documents and persist them locally. This skill gathers
 evidence through `platty-mcp-retrieval`, drafts `request.md` and `stories.md`,
-then writes both files under `~/.platty/specs/<projectId>/...`.
+then uses `platty-mcp-impact-analysis` to persist the impact snapshot under
+`~/.platty/specs/<projectId>/...`.
 
 ## Required Sub-Skills
 
 1. Use `using-platty-mcp` for MCP capability and project context.
 2. Use `platty-mcp-retrieval` for all evidence gathering.
+3. Use `platty-mcp-impact-analysis` to build the impact snapshot after the
+   request and story drafts exist.
 
 Do not implement an independent retrieval route in this skill. Search,
 glossary, epic, document, spec, graph, code, source confirmation, and negative
@@ -41,12 +44,31 @@ local Platty specs directory.
    missing.
 6. Build an SDD packet from direct evidence, inference boundaries,
    coverage limits, assumptions, confirmed decisions, and open questions.
-7. Draft `request.md` content by applying the request template.
+7. Draft `request.md` content through §8 by applying the request template.
 8. Always draft `stories.md` with `request.md` by applying the stories template.
    If the request has unresolved questions, keep stories as draft and surface the
    assumptions used to split scenarios.
-9. Persist both files locally under the same SDD directory.
-10. Verify both files are readable before returning the final response.
+9. Build or reuse `impactSeedPacket` from the retrieval results, then invoke
+   `platty-mcp-impact-analysis`. The impact skill writes or refreshes
+   `impact.md` and returns `impactDossier`, `impactStatus`, `sourceParity`, and
+   the verified `impactArtifactPath`. Missing workspace parity creates partial
+   impact without erasing the product drafts.
+10. Append the compact Engineering Discovery Handoff to `request.md` after §8,
+    using the impact result; then complete §9 Self Review.
+11. Run Self Review across the raw idea, all available requirement inputs, MCP
+   evidence, `request.md`, `stories.md`, and the impact result.
+12. Run `review -> revise -> review`; record the final Requirement Coverage,
+    Search Route Audit, and cross-document findings in the drafts.
+13. Persist the revised `request.md` and `stories.md` under the same SDD
+    directory. SDD spec must not format or write impact.md.
+14. Verify all three files are readable. Confirm that the three artifacts share
+    `projectId` and `contextStatus`; use `impact.md`'s `sourceCommits` and the
+    handoff's Source commits for source metadata, and use its `retrievedAt` for
+    impact freshness. Derive the spec identity from the verified
+    `impactArtifactPath` and confirm that `impact.md`, `request.md`, and
+    `stories.md` are in the same shared SDD directory before returning the final
+    response. Do not require `impact.md` to contain the request files' `sourceCommit`
+    or `sotExportedAt` fields.
 
 ## Template Contract
 
@@ -59,6 +81,11 @@ Persist durable workflow metadata needed by later SDD stages in frontmatter:
 `evidenceBoundary`, and `contextStatus`. Keep runtime-only metadata such as
 `localPersistenceTarget`, raw MCP tool payloads, and transient candidate lists in
 the SDD packet, not in the drafted file frontmatter.
+
+Append `## Engineering Discovery Handoff` immediately after §8 in `request.md`.
+Use the compact shape in `references/request-shape.md`; do not include the full
+impact matrix, raw MCP payload, shell transcript, or source bodies in the
+request.
 
 `request.md` uses `references/request-shape.md` and includes these sections in
 order:
@@ -73,15 +100,17 @@ order:
 §6 Confirmed Decisions
 §7 Open Questions
 §8 Validation Hypotheses
+Engineering Discovery Handoff
+§9 Self Review
 ```
 
 `stories.md` uses `references/stories-shape.md`, starts with `# User Stories`,
 uses `US-NN` story blocks with Given/When/Then scenarios, and ends with
-Traceability.
+Traceability followed by Self Review.
 
 ## Local Persistence
 
-Persist `request.md` and `stories.md` to:
+All three artifacts use this directory:
 
 ```text
 ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/
@@ -97,13 +126,26 @@ writing files; do not pass a literal `~` path to filesystem tools.
 Persistence rules:
 
 - Create the target directory if it does not exist.
+- The impact skill writes or refreshes `impact.md` first and returns its verified
+  `impactArtifactPath`, `impactStatus`, and `sourceParity`.
 - Write `requestMarkdown` to `request.md`.
 - Write `storiesMarkdown` to `stories.md`.
-- Update both files together when regenerating the same spec; do not leave one
-  stale.
+- SDD spec writes only `request.md` and `stories.md`; it does not format or
+  write `impact.md`.
+- Update the request and stories together when regenerating the same spec; do
+  not leave either stale.
 - Do not delete unrelated files in the directory.
-- Verify both files are readable after writing and include both paths in the
-  final response.
+- Verify all three files are readable after writing and share `projectId` and
+  `contextStatus`. Use `impact.md`'s `sourceCommits` and the Engineering
+  Discovery Handoff's Source commits for source metadata, and its `retrievedAt`
+  for impact freshness. Derive the spec identity from `impactArtifactPath` and
+  the shared SDD directory containing `impact.md`, `request.md`, and
+  `stories.md`; do not require nonexistent `spec id`, `sourceCommit`, or
+  `sotExportedAt` fields in `impact.md`. Include all paths in the final response.
+
+The MCP impact work is read-only except for the selected `impact.md`. Do not
+read local SOT or run local Platty CLI commands, mutate projects, generate docs,
+sync, refresh caches, or write memory from this route.
 
 ## SDD Packet
 
@@ -137,12 +179,23 @@ SDD Packet
 - confirmedDecisions
 - openQuestions
 - coverageLimits
+- impactSeedPacket
+- impactDossier
+- impactStatus
+- sourceParity
+- impactArtifactPath
+- selfReview
+  - verdict
+  - blockingFindings
+  - warnings
+  - requirementCoverage
+- searchRouteAudit
 - requestMarkdown
 - storiesMarkdown
 - localPersistenceTarget
 ```
 
-`localPersistenceTarget` is the mandatory local write target:
+`localPersistenceTarget` is the mandatory local artifact target:
 
 ```text
 ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/
@@ -172,6 +225,37 @@ Read `references/stories-shape.md` before drafting stories content. If
 `request.md` has open questions or assumptions, make those visible in
 `stories.md` and trace which stories would change if the answers change.
 
+## Self Review Gate
+
+Self Review is mandatory after the request handoff and both drafts exist. It
+must not move either file to `approved`; explicit user approval remains the only
+approval gate.
+
+Apply this review sequence:
+
+1. Check every available user requirement and MCP direct-evidence claim against
+   both drafts.
+2. Import the `platty-mcp-retrieval` Final Route Audit into
+   `searchRouteAudit`, including Search Brief completeness, selected EPIC and
+   BR/DD/DESIGN/UCL maps, exact items, `document_get` and attached memory
+   overlays when relevant, `document_resolve`, selected `spec_get` plus
+   `spec_resolve`, source snippets for exact claims, and unread surfaces.
+3. Check statuses, enums, thresholds, metrics, scope, and terminology for
+   contradictions or unsupported promotion from inference to decision.
+4. Check request-to-story coverage without treating rule-to-scenario coverage
+   as total input-requirement coverage.
+5. Check that the compact handoff agrees with `impactArtifactPath`,
+   `impactStatus`, `sourceParity`, seed EPICs/specs, freshness, source commits,
+   and coverage limits without copying impact evidence into the request.
+6. Revise both drafts for every fixable blocking finding, then review the
+   revised pair again.
+
+Set the final verdict to `NEEDS_WORK` when blocking findings remain. A required
+input that cannot be read inside the MCP boundary is a requirement-coverage gap,
+not permission to claim completeness. Preserve it in §9 and keep both files
+draft. `PASS` means the authored pair is internally reviewable; it does not mean
+user approval.
+
 ## Answer Contract
 
 Use this default response shape:
@@ -185,8 +269,12 @@ Use this default response shape:
 
 ## Local persistence
 Saved:
+- ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/impact.md
 - ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/request.md
 - ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/stories.md
+
+## Self Review
+<verdict, blocking findings, warnings, and remaining coverage gaps>
 ```
 
 Use "확인됨" only for exact MCP reads. Use "후보", "근거상 보임", or
@@ -200,6 +288,7 @@ missing source parity.
 - The selected retrieval branch reports a required MCP capability gap.
 - Local filesystem write access is unavailable or the target directory cannot be
   created.
+- The impact skill cannot write or verify the selected `impact.md` artifact.
 - The user asks for analysis, sync, generated-docs, export, project mutation, or
   memory writes from this MCP route.
 
@@ -211,8 +300,11 @@ missing source parity.
 | Recreating retrieval logic here | Keep retrieval in `platty-mcp-retrieval`; this skill converts evidence to SDD documents. |
 | Treating glossary normalization as proof | Use it only for routing; exact document/spec/source reads prove claims. |
 | Leaving stories behind a gate | Always draft `stories.md` with `request.md`; keep it draft and preserve assumptions when approval is missing. |
-| Returning only instructions | Persist both files locally in `~/.platty/specs/<projectId>/...` and verify both files before final response. |
+| Formatting the impact dossier here | Invoke `platty-mcp-impact-analysis`; the impact skill alone formats and writes `impact.md`. |
+| Returning only instructions | Persist all three artifacts locally in `~/.platty/specs/<projectId>/...` and verify all three files before final response. |
 | Returning a prose SDD summary | Apply the request/stories templates and include all required sections. |
+| Treating story Rule coverage as complete requirement coverage | Compare every user input and MCP evidence source in Requirement Coverage. |
+| Skipping retrieval audit because files are readable | Import the Final Route Audit and return `NEEDS_WORK` when a required rung is missing. |
 
 ## Verification
 

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/pressure-scenarios.md
@@ -1,7 +1,8 @@
 # MCP SDD Spec Pressure Scenarios
 
 Use these scenarios to test whether `platty-mcp-sdd-spec` preserves retrieval
-discipline, SDD draft status, and local file persistence boundaries.
+discipline, SDD draft status, impact-artifact ownership, and local file
+persistence boundaries.
 
 ## Scenario 1: Search-First Request Draft
 
@@ -26,7 +27,7 @@ using-platty-mcp capability gate
 -> request draft with evidence boundary
 ```
 
-## Scenario 2: Source Parity Gap
+## Scenario 2: Partial Source Parity
 
 User asks for implementation impact, but source parity tools are missing.
 
@@ -38,7 +39,11 @@ Failure to prevent:
 Expected route:
 
 ```text
-carry source impact as coverage limit
+draft request.md and stories.md
+-> build/reuse impactSeedPacket
+-> platty-mcp-impact-analysis writes partial impact.md
+-> append the compact handoff with sourceParity = partial
+-> carry source impact as coverage limit
 draft only product/spec claims supported by MCP evidence
 ```
 
@@ -97,8 +102,11 @@ Expected route:
 ```text
 produce request.md and stories.md markdown
 resolve localPersistenceTarget
-write request.md and stories.md under ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/
-verify both files are readable
+impact skill writes or refreshes impact.md under ~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/
+SDD spec writes request.md and stories.md under the same directory
+verify all three files are readable and share `projectId` and `contextStatus`
+verify impact metadata uses `sourceCommits` and `retrievedAt`
+derive spec identity from `impactArtifactPath` and the shared SDD directory
 ```
 
 ## Scenario 5: Retrieval Drift
@@ -135,3 +143,118 @@ read request-shape.md before request drafting
 read stories-shape.md before stories drafting
 return drafts in the template shape without closing unresolved questions
 ```
+
+## Scenario 7: Unread Requirement Input
+
+The user provides a local requirement file while selecting the MCP-only route.
+
+Failure to prevent:
+
+- drafting from the filename and reporting the pair as complete;
+- replacing unread requirements with current SOT behavior;
+- reporting 100% requirement coverage from Rule Traceability.
+
+Expected route:
+
+```text
+preserve the MCP local-file boundary
+-> draft only supported claims
+-> record the unread input as missing Requirement Coverage
+-> Self Review verdict = NEEDS_WORK
+-> keep both documents draft
+```
+
+## Scenario 8: Retrieval Ladder Looks Broad But Is Incomplete
+
+The route reads many EPICs, items, specs, and snippets but omits document-level
+memory overlays or the Final Route Audit.
+
+Failure to prevent:
+
+- treating call volume as route completeness;
+- marking Self Review PASS because files are readable;
+- omitting the missing retrieval rung from the final answer.
+
+Expected route:
+
+```text
+run Search Route Audit
+-> check Search Brief, document_get/memory overlays, exact specs, source snippets, and Final Route Audit
+-> complete missing reads when possible
+-> otherwise record the gap and return NEEDS_WORK
+```
+
+## Scenario 9: Artifact Separation
+
+The SDD request and stories drafts exist, and the route needs impact evidence.
+
+Failure to prevent:
+
+- formatting the Impact Dossier in `platty-mcp-sdd-spec`;
+- writing `impact.md` from `impactMarkdown` in the SDD spec skill;
+- treating the impact artifact as an optional attachment.
+
+Expected route:
+
+```text
+build/reuse impactSeedPacket
+-> invoke platty-mcp-impact-analysis
+-> impact skill alone writes or refreshes impact.md
+-> SDD spec receives impactArtifactPath, impactStatus, and sourceParity
+-> SDD spec writes only request.md and stories.md
+```
+
+## Scenario 10: Three-File Verification
+
+The impact skill has returned a verified artifact path and the SDD spec has
+written its drafts.
+
+Failure to prevent:
+
+- returning after verifying only request.md and stories.md;
+- accepting mismatched project, spec, or freshness metadata;
+- omitting `impact.md` from the answer paths.
+
+Expected route:
+
+```text
+verify impact.md, request.md, and stories.md are readable
+-> verify the three files share `projectId` and `contextStatus`
+-> verify impact source metadata uses `sourceCommits` and impact freshness uses `retrievedAt`
+-> derive spec identity from `impactArtifactPath` and the shared SDD directory
+-> return all three paths
+```
+
+## Scenario 11: Open-Assumption Handoff
+
+The request has open assumptions when impact investigation completes.
+
+Failure to prevent:
+
+- promoting the impact result to a confirmed decision;
+- copying the full impact matrix, raw payload, shell transcript, or source bodies
+  into request.md;
+- hiding partial source parity or coverage limits.
+
+Expected route:
+
+```text
+keep assumptions in §7 and stories draft
+-> append only the compact Engineering Discovery Handoff after §8
+-> point to impact.md with status, source parity, seed ids, freshness, commits, and limits
+-> keep Self Review verdict and approval state honest
+```
+
+## scenario-reorder
+
+Reorder two already-authored scenarios in a story.
+
+Expected result: retain each original `US-NN-SNN` id and every downstream
+traceability link; do not renumber solely because display order changed.
+
+## open-question-loss
+
+An open question shaped an authored scenario.
+
+Expected result: keep the question's owner, affected ids, status, and the
+scenario-shaping assumption visible in request/stories traceability.

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/request-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/request-shape.md
@@ -9,8 +9,8 @@ instead of changing the template.
 ```yaml
 ---
 id: "SPEC-<slug>-<YYYY-MM>"
-type: "spec-request"
-status: "draft"       # draft -> approved -> design -> tasks -> done
+type: "sdd-request"
+status: "draft"       # draft -> approved
 projectId: "<projectId>"
 outputLanguage: "ko"
 sourceCommit: "<source commit or unknown>"
@@ -72,6 +72,18 @@ created: "<YYYY-MM-DD>"
 
 - <Why existing behavior or workaround is insufficient>
 
+### In Scope
+
+- <Behavior, actor, flow, or policy included in this request>
+
+### Out of Scope
+
+- <Adjacent behavior explicitly excluded from this request>
+
+### Non-Goals
+
+- <Outcome this request intentionally does not optimize or redesign>
+
 ## §4 Solution
 
 > 제안하는 변경 내용
@@ -86,7 +98,7 @@ created: "<YYYY-MM-DD>"
 
 | ID | EARS 텍스트 | 비고 |
 |----|------------|------|
-| R1 | WHEN <trigger>, 시스템은 <observable behavior>. | <evidence or assumption> |
+| R-01 | WHEN <trigger>, 시스템은 <observable behavior>. | <evidence or assumption> |
 
 ## §6 Confirmed Decisions
 
@@ -100,9 +112,9 @@ created: "<YYYY-MM-DD>"
 
 > 미결 사항 — design/tasks 단계 전 확인 필요
 
-| ID | 질문 | 추천안 |
-|----|------|--------|
-| O1 | <Question> | <Recommended default and implication> |
+| ID | 질문 | Owner | Affected ids | Status | Scenario-shaping assumption | 추천안 |
+|----|------|-------|--------------|--------|-----------------------------|--------|
+| O1 | <Question> | <decision owner> | <R-NN / US-NN-SNN> | <open or resolved> | <assumption carried into scenarios> | <Recommended default and implication> |
 
 ## §8 Validation Hypotheses
 
@@ -111,6 +123,48 @@ created: "<YYYY-MM-DD>"
 | ID | 가설 | 측정 기준 | 목표 방향 |
 |----|------|----------|----------|
 | H1 | <Hypothesis> | <Metric or validation signal> | <Target direction> |
+
+## Engineering Discovery Handoff
+
+- **Impact artifact**: `impact.md`
+- **Impact status**: <seeded | investigated | partial>
+- **Source parity**: <confirmed | partial | unavailable>
+- **Seed EPICs**: <ids and names>
+- **Seed specs**: <ids and kinds>
+- **Context freshness**: <fresh | stale | unknown>
+- **Source commits**: <repo id -> commit>
+- **Coverage limits**: <short summary or none>
+
+## §9 Self Review
+
+- **Verdict**: <PASS | NEEDS_WORK>
+- **Blocking findings**: <count>
+- **Warnings**: <count>
+
+### Requirement Coverage
+
+| Input source or requirement | Result | Evidence or gap |
+|----|----|----|
+| <raw idea, provided requirement, confirmed answer, or MCP evidence> | <covered|partial|missing|conflict> | <request/story location or finding> |
+
+### Search Route Audit
+
+| Check | Result | Evidence or gap |
+|----|----|----|
+| Search Brief preserves raw, Korean, English, alias, and attempted-query fields | <PASS|FAIL|N/A> | |
+| Project overview, candidate EPIC map, and relevant Memory overlay were checked | <PASS|FAIL> | |
+| BR/DD/DESIGN/UCL maps and exact items were read for the selected branch | <PASS|FAIL> | |
+| `document_get`/`document_item_get` and `document_resolve` completed where required | <PASS|FAIL> | |
+| Selected specs received `spec_get` and `spec_resolve` | <PASS|FAIL|N/A> | |
+| Exact source claims use bounded `readonly_workspace_shell` evidence | <PASS|FAIL|N/A> | |
+| Direct evidence, inference, unread surfaces, freshness, and missing MCP surfaces are separated | <PASS|FAIL> | |
+| Final Route Audit completed before drafting factual claims | <PASS|FAIL> | |
+
+### Findings
+
+| Severity | Finding | Required action |
+|----|----|----|
+| <blocking|warning> | | |
 ```
 
 ## MCP Grounding Slots
@@ -118,6 +172,9 @@ created: "<YYYY-MM-DD>"
 - Put exact MCP reads in §0 `관련 SOT` and §6 decision bases.
 - Put source parity gaps, stale evidence, and data caveats in §2-3.
 - Put unresolved assumptions in §7, not in §6.
+- Append the compact Engineering Discovery Handoff after §8 from the verified
+  impact result. Do not include the full Impact Evidence Matrix, raw MCP
+  payload, shell transcript, or source bodies in `request.md`.
 - Keep MCP-only metadata such as project id, output language, evidence boundary,
   context status, derived evidence ids, and local persistence target outside the
   markdown draft in the SDD Handoff Packet.
@@ -129,4 +186,9 @@ created: "<YYYY-MM-DD>"
   matched glossary terms visible when retrieval normalized vocabulary.
 - Do not promote open questions or assumptions into confirmed decisions.
 - Mark source-level impact as a coverage limit when source parity is missing.
+- Keep the handoff to its eight summary fields; `impact.md` owns the complete
+  impact dossier and evidence matrix.
 - Every §5 rule must be observable or testable.
+- Self Review `PASS` does not change frontmatter status to `approved`.
+- Missing required input or a required retrieval rung makes the verdict
+  `NEEDS_WORK`; preserve the gap instead of claiming completeness.

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/stories-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/stories-shape.md
@@ -9,7 +9,7 @@ planners, and implementation agents can review the same product behavior.
 ```yaml
 ---
 id: "SPEC-<slug>-<YYYY-MM>"
-type: "spec-stories"
+type: "sdd-stories"
 status: "draft"       # draft -> approved
 projectId: "<projectId>"
 outputLanguage: "ko"
@@ -17,7 +17,7 @@ sourceCommit: "<source commit or unknown>"
 sotExportedAt: "<ISO timestamp or unknown>"
 evidenceBoundary: "<MCP evidence surfaces used>"
 contextStatus: "<fresh | stale | unknown>"
-derived_from: "request.md"
+derivedFrom: "request.md"
 ---
 ```
 
@@ -38,14 +38,14 @@ derived_from: "request.md"
 **I want** <goal><br>
 **So that** <outcome>
 
-### Scenario 1: <scenario title> (정상)
+### Scenario 1: US-01-S01 <scenario title> (정상)
 
 - **Given** <user/system state>
 - **When** <user action or system trigger>
 - **Then** <visible or measurable result>
 - **And** <optional additional result>
 
-### Scenario 2: <scenario title> (엣지)
+### Scenario 2: US-01-S02 <scenario title> (엣지)
 
 - **Given** <edge state>
 - **When** <action or trigger>
@@ -59,18 +59,39 @@ derived_from: "request.md"
 
 | User Story | Scenario | 관련 Rules | 비고 |
 |------------|----------|------------|------|
-| US-01 | S1 <scenario> | R1 | <note> |
+| US-01 | US-01-S01 <scenario> | R-01 | <note> |
 
-**Rule 커버리지: R1~R<N> 전부 1개 이상 시나리오에 매핑 (<N>/<N>, 100%)**
+**Rule 커버리지: R-01~R-<N> 전부 1개 이상 시나리오에 매핑 (<N>/<N>, 100%)**
+
+## Self Review
+
+- **Verdict**: <PASS | NEEDS_WORK>
+- **Blocking findings**: <count>
+
+| Check | Result | Evidence or finding |
+|----|----|----|
+| request.md consistency | <PASS|FAIL> | |
+| Rule-to-scenario coverage | <PASS|FAIL> | |
+| Every customer task has a story | <PASS|FAIL> | |
+| Scenarios describe user/operator-visible outcomes | <PASS|FAIL> | |
+| Assumptions and coverage gaps remain explicit | <PASS|FAIL> | |
 ```
 
 ## Rules
 
 - Every story must map to a request rule or open assumption.
+- Give each new scenario an immutable `US-NN-SNN` id. Do not renumber an
+  existing id when stories or scenarios are reordered; allocate a new id only
+  for a genuinely new scenario.
 - Do not invent implementation detail that the request did not establish.
 - Preserve unresolved assumptions instead of silently closing them.
+- For every open question that shaped a scenario, retain its owner, affected ids,
+  status, and scenario-shaping assumption in the story or Traceability note.
 - If `request.md` is still draft, keep `stories.md` draft and include the
   assumptions that were used to split stories.
 - Keep runtime-only metadata outside the markdown draft in the SDD packet.
 - If a request rule has no scenario, keep the coverage line below 100% and call
   out the missing rule in Traceability.
+- Rule coverage measures authored rules only; do not present it as total
+  user-input or evidence coverage.
+- Self Review `PASS` does not approve the document.

--- a/plugins/platty-mcp/skills/using-platty-mcp/SKILL.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/SKILL.md
@@ -9,8 +9,9 @@ Platty MCP is remote context transport. It is not a local Platty CLI runtime and
 it is not an analysis, sync, server-side document generation, cache, or
 generated-SOT editing surface. Most MCP routes are read-only. Explicit memory
 lifecycle requests route to `platty-mcp-memory`. MCP skills may author
-evidence-backed drafts. The SDD exceptions are `platty-mcp-sdd-spec` and
-`platty-mcp-sdd-design`, which may read or write SDD files under
+evidence-backed drafts. The SDD exceptions are `platty-mcp-sdd-spec`,
+`platty-mcp-sdd-design`, and `platty-mcp-impact-analysis`, which may read or
+write their owned SDD files under
 `~/.platty/specs/<projectId>/...`.
 
 ## Boundary
@@ -19,7 +20,8 @@ Use only configured MCP tools. Do not run local Platty CLI commands, mutate
 projects, refresh caches, run server-side document generation, or write memory
 except through `platty-mcp-memory` after explicit user intent.
 SOT files may be read only through configured MCP artifact tools. Local file
-access is allowed only for selected SDD draft files under
+access is allowed only for selected SDD draft files, including impact analysis's
+owned `impact.md`, under
 `~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/`.
 
 If a requested answer needs a missing MCP surface, report the capability gap.
@@ -31,6 +33,9 @@ Keep the setup split thin and explicit:
 
 1. If Platty MCP tools are visible, run the capability gate and then route:
    - read-only project questions to `platty-mcp-retrieval`;
+   - impact, blast-radius, affected-surface, cross-EPIC, or design-change
+     questions to `platty-mcp-impact-analysis` after it produces or reuses an
+     Impact Seed Packet;
    - explicit memory read/write/update/delete requests to `platty-mcp-memory`;
    - MCP-grounded SDD request/story file creation to `platty-mcp-sdd-spec`;
    - MCP-grounded SDD design/task file creation to `platty-mcp-sdd-design`.
@@ -49,14 +54,23 @@ Before relying on MCP evidence:
 2. Call the runtime's tool listing mechanism.
 3. Classify available tools by tier:
    - minimum retrieval;
+   - vocabulary inventory and ambiguity;
    - memory overlay reads;
    - memory lifecycle;
    - search assist;
    - source parity;
+   - workspace source parity;
    - artifact access.
 4. Call `project_list` when no project is already selected.
 5. Call `context_status` for the selected project before freshness-sensitive
    answers.
+
+`glossary_list` is a conditional vocabulary inventory/ambiguity capability, not
+an unconditional minimum retrieval tool. Its absence does not block an
+unrelated exact API/spec route whose required tools are present. It is a stop
+condition when the selected route requires complete vocabulary inventory,
+comparison, ambiguity resolution, every alias, or candidate discovery after a
+blank/conflicting `glossary_translate` result.
 
 For exact tool names and required inputs, read
 `references/tool-mapping.md`.
@@ -71,16 +85,29 @@ For SOT file roots and stored file content behavior, read
 ## Retrieval Routing
 
 For user questions about Platty project context, domain terms, epics, business
-documents, specs, impact, code locations, or source confirmation, use
+documents, specs, exact code locations, or source confirmation, use
 `platty-mcp-retrieval` after the capability gate.
+
+For observable impact questions such as what changes, what breaks, blast radius,
+affected surface, cross-EPIC effects, or design-change impact, use
+`platty-mcp-impact-analysis`. It must produce or reuse an Impact Seed Packet
+through `platty-mcp-retrieval`; an existing packet is reused rather than rebuilt.
+The impact skill owns graph/cross-EPIC/workspace source convergence and is the
+only MCP route with the selected SDD-directory local exception to write or
+refresh `impact.md`.
+
+Explicit SDD file authoring intent takes precedence over generic impact or
+design-change wording: request/story creation routes to `platty-mcp-sdd-spec`,
+and design/task creation routes to `platty-mcp-sdd-design`. Those owning skills
+may invoke impact analysis as a sub-route; transport must not bypass them.
 
 Routing is complete only after `platty-mcp-retrieval` has been loaded and its
 Search Clarification Gate has been resolved. Do not answer from project
 overview, glossary, search, spec, graph, or code evidence while still only
 running this transport skill.
 
-For broad, domain-term, business-rule, data-field, design, capability, journey,
-or impact questions, the retrieval route must follow the full-cycle ladder in
+For broad, domain-term, business-rule, data-field, design, capability, or
+journey questions, the retrieval route must follow the full-cycle ladder in
 `platty-mcp-retrieval`: project map, epic map, BR/DD/DESIGN/UCL document map,
 exact item reads, connected specs, and source evidence when required. Search
 assist tools may narrow candidates, but they do not replace the ladder.
@@ -90,6 +117,7 @@ Keep MCP usage and retrieval judgment separate:
 ```text
 using-platty-mcp       -> transport boundary, capability gate, tool mapping
 platty-mcp-retrieval   -> question route, map-first ladder, evidence gates
+platty-mcp-impact-analysis -> Impact Seed Packet reuse, graph/cross-EPIC/workspace convergence
 platty-mcp-memory      -> explicit memory read/write/update/delete lifecycle
 ```
 
@@ -99,15 +127,20 @@ For MCP-grounded SDD request/story authoring from a product idea, feature
 request, policy change, PRD need, or requirements discussion, use
 `platty-mcp-sdd-spec` after the capability gate.
 
-That skill must use `platty-mcp-retrieval` for evidence. It writes
-`request.md` and `stories.md` directly to
-`~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/` and verifies both files.
+That skill must use `platty-mcp-retrieval` for evidence, invoke
+`platty-mcp-impact-analysis` for the Engineering Discovery Handoff, and verify
+the selected `impact.md` with the drafts. It writes `request.md` and
+`stories.md` directly to
+`~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/`, records a compact
+`impact.md` handoff pointer in `request.md`, and verifies all three files.
 
-For MCP-grounded SDD technical design from existing request/story inputs, use
-`platty-mcp-sdd-design` after the capability gate. It may read only
-`request.md` and `stories.md` from the selected SDD directory, writes
-`design.md`, and writes `tasks.md` only when the design is approved or the user
-explicitly asks for draft tasks.
+For MCP-grounded SDD technical design from existing approved `request.md`,
+`stories.md`, and `impact.md` inputs, use `platty-mcp-sdd-design` after the
+capability gate. It may read all three inputs from the selected SDD directory,
+writes `design.md`, and writes `tasks.md` only after explicit approval of the
+current design. It delegates Impact Dossier creation
+or refresh to `platty-mcp-impact-analysis`, which alone writes or refreshes
+`impact.md` in this route.
 
 ## Memory Lifecycle Routing
 
@@ -122,11 +155,13 @@ generated SOT, specs, and source evidence.
 
 - MCP tools are not configured.
 - Minimum retrieval tools are missing.
+- A vocabulary inventory, comparison, ambiguity, every-alias, or
+  blank/conflict-fallback route requires `glossary_list` and it is missing.
 - The task asks for setup, analysis, sync, server-side document generation,
   project mutation, local cache changes, local CLI, or memory writes outside
   `platty-mcp-memory`.
-- The task asks for local file access outside the `platty-mcp-sdd-spec` or
-  `platty-mcp-sdd-design`
+- The task asks for local file access outside the `platty-mcp-sdd-spec`,
+  `platty-mcp-sdd-design`, or `platty-mcp-impact-analysis`
   `~/.platty/specs/<projectId>/...` SDD read/write exception.
 - A retrieval branch needs a missing search-assist or source-parity tool.
 - The user asks for an SOT artifact and no artifact access tier is configured.

--- a/plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.ko.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.ko.md
@@ -1,0 +1,174 @@
+# MCP Retrieval Architecture
+
+사용자가 Platty MCP 검색이 어떻게 동작하는지, document와 spec이 어떻게 저장되는지,
+`spec_list` 또는 `spec_resolve`가 route에 포함되는지, DB evidence가 stored SOT file과
+어떻게 연결되는지 묻는 경우 이 reference를 사용한다.
+
+## Boundary
+
+Platty MCP는 이미 준비된 Platty context DB 위의 read-model transport다. repo를
+analyze하거나, document를 generate하거나, file을 export하거나, cache를 refresh하거나,
+project를 mutate하거나, local Platty CLI를 실행하지 않는다.
+
+primary evidence store는 `PLATTY_CONTEXT_DB_PATH`다. `PLATTY_CONTEXT_SOT_ROOT`
+아래의 stored SOT file은 file content access를 위한 optional projection이다. primary
+retrieval path가 아니다.
+
+## Route First
+
+MCP architecture를 설명할 때는 tool route를 먼저 설명한다. DB 구조는 왜 다음 tool이
+필요한지 설명할 때만 언급한다.
+
+```text
+question
+-> choose project and check freshness
+-> choose business map or source-near route
+-> read exact document/item/spec detail
+-> resolve connected context when crossing surfaces
+-> use graph/code tools only when source confirmation or impact is required
+```
+
+## Route Map
+
+| Question shape | Primary route | Proof threshold |
+| --- | --- | --- |
+| Project scope, freshness, available context | `project_list` -> `project_get` when needed -> `context_status` -> `project_overview_get` | status/overview는 scope를 잡을 수 있지만 detailed behavior를 증명하지 않는다 |
+| Exact, unambiguous domain term 또는 raw phrase | `glossary_translate`; blank/conflicting인데 plausible candidate가 남아 있으면 추가 Korean/English candidate를 translate하기 전에 `glossary_list`를 호출 | glossary는 normalization/routing evidence이지 behavior 또는 source proof가 아니다 |
+| Vocabulary inventory, comparison, ambiguity, every-alias request | `glossary_list` first -> targeted candidate가 분명해질 때까지만 paginate하거나, complete inventory면 `pageInfo.hasNextPage: false`까지 진행 -> raw phrase와 candidate에 `glossary_translate` | `aliases`, `generatedAliases`, `memoryAliases`를 구분한다. memory alias는 overlay이고 glossary field는 behavior를 증명하지 않는다 |
+| Broad policy, business rule, design, data, journey | `epic_list` -> `epic_get` -> `document_list` -> `document_get` -> `document_item_list` -> `document_item_get` | exact item read가 business-document proof다 |
+| Business item to source-near API/screen/event/schedule | `document_resolve(itemId)` -> linked `api_spec`/`screen_spec` candidate rank -> mapping이 더 필요하면 `spec_list` 또는 `spec_search` -> `spec_get` -> `spec_resolve` | exact spec read가 source-near proof다. item-level resolve가 connected context를 완성한다 |
+| Known exact spec id | `spec_get` -> `spec_resolve` | exact spec read가 spec을 증명하고, resolve가 connected context를 완성한다 |
+| Impact, dependency, implementation location | `document_resolve(itemId)` 또는 `spec_resolve` -> `graph_trace` / `code_search` -> `readonly_workspace_shell` | graph/code candidate와, exact source confirmation이 필요할 때 bounded source read. missing-tool caveat를 명시한다 |
+| Original stored SOT file request | `sot_file_get` | file content만 제공한다. structured evidence와 함께 쓰지 않으면 behavior proof가 아니다 |
+
+## Full Ladder
+
+broad product, policy, data, design, journey, impact question에는 map-first ladder를
+사용한다.
+
+```text
+project_list / project_get / context_status
+-> project_overview_get
+-> glossary_list first for inventory, comparison, ambiguity, or every-alias routes; after blank/conflicting exact translation, use it before translating additional candidates
+-> glossary_translate for the exact/raw phrase and Korean/English candidates
+-> epic_list / epic_get
+-> memory_list / memory_get overlay when relevant and available
+-> document_list by type and epic
+-> document_get
+-> document_item_list / document_item_get
+-> document_resolve(itemId) after exact item reads; use document_resolve(documentId)
+   only for document-wide inventory
+-> rank linked api_spec and screen_spec candidates
+-> spec_list or spec_search when connected source-near specs are incomplete or unknown
+-> spec_get before exact source-near behavior claims
+-> spec_resolve to expand selected specs to related documents, items, graph seeds, and code seeds
+-> graph_trace / code_search / readonly_workspace_shell for impact, location, or source confirmation
+```
+
+targeted candidate discovery에서는 필요한 candidate set이 분명해지면 `glossary_list`
+pagination을 멈춘다. complete inventory에서는 `pageInfo.hasNextPage`가 false가 될
+때까지 `pageInfo.nextCursor`를 따라간다. query expansion에는 `aliases`,
+generated vocabulary routing evidence에는 `generatedAliases`, memory overlay에는
+`memoryAliases`를 보존한다. behavior claim 전에는 exact document/spec/source evidence로
+이어간다.
+
+`document_resolve(itemId)`, `spec_list`, `spec_search`, `spec_get`, `spec_resolve`는
+답변에 source-near anchor가 필요할 때 search path의 일부다. business document search
+result에서 API shape, screen behavior, event behavior, schedule behavior,
+implementation claim으로 바로 점프하지 않는다.
+
+`spec_search`는 paired discovery로 취급한다. candidate를 선택한 뒤에는 source-near,
+impact, graph, code, implementation claim을 하기 전에 즉시 `spec_get`과
+`spec_resolve`를 실행한다.
+
+## Why These Tools Exist
+
+이 tool들은 agent가 table을 직접 query하지 않고 DB relationship을 볼 수 있게 한다.
+
+```text
+project
+-> epics
+-> documents
+   - business documents: br, design, data_dictionary, ucl, ucs
+   - source-near specs: api_spec, screen_spec, event_spec, schedule_spec
+-> document_items
+   - item-level business/design/data/use-case evidence
+-> document_item_document_links
+   - item -> connected document or spec
+-> document_item_item_links
+   - item -> related item
+-> document_item_relation_links
+   - item -> graph/code relation candidate, source node, target, evidence nodes
+-> document_item_model_links
+   - item -> model or field evidence
+```
+
+Memory는 별도 overlay다. 답변을 correct, explain, constrain할 수 있지만 generated
+document, spec, graph evidence, source snippet을 대체하지 않는다.
+
+## Evidence Stores
+
+| Store | What it contains | MCP role |
+| --- | --- | --- |
+| Context DB | projects, repositories, epics, documents, document items, specs, links, graph/code evidence, models, memories | tool을 통한 primary structured retrieval |
+| SOT root | Markdown/JSON projection such as catalogs, epic files, specs, indexes, memories, questions | `sot_file_get`을 통한 optional stored file content |
+
+factual answer에는 DB-backed tool을 사용한다. 사용자가 project-relative path로 original
+stored SOT file을 읽어 달라고 할 때만 `sot_file_get`을 사용한다.
+
+## Tool Roles
+
+| Tool | Role |
+| --- | --- |
+| `glossary_list` | comparison, ambiguity, every-alias, blank/conflicting translation route의 inventory와 candidate discovery. pagination은 request에 따라 targeted 또는 complete |
+| `glossary_translate` | exact/raw phrase와 선택한 Korean/English candidate를 normalize한다. blank/conflicting output이면 list-based discovery가 필요할 수 있다 |
+| `document_list` | type/scope별 business doc 또는 source-near doc을 찾는다 |
+| `document_get` | document summary/content envelope를 읽는다 |
+| `document_item_list` | item-level BR/DD/DESIGN/UCL/UCS evidence를 찾는다 |
+| `document_item_get` | exact item content를 읽는다 |
+| `document_resolve` | exact item evidence에서 linked specs, linked docs, items, relation candidates로 가는 첫 bridge. `document_item_get` 뒤에는 `itemId`를 쓰고, `documentId`는 document-wide inventory에 남겨둔다 |
+| `spec_list` | kind, scope, status, filter별 source-near spec을 나열한다 |
+| `spec_search` | exact spec id를 모를 때 targeted discovery |
+| `spec_get` | source-near claim 전에 exact source-near spec detail을 읽는다 |
+| `spec_resolve` | spec 선택 뒤 related docs/items와 graph/code seeds로 확장한다 |
+| `graph_trace` | 노출되어 있을 때 graph impact 또는 dependency path를 따라간다 |
+| `code_search` / `readonly_workspace_shell` | `code_search`는 candidate file/symbol을 찾고, `readonly_workspace_shell`은 exact implementation claim 전에 bounded source를 읽는다 |
+| `sot_file_get` | stored SOT file content만 읽는다. 그 자체로 proof가 아니다 |
+
+## SOT Projection Shape
+
+SOT root는 human/file access를 위해 DB evidence를 mirror한다. 일반적인 path는 다음과
+같다.
+
+```text
+overview.md
+catalog/epics.md
+catalog/apis.md
+catalog/screens.md
+catalog/events.md
+catalog/schedules.md
+epics/<epic-id>/br.md
+epics/<epic-id>/design.md
+epics/<epic-id>/data_dictionary.md
+epics/<epic-id>/usecases/ucl.md
+epics/<epic-id>/usecases/ucs.md
+specs/api/<name>.md
+specs/screen/<name>.md
+specs/event/<name>.md
+specs/schedule/<name>.md
+project/glossary.index.json
+project/claim.index.json
+```
+
+이 file들은 stored projection으로 취급한다. 사용자가 architecture, search order,
+policy, behavior, impact를 묻는다면 structured MCP tool을 먼저 사용하고, SOT file은
+사용자가 file content를 요청했을 때만 사용한다.
+
+## Common Mistakes
+
+- `sot_file_get`, catalog text, artifact path를 behavior claim의 proof path로 취급하지 않는다.
+- old bundle/download tool name을 사용하지 않는다. 이 MCP profile은 stored file content용 `sot_file_get`만 노출한다.
+- broad business question에 `spec_search` 하나로 답하지 않는다. 사용자가 exact spec id를 준 경우가 아니라면 project/epic/document/item map을 먼저 걷는다.
+- `spec_get`을 읽기 전에 exact API, screen, event, schedule, graph, code claim에 답하지 않는다. branch가 code parity를 요구하면 source tool을 사용한다.
+- source-near branch에서는 selected spec read 뒤 `spec_resolve`를 건너뛰지 않는다. 이것이 related document/item과 graph/code seed context를 완성한다.
+- MCP tool 또는 artifact access가 없을 때 local file이나 local Platty CLI로 fallback하지 않는다.

--- a/plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.md
@@ -33,11 +33,12 @@ question
 | Question shape | Primary route | Proof threshold |
 | --- | --- | --- |
 | Project scope, freshness, available context | `project_list` -> `project_get` when needed -> `context_status` -> `project_overview_get` | status/overview can frame scope, not prove detailed behavior |
-| Domain term, alias, Korean/English wording | `glossary_translate` -> continue to the relevant route | glossary is normalization, not proof |
+| Exact, unambiguous domain term or raw phrase | `glossary_translate`; if it is blank/conflicting while plausible candidates remain, call `glossary_list` next before translating additional Korean/English candidates | glossary is normalization/routing evidence, not behavior or source proof |
+| Vocabulary inventory, comparison, ambiguity, or every-alias request | `glossary_list` first -> paginate only until targeted candidates are clear, or through `pageInfo.hasNextPage: false` for complete inventory -> `glossary_translate` on the raw phrase and candidates | keep `aliases`, `generatedAliases`, and `memoryAliases` distinct; memory aliases are overlays and no glossary field proves behavior |
 | Broad policy, business rule, design, data, journey | `epic_list` -> `epic_get` -> `document_list` -> `document_get` -> `document_item_list` -> `document_item_get` | exact item read is the business-document proof |
-| Business item to source-near API/screen/event/schedule | `document_resolve` -> rank linked `api_spec`/`screen_spec` candidates -> `spec_list` or `spec_search` when more mapping is needed -> `spec_get` -> `spec_resolve` | exact spec read is the source-near proof; resolve completes connected context |
+| Business item to source-near API/screen/event/schedule | `document_resolve(itemId)` -> rank linked `api_spec`/`screen_spec` candidates -> `spec_list` or `spec_search` when more mapping is needed -> `spec_get` -> `spec_resolve` | exact spec read is the source-near proof; item-level resolve completes connected context |
 | Known exact spec id | `spec_get` -> `spec_resolve` | exact spec read proves the spec; resolve completes connected context |
-| Impact, dependency, implementation location | `document_resolve` or `spec_resolve` -> `graph_trace` / `code_search` -> `code_snippet` | graph/code result or snippet, with missing-tool caveat when unavailable |
+| Impact, dependency, implementation location | `document_resolve(itemId)` or `spec_resolve` -> `graph_trace` / `code_search` -> `readonly_workspace_shell` | graph/code candidates plus bounded source reads when exact source confirmation is required; state missing-tool caveats |
 | Original stored SOT file request | `sot_file_get` | file content only; not proof for behavior unless paired with structured evidence |
 
 ## Full Ladder
@@ -48,21 +49,30 @@ map-first ladder:
 ```text
 project_list / project_get / context_status
 -> project_overview_get
--> glossary_translate when terms, aliases, or Korean/English mapping matter
+-> glossary_list first for inventory, comparison, ambiguity, or every-alias routes; after blank/conflicting exact translation, use it before translating additional candidates
+-> glossary_translate for the exact/raw phrase and Korean/English candidates
 -> epic_list / epic_get
 -> memory_list / memory_get overlay when relevant and available
 -> document_list by type and epic
 -> document_get
 -> document_item_list / document_item_get
--> document_resolve
+-> document_resolve(itemId) after exact item reads; use document_resolve(documentId)
+   only for document-wide inventory
 -> rank linked api_spec and screen_spec candidates
 -> spec_list or spec_search when connected source-near specs are incomplete or unknown
 -> spec_get before exact source-near behavior claims
 -> spec_resolve to expand selected specs to related documents, items, graph seeds, and code seeds
--> graph_trace / code_search / code_snippet for impact, location, or source confirmation
+-> graph_trace / code_search / readonly_workspace_shell for impact, location, or source confirmation
 ```
 
-`document_resolve`, `spec_list`, `spec_search`, `spec_get`, and `spec_resolve`
+For targeted candidate discovery, stop `glossary_list` pagination once the
+needed candidate set is clear. For complete inventory, follow
+`pageInfo.nextCursor` until `pageInfo.hasNextPage` is false. Preserve
+`aliases` for query expansion, `generatedAliases` as generated vocabulary
+routing evidence, and `memoryAliases` as memory overlays. Continue to exact
+document/spec/source evidence before behavior claims.
+
+`document_resolve(itemId)`, `spec_list`, `spec_search`, `spec_get`, and `spec_resolve`
 are part of the search path when the answer needs source-near anchors. Do not
 skip from a business document search result directly to a claim about API shape,
 screen behavior, event behavior, schedule behavior, or implementation.
@@ -110,17 +120,19 @@ asks to read an original stored SOT file by project-relative path.
 
 | Tool | Role |
 | --- | --- |
+| `glossary_list` | inventory and candidate discovery for comparison, ambiguity, every-alias, or blank/conflicting translation routes; targeted or complete pagination depends on the request |
+| `glossary_translate` | normalizes an exact/raw phrase and selected Korean/English candidates; blank/conflicting output may require list-based discovery |
 | `document_list` | finds business docs or source-near docs by type/scope |
 | `document_get` | reads one document summary/content envelope |
 | `document_item_list` | finds item-level BR/DD/DESIGN/UCL/UCS evidence |
 | `document_item_get` | reads exact item content |
-| `document_resolve` | first bridge from document/item evidence to linked specs, linked docs, items, relation candidates |
+| `document_resolve` | first bridge from exact item evidence to linked specs, linked docs, items, relation candidates; use `itemId` after `document_item_get`, and reserve `documentId` for document-wide inventory |
 | `spec_list` | lists source-near specs by kind, scope, status, or filters |
 | `spec_search` | targeted discovery when the exact spec id is unknown |
 | `spec_get` | reads exact source-near spec detail before source-near claims |
 | `spec_resolve` | post-selection expansion from a spec to related docs/items plus graph/code seeds |
 | `graph_trace` | follows graph impact or dependency paths when exposed |
-| `code_search` / `code_snippet` | confirms exact code location or implementation when exposed |
+| `code_search` / `readonly_workspace_shell` | `code_search` finds candidate files/symbols; `readonly_workspace_shell` reads bounded source before exact implementation claims |
 | `sot_file_get` | reads stored SOT file content only; not proof by itself |
 
 ## SOT Projection Shape

--- a/plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.ko.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.ko.md
@@ -1,0 +1,84 @@
+# Platty MCP 도구 매핑
+
+이 문서는 MCP 전용 intent-to-tool map이다. local CLI 대응 명령은 나열하지 않는다.
+
+## Capability Tier
+
+| Tier | Required tools | Supported scope |
+| --- | --- | --- |
+| Minimum retrieval | `project_list`, `project_get`, `context_status`, `project_overview_get`, `glossary_translate`, `epic_list`, `epic_get`, `document_list`, `document_get`, `document_item_list`, `document_item_get`, `document_resolve`, `spec_get` | source-level confirmation 없는 map-first business/spec retrieval |
+| Vocabulary inventory / ambiguity | `glossary_list` | 넓거나 완전한 vocabulary inventory, comparison target map, ambiguous concept, every-alias request, blank/conflicting exact translation 이후 candidate discovery |
+| Memory overlay reads | `memory_list`, `memory_get` | read-only human/agent correction, constraint, why, context overlay. `memory_list`는 기본 summary card, `memory_get`은 exact body를 읽는다 |
+| Memory lifecycle | `memory_add`, `memory_update`, `memory_delete` | 명시적 user intent와 anchor resolution 이후 memory mutation |
+| Search assist | `ssot_search`, `ssot_get`, `ssot_resolve`, `document_search`, `spec_list`, `spec_search`, `spec_resolve` | targeted discovery, connected context, source-near anchor resolution |
+| Graph/code discovery | `graph_trace`, `code_search` | impact/dependency tracing과 source-location candidate. code claim에는 `code_search`를 `readonly_workspace_shell`과 짝으로 사용한다 |
+| Workspace source parity | `workspace_repo_list`, `readonly_workspace_shell` | repository discovery와 후보 발견 이후 bounded read-only grep 및 exact source inspection |
+| Artifact access | `sot_file_get` | 저장된 SOT file content access. 그 자체로 factual proof는 아니다 |
+
+## Intent Map
+
+| Intent | Tool | Required input |
+| --- | --- | --- |
+| Project 목록 | `project_list` | none |
+| Project 단건 읽기 | `project_get` | `projectId` |
+| Freshness/readiness | `context_status` | `projectId` |
+| Project overview | `project_overview_get` | `projectId` |
+| Vocabulary inventory | `glossary_list` | `projectId`; optional `limit`, `cursor` |
+| Vocabulary normalization | `glossary_translate` | `projectId`, `text` |
+| Epic catalog | `epic_list` | `projectId` |
+| Epic detail | `epic_get` | `projectId`, `epicId` |
+| Memory list | `memory_list` | `projectId`; optional `epicId`, `documentId`, `level`, `includeDeleted`, `memoryMode=summary|full` |
+| Memory detail | `memory_get` | `projectId`, `memoryId` |
+| Memory add | `memory_add` | `projectId`, `content`; optional `epicId`, `documentId`, `itemType`, `itemKey`, `memoryKind`, `actor`, `confidence` |
+| Memory update | `memory_update` | `projectId`, `memoryId`, `content`, `reason`; optional `actor` |
+| Memory delete | `memory_delete` | `projectId`, `memoryId`, `reason`; optional `actor` |
+| Document list | `document_list` | `projectId`; optional `documentType`, `epicId`, `status`, `limit`, `cursor` |
+| Document detail | `document_get` | `projectId`, `id` |
+| Business document items | `document_item_list` | `projectId`, `documentId`; optional `itemType`, `limit`, `cursor` |
+| Business document item detail | `document_item_get` | `projectId`, `itemId` |
+| Document/item connected context | `document_resolve` | `projectId` plus `documentId` or `itemId` |
+| Spec list | `spec_list` | `projectId`; optional `specKind`, `scopeId`, `status`, `filters`, `limit`, `cursor` |
+| Spec search | `spec_search` | `projectId`, `query` |
+| Spec detail | `spec_get` | `projectId`, `id` |
+| Spec connected context | `spec_resolve` | `projectId`, `id` |
+| Stored SOT file content | `sot_file_get` | `projectId`, `path` |
+| SSOT targeted discovery | `ssot_search` | `projectId`, `query` |
+| SSOT detail | `ssot_get` | `projectId`, `id` |
+| SSOT connected context | `ssot_resolve` | `projectId`, `id` |
+| Document targeted discovery | `document_search` | `projectId`, `query` |
+| Graph impact/dependency trace | `graph_trace` | `projectId`, `from` |
+| Code symbol/location search | `code_search` | `projectId`, `query`; optional `repoId`, `limit` |
+| Workspace repository inventory | `workspace_repo_list` | `projectId` |
+| Bounded repository exploration and source read | `readonly_workspace_shell` | `projectId`, `repoId`, `command`; optional `cwd`, `timeoutMs`, `maxBytes` |
+
+## Missing Tool 동작
+
+- Minimum retrieval tool이 없으면 retrieval 전에 중단하고 MCP configuration gap을
+  보고한다.
+- Vocabulary inventory/ambiguity tool이 없으면, required tool이 있는 무관한 exact
+  API/spec 및 다른 retrieval route는 계속할 수 있다. 선택된 route가 vocabulary
+  inventory, comparison, ambiguity resolution, every alias, 또는 blank/conflicting
+  `glossary_translate` 이후 candidate discovery를 필요로 하면 중단하고 capability
+  gap을 보고한다.
+- Search assist tool이 없으면 targeted discovery나 connected context가 필요 없는
+  branch만 계속한다.
+- Graph/code discovery tool이 없으면 map/spec evidence만으로 답하고 graph/code
+  discovery를 사용할 수 없다고 말한다.
+- Workspace source-parity tool이 없으면 가능한 graph/code parity는 유지하되,
+  repository source parity를 사용할 수 없다고 보고한다. local fallback을 쓰지 않는다.
+- Memory overlay tool이 없으면 present한 `epic_get.memories`와
+  `document_get.memories`를 사용한다. 그렇지 않으면 local file이나 CLI 대신 memory
+  revision/detail을 사용할 수 없다고 말한다.
+- Memory lifecycle tool이 없으면 가능한 경우 read-only로 답하거나 memory mutation
+  capability gap을 보고한다. MCP에서 local CLI로 fallback하지 않는다.
+- Artifact access tool이 없으면 structured evidence로 retrieval question에 답하되,
+  stored SOT file content access를 사용할 수 없다고 보고한다.
+
+`memory_add`, `memory_update`, `memory_delete`는 mutation tool이다. read-only
+retrieval route가 아니라 `platty-mcp-memory`를 통해서만 사용한다.
+
+Project-wide memory는 project overview document에 저장된다. `project_overview_get`을
+호출한 뒤 `overview.id`를 `documentId`로 사용한다. MCP memory write contract에는
+project-only anchor가 없다. `project_overview_get.overview`가 null이면 중단하고
+epic/document/item anchor를 요청하거나 MCP에서 project-wide memory를 쓸 수 없다고
+보고한다.

--- a/plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md
@@ -7,10 +7,12 @@ This is the MCP-only intent-to-tool map. It does not list local CLI equivalents.
 | Tier | Required tools | Supported scope |
 | --- | --- | --- |
 | Minimum retrieval | `project_list`, `project_get`, `context_status`, `project_overview_get`, `glossary_translate`, `epic_list`, `epic_get`, `document_list`, `document_get`, `document_item_list`, `document_item_get`, `document_resolve`, `spec_get` | map-first business/spec retrieval without source-level confirmation |
-| Memory overlay reads | `memory_list`, `memory_get` | read-only human/agent correction, constraint, why, and context overlays |
+| Vocabulary inventory / ambiguity | `glossary_list` | broad or complete vocabulary inventory, comparison target maps, ambiguous concepts, every-alias requests, and candidate discovery after blank/conflicting exact translation |
+| Memory overlay reads | `memory_list`, `memory_get` | read-only human/agent correction, constraint, why, and context overlays; `memory_list` defaults to summary cards, `memory_get` reads exact bodies |
 | Memory lifecycle | `memory_add`, `memory_update`, `memory_delete` | explicit memory mutation after user intent and anchor resolution |
 | Search assist | `ssot_search`, `ssot_get`, `ssot_resolve`, `document_search`, `spec_list`, `spec_search`, `spec_resolve` | targeted discovery, connected context, and source-near anchor resolution |
-| Source parity | `graph_trace`, `code_search`, `code_snippet` | impact, exact code location, source confirmation, and negative source evidence |
+| Graph/code discovery | `graph_trace`, `code_search` | impact/dependency tracing and source-location candidates; pair `code_search` with `readonly_workspace_shell` for code claims |
+| Workspace source parity | `workspace_repo_list`, `readonly_workspace_shell` | repository discovery plus bounded read-only grep and exact source inspection after candidates are found |
 | Artifact access | `sot_file_get` | stored SOT file content access, not factual proof by itself |
 
 ## Intent Map
@@ -21,10 +23,11 @@ This is the MCP-only intent-to-tool map. It does not list local CLI equivalents.
 | Read one project | `project_get` | `projectId` |
 | Freshness/readiness | `context_status` | `projectId` |
 | Project overview | `project_overview_get` | `projectId` |
+| Vocabulary inventory | `glossary_list` | `projectId`; optional `limit`, `cursor` |
 | Vocabulary normalization | `glossary_translate` | `projectId`, `text` |
 | Epic catalog | `epic_list` | `projectId` |
 | Epic detail | `epic_get` | `projectId`, `epicId` |
-| Memory list | `memory_list` | `projectId`; optional `epicId`, `documentId`, `level`, `includeDeleted` |
+| Memory list | `memory_list` | `projectId`; optional `epicId`, `documentId`, `level`, `includeDeleted`, `memoryMode=summary|full` |
 | Memory detail | `memory_get` | `projectId`, `memoryId` |
 | Memory add | `memory_add` | `projectId`, `content`; optional `epicId`, `documentId`, `itemType`, `itemKey`, `memoryKind`, `actor`, `confidence` |
 | Memory update | `memory_update` | `projectId`, `memoryId`, `content`, `reason`; optional `actor` |
@@ -45,16 +48,25 @@ This is the MCP-only intent-to-tool map. It does not list local CLI equivalents.
 | Document targeted discovery | `document_search` | `projectId`, `query` |
 | Graph impact/dependency trace | `graph_trace` | `projectId`, `from` |
 | Code symbol/location search | `code_search` | `projectId`, `query`; optional `repoId`, `limit` |
-| Source snippet | `code_snippet` | `projectId`, `repoId`, `file`, `lines` |
+| Workspace repository inventory | `workspace_repo_list` | `projectId` |
+| Bounded repository exploration and source read | `readonly_workspace_shell` | `projectId`, `repoId`, `command`; optional `cwd`, `timeoutMs`, `maxBytes` |
 
 ## Missing Tool Behavior
 
 - Missing minimum retrieval tools: stop before retrieval and report MCP
   configuration gap.
+- Missing vocabulary inventory/ambiguity tools: continue unrelated exact
+  API/spec and other retrieval routes whose required tools are present. Stop and
+  report the capability gap when the selected route requires vocabulary
+  inventory, comparison, ambiguity resolution, every alias, or candidate
+  discovery after blank/conflicting `glossary_translate`.
 - Missing search assist tools: continue only for branches that do not require
   targeted discovery or connected context.
-- Missing source parity tools: answer only from map/spec evidence and say source
-  confirmation is unavailable.
+- Missing graph/code discovery tools: answer only from map/spec evidence and say
+  graph/code discovery is unavailable.
+- Missing workspace source-parity tools: retain graph/code parity when it is
+  available; otherwise report that repository source parity is unavailable. Do
+  not use a local fallback.
 - Missing memory overlay tools: use attached `epic_get.memories` and
   `document_get.memories` when present; otherwise name memory revision/detail as
   unavailable instead of using local files or CLI.

--- a/plugins/platty/skills/platty-sdd-design/SKILL.md
+++ b/plugins/platty/skills/platty-sdd-design/SKILL.md
@@ -50,8 +50,8 @@ Use the Platty CLI convention from `using-platty`. Inside this repository, `AGEN
    - use catalog or `sot resolve` compact-row `traceId` when present;
    - read default compact `graph trace` output from `.data.confirmed`, `.data.candidates`, `.data.relationCandidates`, and `.data.flags`;
    - use `--detail full` only when raw hop/source-line metadata is required;
-   - if `traceId` is absent or trace has no confirmed edge, downgrade to risk and use `code search` or direct source reads.
-7. Read registered repository files from `repo list` paths for complex flows, DTOs, transactions, UI state, error handling, or tests.
+   - if `traceId` is absent or trace has no confirmed edge, downgrade to risk and use `code search` for incomplete addresses or bounded `readonly_workspace_shell` reads for exact source.
+7. Read registered repository files with bounded `readonly_workspace_shell` commands for complex flows, DTOs, transactions, UI state, error handling, or tests.
 
 Do not report graph trace as exhaustive when it returns candidates, omitted edge classes, truncation, or no confirmed edge.
 
@@ -91,7 +91,7 @@ Unsupported implementation claims must be marked as assumptions or risks.
 
 - `request.md` or `stories.md` is not approved and the user did not explicitly request draft-only design.
 - SOT documents referenced by the spec are stale or missing and the user has not accepted stale-evidence risk.
-- A critical implementation path has only graph candidates and no confirmed edge or source snippet.
+- A critical implementation path has only graph candidates and no confirmed edge or bounded source read.
 - The design requires a shared engine contract, persisted schema, public CLI behavior, or common resolver semantic change without explicit user approval.
 - No owning repository or implementation boundary can be identified after two discovery passes.
 

--- a/plugins/platty/skills/platty-sdd-design/references/design-review-rubric.md
+++ b/plugins/platty/skills/platty-sdd-design/references/design-review-rubric.md
@@ -12,7 +12,7 @@ Return `PASS` only when the draft is implementation-ready or clearly marked as a
 
 ## Technical Feasibility
 
-- Claims about implementation are grounded in graph trace, code search/snippet, or direct source reads.
+- Claims about implementation are grounded in graph trace, `code search` address resolution, or bounded `readonly_workspace_shell` source reads.
 - Missing graph evidence is not treated as no impact.
 - Existing patterns in registered repositories are followed.
 - Stale SOT is declared and accepted before use.

--- a/plugins/platty/skills/platty-sdd-spec/SKILL.md
+++ b/plugins/platty/skills/platty-sdd-spec/SKILL.md
@@ -37,6 +37,7 @@ state and make those assumptions visible in `request.md` §7 and in
 5. Ask SOT-informed questions before finalizing `request.md`.
 6. Generate `stories.md` with `request.md` as a draft even when open questions remain. Approval gates control `approved` status and design readiness, not whether the stories file exists.
 7. Set the output language before authoring. Use the language the user requested for the spec; if no language is explicitly requested, infer it from the user's latest idea/request and confirm only when mixed-language intent is ambiguous.
+8. Run the Self Review gate after both drafts exist; persist the final review result at the bottom of both documents.
 
 Use the Platty CLI convention from `using-platty`. Inside this repository, `AGENTS.md` overrides public plugin examples: run the local build with `node packages/cli/dist/main.js <command> --json`.
 
@@ -56,7 +57,8 @@ Use the Platty CLI convention from `using-platty`. Inside this repository, `AGEN
 4. Implementation hints only when needed:
    - catalog API/screen/table rows
    - graph trace for confirmed relationships
-   - code search/snippet for source-grounded terms
+   - `code search` for source addresses when file/symbol identity is incomplete
+   - bounded `readonly_workspace_shell` reads for exact source evidence
 
 Do not brute-force all `epics/` or `specs/`. Narrow through catalogs and frontmatter paths.
 
@@ -109,7 +111,7 @@ Minimum final response when files are written:
 - `request.md`: status, path, outputLanguage, evidence boundary, confirmed
   decisions, open questions, main request rules, and validation/release notes.
 - `stories.md`: status, path, outputLanguage, user stories, acceptance
-  scenarios, and unresolved assumptions.
+  scenarios, unresolved assumptions, and Self Review verdict.
 
 If a document is too long for chat, include its main sections and say which
 sections were abbreviated. Always include all open questions and assumptions.
@@ -121,6 +123,7 @@ Read reference templates only when writing the files:
 - `references/request-template.md`
 - `references/stories-template.md`
 - `references/spec-review-rubric.md`
+- `references/pressure-scenarios.md` when testing or changing this skill
 
 Authoring order:
 
@@ -132,6 +135,37 @@ Authoring order:
    when unresolved open questions or assumptions remain.
 5. Include all unresolved assumptions that affect story splitting in
    `stories.md`; do not silently close them.
+6. Run `review -> revise -> review` against `references/spec-review-rubric.md`.
+7. Compare the drafts with every user-supplied requirement source, not only the
+   rules created in `request.md`.
+8. Record the final requirement coverage and Search Route Audit in
+   `request.md` §10, and cross-document checks in `stories.md` Self Review.
+9. If blocking findings remain, set the Self Review verdict to `NEEDS_WORK`,
+   keep both documents in draft state, and expose the findings to the user.
+10. Persist and verify both revised files together.
+
+## Self Review Gate
+
+Self Review is an authoring quality gate, not an approval. It must not set either
+document to `approved`; only explicit user approval may do that.
+
+The review must check:
+
+- every user-supplied input document, pasted requirement, and confirmed answer
+  is represented or named as a coverage gap;
+- SOT facts, user-requested changes, inferences, and recommended defaults are
+  labeled separately;
+- statuses, enums, thresholds, metrics, scope, and terminology agree across the
+  input sources, `request.md`, and `stories.md`;
+- rule-to-scenario coverage is not presented as total input-requirement
+  coverage;
+- the search route records map-first evidence, exact reads, unread surfaces,
+  freshness, and any retrieval audit failure.
+
+Any missing required input, unresolved evidence conflict, unsupported numeric
+target, or cross-document contradiction is blocking. Revise once and review the
+revised pair; if it still fails, return `NEEDS_WORK` instead of claiming the
+documents are ready.
 
 `request.md` status:
 
@@ -161,6 +195,6 @@ Authoring order:
 | "The user wants speed, skip questions." | Draft with named assumptions and use `draft-with-open-questions`. |
 | "Stories need approval first." | Approval controls `approved` status. Still create `stories.md` as `draft` beside `request.md` and preserve assumptions. |
 | "Business docs are missing, so invent product intent from code." | Use static evidence only and state the boundary. |
-| "A code term can go directly to graph trace." | Resolve code term with `code search` first. |
+| "A code term can go directly to graph trace." | Resolve code term with `code search` first when the file/symbol address is incomplete, then verify exact source with a bounded `readonly_workspace_shell` read. |
 | "Fix the generated SOT markdown." | Never edit SOT projection; suggest memory or regeneration. |
 | "The SOT is English, so the spec should be English." | Follow the requested language; keep only identifiers and evidence labels unchanged. |

--- a/plugins/platty/skills/platty-sdd-spec/references/pressure-scenarios.md
+++ b/plugins/platty/skills/platty-sdd-spec/references/pressure-scenarios.md
@@ -1,0 +1,39 @@
+# SDD Spec Pressure Scenarios
+
+Use these scenarios when changing `platty-sdd-spec`.
+
+## Scenario 1: Input Fidelity Beats Internal Coverage
+
+The user supplies detailed requirement documents whose statuses, thresholds,
+scope, and metrics differ from the current SOT.
+
+Expected behavior:
+
+```text
+draft request.md and stories.md
+-> compare every input requirement with SOT and both drafts
+-> distinguish existing behavior from requested behavior
+-> revise contradictions
+-> record Requirement Coverage and Self Review
+-> return NEEDS_WORK while required input is unread or conflicting
+```
+
+Failure to prevent:
+
+- reporting 100% coverage because every self-authored rule has a story;
+- replacing requested statuses or thresholds with current implementation values;
+- moving a confirmed user decision into open questions.
+
+## Scenario 2: Search Route Is Incomplete
+
+The draft used search evidence but skipped a required map, exact read, memory or
+human-knowledge overlay, or final route audit.
+
+Expected behavior:
+
+```text
+record the missing rung in Search Route Audit
+-> complete the read when possible
+-> otherwise preserve the coverage gap
+-> Self Review verdict = NEEDS_WORK for a required missing rung
+```

--- a/plugins/platty/skills/platty-sdd-spec/references/request-template.md
+++ b/plugins/platty/skills/platty-sdd-spec/references/request-template.md
@@ -67,3 +67,32 @@ Use EARS-style rules. Each rule must be observable or testable.
 
 | Evidence | Path or command | Freshness | Notes |
 | --- | --- | --- | --- |
+
+## §10 Self Review
+
+- **Verdict**: <PASS | NEEDS_WORK>
+- **Blocking findings**: <count>
+- **Warnings**: <count>
+
+### Requirement Coverage
+
+| Input source or requirement | Result | Evidence or gap |
+| --- | --- | --- |
+| <user input, SOT item, or confirmed answer> | <covered|partial|missing|conflict> | <request/story location or finding> |
+
+### Search Route Audit
+
+| Check | Result | Evidence or gap |
+| --- | --- | --- |
+| Project/SOT freshness and evidence boundary were checked | <PASS|FAIL> | |
+| Vocabulary and candidate areas were mapped before narrow search | <PASS|FAIL|N/A> | |
+| Relevant BR/DD/DESIGN/UCL and exact evidence were read | <PASS|FAIL|N/A> | |
+| Memory overlays or equivalent human-knowledge surfaces were accounted for | <PASS|FAIL|N/A> | |
+| Unread relevant surfaces and missing capabilities are disclosed | <PASS|FAIL> | |
+| Final route audit completed before factual claims | <PASS|FAIL> | |
+
+### Findings
+
+| Severity | Finding | Required action |
+| --- | --- | --- |
+| <blocking|warning> | | |

--- a/plugins/platty/skills/platty-sdd-spec/references/spec-review-rubric.md
+++ b/plugins/platty/skills/platty-sdd-spec/references/spec-review-rubric.md
@@ -4,6 +4,7 @@ Return `PASS` only when every required item is satisfied or explicitly accepted 
 
 ## Request Review
 
+- Every user-supplied source and confirmed answer is covered or named as a gap.
 - Impact names affected users, areas, and scale.
 - Customer task is written from the user's perspective.
 - Current situation and limits explain why the change is needed.
@@ -13,6 +14,11 @@ Return `PASS` only when every required item is satisfied or explicitly accepted 
 - Confirmed decisions have evidence or user answers.
 - Open questions are either answered, accepted as assumptions, or block approval.
 - Evidence appendix includes SOT paths or commands and freshness.
+- Status values, enums, thresholds, metrics, scope, and terminology match the
+  user inputs or expose the conflict explicitly.
+- Numeric targets identify their source or remain recommendations/open questions.
+- Search Route Audit records map-first evidence, exact reads, memory/human
+  knowledge overlays when available, unread surfaces, and the final route audit.
 
 ## Stories Review
 
@@ -22,3 +28,14 @@ Return `PASS` only when every required item is satisfied or explicitly accepted 
 - Scenarios use Given-When-Then.
 - Then clauses describe user-visible or operator-visible results, not hidden implementation details.
 - Stories do not contradict `request.md`.
+- Rule coverage is not mislabeled as total input-requirement coverage.
+
+## Verdict
+
+- `PASS`: no blocking findings remain; open items are explicit and accepted as
+  assumptions or approval blockers.
+- `NEEDS_WORK`: a required input is missing, an evidence conflict is unresolved,
+  a numeric rule is unsupported, a search route is incomplete, or the two
+  documents contradict each other.
+
+Self Review never changes document status to `approved`.

--- a/plugins/platty/skills/platty-sdd-spec/references/stories-template.md
+++ b/plugins/platty/skills/platty-sdd-spec/references/stories-template.md
@@ -38,3 +38,16 @@ approvedBy:
 | Story | Scenarios | Request rules | Notes |
 | --- | --- | --- | --- |
 | US-01 | Scenario 1, Scenario 2 | R1 | |
+
+## Self Review
+
+- **Verdict**: <PASS | NEEDS_WORK>
+- **Blocking findings**: <count>
+
+| Check | Result | Evidence or finding |
+| --- | --- | --- |
+| request.md consistency | <PASS|FAIL> | |
+| Rule-to-scenario coverage | <PASS|FAIL> | |
+| Every customer task has a story | <PASS|FAIL> | |
+| Scenarios describe user/operator-visible outcomes | <PASS|FAIL> | |
+| No unsupported implementation detail or closed assumption | <PASS|FAIL> | |

--- a/plugins/platty/skills/platty-ultra-spec/references/grounding-agent.md
+++ b/plugins/platty/skills/platty-ultra-spec/references/grounding-agent.md
@@ -61,7 +61,7 @@ Follow map-first source-grounding discipline:
    - **Richer list when available**: `graph trace --from <traceId> --direction downstream` returns the
      connected code-node list. (It can be empty if those call edges weren't built — then fall back to the
      file+function names the spec already gives you.)
-   Then **read just those key functions directly** in that file — a handful of targeted reads, not the
+   Then use bounded `readonly_workspace_shell` commands to **read just those key functions directly** in that file — a handful of targeted reads, not the
    whole repo. That is the targeted grounding a blind grep can't match: the SOT told you the
    likely functions; you verify the truth in them.
 


### PR DESCRIPTION
## Summary
- Release Platty agent plugin v0.0.4 build 202607130400.

## Release metadata
- Version: `0.0.4`
- Build: `202607130400`
- Branch: `release/platty-plugin-v0.0.4-build-202607130400`
- Source commit: `df82a06686c98206c4dfbda7a352a23ddeb2f6fa`

## Exported managed paths
- `.agents`
- `.claude-plugin`
- `plugins/platty`
- `plugins/platty-mcp`
- `guide`
- `README.md`
- `README.ko.md`
- `GETTING_STARTED.md`
- `LICENSE.md`

## Changed files
- `.claude-plugin/marketplace.json`
- `README.ko.md`
- `README.md`
- `plugins/platty-mcp/.claude-plugin/plugin.json`
- `plugins/platty-mcp/.codex-plugin/plugin.json`
- `plugins/platty-mcp/README.md`
- `plugins/platty-mcp/skills/platty-mcp-client-setup/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-memory/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-memory/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/evidence-gates.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/search-clarification.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-shape.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/references/tasks-shape.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/request-shape.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/stories-shape.md`
- `plugins/platty-mcp/skills/using-platty-mcp/SKILL.md`
- `plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.md`
- `plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md`
- `plugins/platty/skills/platty-sdd-design/SKILL.md`
- `plugins/platty/skills/platty-sdd-design/references/design-review-rubric.md`
- `plugins/platty/skills/platty-sdd-spec/SKILL.md`
- `plugins/platty/skills/platty-sdd-spec/references/request-template.md`
- `plugins/platty/skills/platty-sdd-spec/references/spec-review-rubric.md`
- `plugins/platty/skills/platty-sdd-spec/references/stories-template.md`
- `plugins/platty/skills/platty-ultra-spec/references/grounding-agent.md`
- `plugins/platty-mcp/skills/platty-mcp-impact-analysis/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/cross-epic-traversal.md`
- `plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/impact-dossier.md`
- `plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/impact-seed-packet.md`
- `plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.ko.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/evidence-gates.ko.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.ko.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.ko.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.ko.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-review-rubric.md`
- `plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.ko.md`
- `plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.ko.md`
- `plugins/platty/skills/platty-sdd-spec/references/pressure-scenarios.md`

## Safety gate result
- `public_plugin_release_safety: passed`

## Verification
- `npm run check:agent-skills`
- `npm run check:agent-marketplace`
- `node --test tests/export-public-plugin-repo.test.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * Platty MCP 플러그인에 영향 분석 기능과 Impact Dossier 작성 흐름을 추가했습니다.
  * SDD 설계 문서와 작업 초안 생성에 승인 단계와 자체 검토 절차를 도입했습니다.
  * 메모리 목록에서 요약 보기와 전체 본문 보기를 선택할 수 있습니다.
  * 검색·증거 확인 및 영향 분석 라우팅 절차를 강화했습니다.

* **문서**
  * 설치 안내, 사용법, 검색·영향 분석·SDD 산출물 흐름을 상세히 보완했습니다.
  * 새 플러그인 버전은 0.0.5입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->