### PR TITLE
Release Platty agent plugin v0.0.4 build 202607131033

### DIFF
--- a/plugins/platty-mcp/skills/platty-mcp-impact-analysis/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-impact-analysis/SKILL.md
@@ -22,21 +22,34 @@ of confirmed impact, likely impact, candidates, unknowns, coverage, and next rea
    packet. Otherwise invoke retrieval with `routeMode: seed-only` and require it
    to return the packet to this caller without escalating back to impact. Read
    `references/impact-seed-packet.md`.
-3. Resolve selected specs and trace graph upstream/downstream while preserving
+3. Resolve selected business-document items with `document_resolve` before
+   graph tracing, then trace graph upstream/downstream while preserving
    confirmed edges, candidates, relation candidates, omissions, and truncation.
+   Use `graph_trace` as the fast structural map of `screen ↔ API ↔ domain ↔ DB`
+   plus related event/job/external paths; it never proves detailed behavior alone.
 4. Traverse confirmed cross-EPIC evidence through
    `references/cross-epic-traversal.md`.
-5. Follow the source ladder exactly: `workspace_repo_list -> select repo ->
-   readonly_workspace_shell search -> exact source read`. Call
-   `workspace_repo_list` before shell investigation unless repo id and analyzed
-   commit are already present.
+5. Apply the affected-code-path coverage gate to every implementation anchor.
+   The bounded path is not the whole repository: start at the affected UI/caller
+   or API/event entry and cover the reachable domain/orchestration,
+   DB/external boundary, event producers/consumers, and adjacent tests,
+   configuration, and migrations when they exist. Follow the source ladder
+   exactly: `workspace_repo_list -> select repo -> readonly_workspace_shell
+   search -> exact source read`. Call `workspace_repo_list` before shell
+   investigation unless repo id and analyzed commit are already present.
 6. Use `readonly_workspace_shell` only after repository selection, with the
    documented read-only command allowlist and bounded output. Search exact
    identifiers before aliases, then read exact source regions. A grep hit remains
    a candidate until its source region is read. Never write, install, execute
    project code, read blocked secrets, or leave the selected repository root.
 7. Build one evidence-matrix entry per target and classify confirmed, likely,
-   candidate, or unknown.
+   candidate, or unknown. Add a compact path map that separates confirmed hops,
+   candidate/unknown hops, omitted classes, and required exact source reads.
+   For each implementation anchor, add a code-path coverage row: resolved
+   document context, graph candidates and truncation, exact source files/symbols
+   read with their roles, consumers checked, and unread candidates with a reason.
+   Mark it `confirmed-path` only when every known bounded boundary was actually
+   read; otherwise mark it `partial-path`.
 8. Apply `references/impact-dossier.md` and its completion gate.
 9. In an SDD context, write or refresh only `impact.md` under the selected
    `~/.platty/specs/<projectId>/SPEC-<slug>-<YYYY-MM>/` and verify readability.
@@ -46,8 +59,8 @@ of confirmed impact, likely impact, candidates, unknowns, coverage, and next rea
 Complete only when every seed has an exact spec or explicit gap, graph
 directions were attempted, API/screen candidates were classified, confirmed
 cross-EPIC edges reached the bound or retained a frontier, repository scope is
-known or named as a gap, hard code claims have bounded source reads, and missing
-evidence has a next exact read or coverage limit.
+known or named as a gap, every hard code claim has `confirmed-path` bounded
+source reads, and missing evidence has a next exact read or coverage limit.
 
 If a required branch is incomplete, return and persist a partial dossier.
 Never convert empty graph/search output into no impact.

--- a/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/impact-dossier.md
+++ b/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/impact-dossier.md
@@ -50,13 +50,39 @@ nextExactRead
 `observedBehavior` is a short source-grounded statement of what the bounded read
 proved. It must not contain a complete source file or an unbounded snippet.
 
+## Affected Code Path Coverage
+
+For every anchor that can produce an implementation claim, add one row. The
+goal is to read the complete *known affected path*, not to claim that the whole
+repository was read. Follow this order: `document_resolve` selects linked
+context; `graph_trace` maps both directions and exposes candidates; `code_search`
+finds exact symbols; `readonly_workspace_shell` reads the bounded source.
+
+```text
+anchor, resolvedDocuments, graphConfirmed, graphCandidatesOrTruncation,
+sourceFilesReadAndRoles, consumersChecked, unreadCandidatesAndReason, status,
+nextExactRead
+```
+
+- The known path includes the UI/caller or API/event entry, domain or
+  orchestration, DB/external boundary, event producers/consumers, and adjacent
+  tests, configuration, and migrations when each exists in the bounded path.
+- `confirmed-path` means all known boundaries in that path were read at the
+  recorded commit. It can support a hard implementation claim.
+- `partial-path` means a candidate, consumer, boundary, test/config/migration,
+  or source surface remains unread. It supports only a candidate, assumption,
+  risk, or evidence-resolution task.
+- A graph hop, search hit, or document link is never a replacement for the
+  matching exact source read. Empty output is also not evidence of no boundary.
+
 ## Stable Impact Revision
 
 `impactRevision` is `sha256:<hex>` over a canonical JSON evidence snapshot. The
 snapshot contains the artifact's evidence-bearing metadata (`status`,
 `sourceParity`, `projectId`, `contextStatus`, lexically sorted `sourceCommits`,
 and `maxCrossEpicDepth`), lexically sorted coverage-limit strings, canonical
-matrix rows sorted by `evidenceId`, and the exact canonical cross-EPIC traversal
+matrix rows sorted by `evidenceId`, canonical affected-code-path coverage rows
+sorted by their canonical JSON bytes, and the exact canonical cross-EPIC traversal
 state owned by `cross-epic-traversal.md`: sorted `frontierEpicIds`, `visitedEpicIds`,
 `visitedSpecIds`, `visitedGraphSeeds`, and `visitedCodeQueries`; `currentDepth`;
 `maxDepth`; sorted `truncationReasons`; and separate sorted `confirmedEdges`,
@@ -77,6 +103,15 @@ leading zeroes. The array fields are `businessEvidence`, `specEvidence`,
 `graphEvidence`, `sourceEvidence`, and `missingEvidence`; normalize every member
 as an LF-normalized string and sort it bytewise. No matrix field changes type
 between snapshots.
+
+Normalize every affected-code-path coverage row as a canonical object with
+scalar fields `anchor`, `status`, and `nextExactRead`, plus sorted LF-normalized
+string arrays `resolvedDocuments`, `graphConfirmed`,
+`graphCandidatesOrTruncation`, `sourceFilesReadAndRoles`, `consumersChecked`,
+and `unreadCandidatesAndReason`. Use `""` and `[]` for absent values. Sort each
+row's canonical JSON byte string in UTF-8 bytewise lexical order before placing
+the parsed objects in the snapshot. A changed code-path coverage boundary must
+therefore create a new `impactRevision` and downstream evidence fingerprint.
 
 Normalize every directed edge with all owning fields: `sourceEpicId`,
 `targetEpicId`, `direction`, `originLayer`, `sourceDocumentId`, sorted
@@ -114,7 +149,7 @@ status: "seeded | investigated | partial"
 impactRevision: "sha256:<hex>"
 sourceParity: "confirmed | partial | unavailable"
 projectId: "<projectId>"
-outputLanguage: "<language>"
+outputLanguage: "ko"
 contextStatus: "fresh | stale | unknown"
 sourceCommits: {}
 retrievedAt: "<ISO timestamp>"
@@ -125,38 +160,26 @@ maxCrossEpicDepth: 2
 Use these headings verbatim:
 
 ```text
-# Impact Analysis - <Request title>
-## 1. Seed and Interpretation
-## 2. Freshness and Evidence Boundary
-## 3. Selected EPICs and Specs
-## 4. API and Screen Candidates
-## 5. Cross-EPIC Traversal
-## 6. Graph Impact
-## 7. Repository Search
-## 8. Source Evidence
-## 9. Impact Evidence Matrix
-## 10. Coverage Limits
-## 11. Next Exact Reads
+# 영향도 및 근거 조사 — <요청 제목>
+## 1. 조사 기준과 문서 연결
+## 2. 최신성 및 근거 경계
+## 3. 관련 EPIC·문서·스펙
+## 4. 화면·API·데이터 후보
+## 5. 빠른 경로 지도 (Graph Trace)
+## 6. 교차 EPIC·저장소·원문 확인
+## 7. 영향 근거 매트릭스
+## 8. 조사 한계와 다음 확인
 ```
 
-## Compact Request Handoff
+`document_resolve`로 선택한 문서 항목과 연결 스펙을 확인한 뒤,
+`graph_trace`로 `화면 ↔ API ↔ 도메인 ↔ DB/외부 연동` 경로를 기록한다.
+경로 지도에는 시작 앵커, 확인된 홉, 후보/미확인 홉, 누락·절단 정보, 다음 원문
+확인을 표로 남긴다. Graph trace만으로 쓰기, 권한, 트랜잭션, 계약, 영향 부재를
+확정하지 않는다.
 
-Keep this compact Engineering Discovery Handoff as an in-memory/reference
-contract that the SDD spec flow may copy later when it owns the request. Impact
-analysis must not mutate `request.md`:
-
-```markdown
-## Engineering Discovery Handoff
-
-- **Impact artifact**: `impact.md`
-- **Impact status**: <seeded | investigated | partial>
-- **Source parity**: <confirmed | partial | unavailable>
-- **Seed EPICs**: <ids and names>
-- **Seed specs**: <ids and kinds>
-- **Context freshness**: <fresh | stale | unknown>
-- **Source commits**: <repo id -> commit>
-- **Coverage limits**: <short summary or none>
-```
+`## 6. 교차 EPIC·저장소·원문 확인`에는 앵커별 **영향 코드 경로 읽기 범위** 표를
+함께 둔다. 표에는 읽은 파일·심볼과 역할, 확인한 소비자, 미열람 후보와 이유,
+`confirmed-path | partial-path`, 다음 원문 확인을 기록한다.
 
 ## Completion Gate And Boundary Outcomes
 

--- a/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/pressure-scenarios.md
@@ -142,10 +142,10 @@ workspace_repo_list와 readonly_workspace_shell이 없다고 가정해. 로컬 P
 MCP 근거로 결제 쿠폰 기능 request.md와 stories.md를 남겨줘. 나중 설계에서 재사용할 코드·graph·cross-EPIC 검색 결과도 보존해줘.
 ```
 
-- **RED failure**: No impact artifact or compact handoff contract existed.
-- **Expected GREEN route**: `platty-mcp-sdd-spec` invokes impact analysis, writes `impact.md`, and adds a compact request handoff.
-- **Owner reference**: `impact-dossier.md` compact request handoff.
-- **Observable pass criteria**: `impact.md` retains the full evidence packet while `request.md` contains only the reference-oriented handoff.
+- **RED failure**: No impact artifact or planner-safe reference existed.
+- **Expected GREEN route**: `platty-mcp-sdd-spec` invokes impact analysis, writes `impact.md`, and adds a compact request link.
+- **Owner reference**: `impact-dossier.md` persisted impact artifact.
+- **Observable pass criteria**: `impact.md` retains the full evidence packet while `request.md` contains only the status link and a user-relevant limit.
 
 ## direct-vs-escalated
 

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/SKILL.md
@@ -8,11 +8,15 @@ description: Use when creating locally saved MCP-grounded SDD technical design a
 **Prerequisite:** Read `using-platty-mcp` before acting unless it has already
 been read in this turn.
 
-Create an evidence-gated technical design from the approved product inputs and
-the persisted Impact Dossier. The design owns technical decisions and the
-canonical change map; impact analysis owns impact discovery and `impact.md`.
+Create an evidence-gated system design from the approved product inputs and the
+persisted Impact Dossier. The design owns system boundaries, technical decisions,
+and the canonical change map; impact analysis owns impact discovery and
+`impact.md`.
 Use `references/design-shape.md` for the design and
 `references/tasks-shape.md` for the approval-gated task plan.
+
+All reader-facing output is Korean. Keep code identifiers, API paths, file
+paths, status values, and quoted evidence in their original form.
 
 ## Required Sub-Skills
 
@@ -62,9 +66,15 @@ Use `references/design-shape.md` for the design and
    `impactRevision`, the sorted matrix `evidenceId` snapshot, source parity,
    commits, traversal status, and `impactCoverageLimits`. Never edit an Impact
    Dossier entry from this skill.
-6. Derive evidence-backed Technical AS-IS facts and Technical TO-BE decisions
-   from request, stories, and impact. Unsupported hard implementation claims
-   become explicit assumptions or risks, or are omitted.
+6. Derive evidence-backed AS-IS facts and system TO-BE decisions from request,
+   stories, and impact. Use the dossier's `document_resolve` links to connect
+   product documents to selected specs, and use its `graph_trace` result as a
+   fast `screen ↔ API ↔ domain ↔ DB` path map. For every hard implementation
+   claim, require the dossier's matching `confirmed-path` coverage row: the
+   entry/caller, orchestration, persistence or external boundary, consumers,
+   and adjacent tests/configuration/migrations when present must have exact
+   source reads. `partial-path` evidence becomes a risk or an
+   Evidence-Resolution task, never a confirmed system fact.
 7. Draft `design.md` from `references/design-shape.md`.
 8. Persist and read back `design.md`, then report its path for user review.
 9. If Self Review is `blocked` or `NEEDS_WORK`, reject approval and stop without
@@ -107,14 +117,17 @@ Persist that record as the `design.md` frontmatter `impactRefreshReason` (use
 `condition: not-needed` with empty lists when no refresh ran); it participates in
 `evidenceFingerprint`, so changing it creates a new unapproved design revision.
 Do not always rerun impact.
-Do not copy its Impact Evidence Matrix or
-search transcript into `design.md`. Reference dossier evidence ids instead.
+Do not copy its Impact Evidence Matrix or search transcript into `design.md`.
+Show only the compact path map needed for implementation, reference dossier
+evidence ids, and link to `impact.md` for detailed evidence.
 
 Hard implementation claims require the relevant bounded evidence and source
-parity. Evidence references may identify `graph_trace` and `code_search`
-results plus bounded `readonly_workspace_shell` exact reads retained by the
-dossier. Empty graph/search results are not proof of no impact. A candidate-only
-result is not a confirmed claim.
+parity plus `confirmed-path` coverage. `document_resolve` selects connected
+document context; `graph_trace` accelerates path discovery; `code_search` finds
+exact source candidates; and `readonly_workspace_shell` reads the bounded
+source. Graph output does not prove writes, permissions, contracts,
+transactions, retries, or absence. Empty graph/search results are not proof of
+no impact. A candidate-only or `partial-path` result is not a confirmed claim.
 
 ## Local SDD File Access
 
@@ -189,6 +202,7 @@ SDD Design Packet
 - sourceCommits
 - crossEpicTraversalStatus
 - impactCoverageLimits
+- codePathCoverage
 - surfacesRead
 - selectedEpics
 - selectedSpecs
@@ -381,7 +395,7 @@ missing source parity.
 | Creating tasks before design approval | Stop after writing and verifying `design.md`; do not create or overwrite `tasks.md`. |
 | Treating user approval as an override for a blocked design | Reject approval and resolve the blocking finding before presenting a new approval-eligible revision. |
 | Treating a stale task plan as current | Compare design approval metadata and regenerate only after the revised design is approved. |
-| Inventing task details from partial source parity | Set readiness to `partial`, preserve the gap and next exact read, and omit unsupported hard claims. |
+| Inventing task details from partial source parity or `partial-path` coverage | Set readiness to `partial`, preserve the gap and next exact read, and omit unsupported hard claims. |
 
 ## Verification
 

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-review-rubric.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-review-rubric.md
@@ -62,9 +62,10 @@ taskGate: "<open | gated, with reason>"
 
 ### Impact Assessment Audit
 
-- All eight surfaces are present: API/contract, DB/data, business logic/state,
-  UI/UX, jobs/events, external integrations, security/permissions, and
-  observability/release.
+- Audit all eight surfaces—API/contract, DB/data, business logic/state, UI/UX,
+  jobs/events, external integrations, security/permissions, and
+  observability/release—against `impact.md` and the `CHG-*` map. Persist this
+  audit in `design.md` frontmatter `review`, not as a reader-facing design section.
 - Every surface is exactly `yes`, `no`, or `unknown`, with reason, impact
   evidence, and `CHG-*` or N/A. A blank blocks readiness.
 - Every `no` passes the negative-claim gate. Empty, missing, omitted,
@@ -100,11 +101,16 @@ taskGate: "<open | gated, with reason>"
 
 - AS-IS facts and hard implementation claims cite relevant dossier/source
   evidence at recorded commits.
+- Every hard implementation claim and exact change location has a matching
+  `confirmed-path` code-path coverage row: entry/caller, orchestration,
+  persistence or external boundary, consumers, and adjacent tests,
+  configuration, and migrations when present were read. An unread known
+  boundary is `partial-path`, never a confirmed claim.
 - Impact status, context status, source parity, source commits, traversal
   status, and coverage limits match `impact.md`.
 - Candidate-only evidence remains candidate; unsupported claims are assumptions,
   risks, or omitted.
-- The Evidence Appendix references dossier entries without copying the dossier.
+- The design footer references `impact.md` evidence without copying the dossier.
 
 ### Delivery Safety
 
@@ -112,6 +118,17 @@ taskGate: "<open | gated, with reason>"
   deployment/backfill/validation/switch/contract ordering, and rollback/restore
   or roll-forward-only behavior.
 - Every change has a release signal and a safe rollback or roll-forward plan.
+
+### System Design Quality
+
+- The design names system boundaries, component responsibilities, and data
+  ownership before listing implementation changes.
+- Target structure distinguishes synchronous contracts, asynchronous events,
+  and external integrations. It records alternatives and selection reasons for
+  material decisions.
+- Critical flows cover consistency, idempotency, timeout/retry/compensation or
+  an explicit N/A rationale. Non-functional responsibilities include applicable
+  permissions/privacy, performance, and observability.
 
 ### Revision, Approval, And Task Gate
 

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-shape.md
@@ -1,272 +1,196 @@
-# MCP SDD Design Document Contract
+# MCP SDD 개발 설계 형식
 
-Use this as the single `design.md` shape. The Impact Dossier remains in
-`impact.md`; reference its entries instead of copying its matrix or transcript.
+`design.md`는 개발자가 구현 방향을 빠르게 파악하는 한국어 문서다. 승인·최신성·
+fingerprint·source parity 같은 기계 검증값은 frontmatter에 보존하고, 상세 근거는
+`impact.md`에 둔다.
 
-## Canonical Revision Rules
-
-- `designRevision` is `sha256:<hex>` over the UTF-8, LF-normalized complete
-  design content after removing the mutable frontmatter keys `status`,
-  `designRevision`, `approvedRevision`, `approvedAt`, and `approvedBy`.
-- `requestRevision` and `storiesRevision` are `sha256:<hex>` over the complete
-  persisted UTF-8, LF-normalized `request.md` and `stories.md` bytes, including
-  their current `status`. Any content or approval-status change therefore
-  changes the corresponding revision.
-- `productInputFingerprint` is `sha256:<hex>` over canonical JSON containing
-  `requestRevision`, `requestStatus`, `storiesRevision`, and `storiesStatus`.
-  Sort object keys lexically and encode as UTF-8. Approval and every task
-  preflight reread both product inputs and require this fingerprint to match.
-- `impactRevision` is the verified `impact.md` frontmatter revision. It is the
-  timestamp-independent canonical evidence snapshot defined by
-  `impact-dossier.md`; do not hash the complete persisted file or mutable
-  `retrievedAt` to recreate it.
-- `impactEvidenceSnapshot` is the lexically sorted list of stable Impact Dossier
-  matrix `evidenceId` values used by this design. It records exactly which
-  impact evidence the design consumed and remains unchanged when only
-  `impact.md.retrievedAt` changes.
-- `impactCoverageLimits` is the canonical persisted list. Copy the Impact
-  Dossier's `coverageLimits` into this frontmatter field; do not persist a
-  second `coverageLimits` alias. The fingerprint sorts this persisted list, so
-  source ordering cannot change approval-time recomputation.
-- `impactRefreshReason` records why this design invoked an optional impact
-  refresh. Persist `condition: not-needed` with empty lists when no refresh was
-  invoked; otherwise persist the observed refresh condition together with every
-  affected Impact Dossier `evidenceId` and coverage limit. It is audit evidence,
-  not a replacement for the Impact Dossier.
-- `evidenceFingerprint` is `sha256:<hex>` over canonical JSON containing
-  `impactRevision`, sorted `impactEvidenceSnapshot`, sorted `sourceCommits`,
-  `contextStatus`, `sourceParity`, `crossEpicTraversalStatus`, and sorted
-  `impactCoverageLimits`, and canonical `impactRefreshReason`. Sort object keys
-  lexically, represent `sourceCommits` as a lexically sorted list of repo/commit
-  pairs, sort the refresh evidence-id and coverage-limit lists lexically, encode
-  as UTF-8, and exclude timestamps.
-- On a new or revised design, keep `status: draft` and leave
-  `approvedRevision`, `approvedAt`, and `approvedBy` empty.
-- Explicit approval rereads the file, verifies its current hash, sets
-  `approvedRevision = designRevision`, fills `approvedAt` with the current ISO
-  timestamp and `approvedBy` with the authenticated actor id or `user`, changes
-  `status` to `approved`, persists, and reads back the transition.
-- Any later design-content, `productInputFingerprint`, or `evidenceFingerprint`
-  change creates another revision, resets `status: draft`, and clears all three
-  approval fields.
+## Frontmatter
 
 ```yaml
 ---
 id: "SPEC-<slug>-<YYYY-MM>"
 type: "sdd-design"
-status: draft
+status: "draft"
 projectId: "<projectId>"
 outputLanguage: "ko"
-contextStatus: "<fresh | stale | unknown>"
-sotExportedAt: "<ISO timestamp or unknown>"
-derivedFrom: ["request.md", "stories.md", "impact.md"]
+requestStatus: "approved"
+storiesStatus: "approved"
 requestRevision: "sha256:<hex>"
-requestStatus: "<draft | approved>"
 storiesRevision: "sha256:<hex>"
-storiesStatus: "<draft | approved>"
 productInputFingerprint: "sha256:<hex>"
-impactArtifact: "impact.md"
 impactRevision: "sha256:<hex>"
+impactArtifact: "impact.md"
 impactEvidenceSnapshot: []
 impactStatus: "<seeded | investigated | partial>"
 impactRefreshReason:
-  condition: "<not-needed | missing | seeded | stale | source-commit-mismatched | partial-required-area>"
-  evidenceIds: []
-  coverageLimits: []
+  condition: "not-needed"
+  affectedEvidenceIds: []
+  affectedCoverageLimits: []
 sourceParity: "<confirmed | partial | unavailable>"
-sourceCommits: {}
-impactRetrievedAt: "<ISO timestamp or unknown>"
-crossEpicTraversalStatus: "<complete | partial | unavailable>"
-impactCoverageLimits: []
-designRevision: "sha256:<hex>"
+impactRetrievedAt: "<ISO timestamp>"
+contextStatus: "<fresh | stale | unknown>"
 evidenceFingerprint: "sha256:<hex>"
-approvedRevision:
-approvedAt:
-approvedBy:
+designRevision: "sha256:<hex>"
+approvedRevision: ""
+approvedAt: ""
+approvedBy: ""
+sourceCommits: {}
+crossEpicTraversalStatus: "<complete | partial | unknown>"
+impactCoverageLimits: []
+review:
+  verdict: "PASS | NEEDS_WORK"
+  readiness: "ready | partial | blocked"
+  blockingFindings: []
+  warnings: []
+  impactAssessmentAudit: {}
+  requirementCoverage: {}
+  changeCoverage: {}
+  verificationCoverage: {}
+derivedFrom: ["request.md", "stories.md", "impact.md"]
 ---
 ```
 
-# Design - <Spec title>
+## 본문
 
-> DRAFT until explicitly approved. Evidence and readiness are audited below.
+```markdown
+# 시스템 설계 — <요청 제목>
 
-## 1. One-Page Overview
+> **DRAFT — 개발자 검토 필요.** 상세 조사 근거: [impact.md](impact.md).
 
-- **Problem and outcome**: <request-backed summary>
-- **Scope and non-goals**: <in/out>
-- **Primary technical decision**: <TO-BE summary>
-- **Change ids**: <CHG-01, ...>
-- **Readiness**: <ready | partial | blocked>
+## 0. 시스템 설계 한눈에 보기
 
-## 2. Inputs, Evidence, Freshness, Assumptions, and Coverage
+| 항목 | 내용 |
+| --- | --- |
+| 변경 목적과 성공 기준 | |
+| 범위와 비목표 | |
+| 영향 시스템/저장소 | |
+| 주요 설계 결정 | |
+| 결정이 필요한 쟁점 | |
 
-Build `productInputMetadata` before validating the design input packet. Canonical
-product metadata is validated directly. Legacy product metadata is adapted only
-in `productInputMetadata` so the same validated design input packet can consume
-it without rewriting `request.md`, `stories.md`, or the input artifact.
+## 1. 시스템 경계와 책임
 
-| Input/evidence | Status or revision | Source parity / Confidence | Coverage and use |
-| --- | --- | --- | --- |
-| request.md | <approved revision/status> | <confidence> | <rules used> |
-| stories.md | <approved revision/status> | <confidence> | <scenarios used> |
-| impact.md | Impact status: <status> | Source parity: <status>; Confidence: <summary> | <coverage limits> |
-
-- **Optional impact refresh**: <not-needed, or condition with affected evidence ids / coverage limits>
-- **Source commits**: <repo -> commit>
-- **Impact retrieved at**: <timestamp>
-- **Cross-EPIC traversal status**: <status and retained frontier>
-- **Assumptions**: <explicit assumptions or none>
-- **Accepted risks**: <separately confirmed D-NN decisions or none>
-
-## 3. Impact Assessment
-
-Every row is required. Assessment is `yes/no/unknown`; a blank is invalid. A
-`no` must pass the negative-claim gate. An implicated `unknown` blocks ready
-unless a separately confirmed `D-NN` risk-acceptance decision records its owner,
-rationale, affected ids, bounded scope, and revisit condition in a new design
-revision. Generic design approval does not accept the risk and must not remove
-the blocker.
-
-| Surface | Assessment (yes/no/unknown) | Reason | Impact evidence | CHG-* or N/A |
+| 구성요소/외부 시스템 | 책임 | 소유 데이터 | 동기/비동기 연결 | 변경 여부 |
 | --- | --- | --- | --- | --- |
-| API/contract | | | | |
-| DB/data | | | | |
-| Business logic/state | | | | |
-| UI/UX | | | | |
-| Jobs/events | | | | |
-| External integrations | | | | |
-| Security/permissions | | | | |
-| Observability/release | | | | |
 
-## 4. Technical AS-IS
+필요한 경우에만 컨텍스트 또는 컴포넌트 Mermaid 다이어그램을 사용한다. 다이어그램은
+책임과 경계를 보여 주며, 확인되지 않은 연결은 `후보`로 표기한다.
 
-Record only evidence-backed current facts. Keep candidates and unknowns out of
-hard factual prose and point to their evidence gaps.
+## 2. 현재 구조와 영향 경로 (As-Is)
 
-| Current area | Current behavior/path | Evidence | Confidence / limit |
+| 경계 | 파일/심볼 또는 문서 | 현재 역할 | 상태 |
 | --- | --- | --- | --- |
 
-## 5. Technical TO-BE
+### 2-1. 빠른 경로 지도 (Graph Trace)
 
-Record technical decisions, constraints, and target behavior. Each decision
-must map to request rules/stories, impact evidence, and one or more `CHG-*` rows.
+`graph_trace`는 빠르게 구조를 파악하는 보조 수단이다. 확정된 홉과 후보·미확인
+홉을 구분하며, 쓰기·권한·트랜잭션·응답 형식은 원문 근거가 있을 때만 확정한다.
 
-| Decision | Target behavior | Rationale | Maps to |
-| --- | --- | --- | --- |
+| 시작 앵커 | 화면 → API → 도메인 → 데이터/외부 경로 | 확인됨 | 후보·미확인 | 다음 확인 |
+| --- | --- | --- | --- | --- |
 
-## 6. Canonical Change Map
+### 2-2. 영향 코드 경로 읽기 범위
 
-This is the only canonical delta list. Do not create another area-change,
-module-change, migration-change, or implementation-delta list elsewhere.
+| 앵커 | 읽은 경계와 파일/심볼 | 확인한 소비자 | 미열람 후보/이유 | 상태 |
+| --- | --- | --- | --- | --- |
 
-| CHG ID | Surface | AS-IS | TO-BE | Rationale | Owner/repo | Compatibility | Impact evidence | Maps to |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| CHG-01 | DB/data | ... | ... | ... | ... | ... | impact.md evidence id | R-01 / US-01-S01 |
+`confirmed-path`만 현재 구현 사실 또는 정확한 변경 위치의 근거가 된다. `partial-path`는
+위험 또는 Evidence-Resolution으로 남긴다. 상세 근거는 `impact.md`를 따른다.
 
-Use stable ids `CHG-NN`. Every applicable impact row and every material AS-IS to
-TO-BE delta maps to a row; non-applicable surfaces use N/A only in the impact
-assessment.
+## 3. 목표 구조와 설계 결정 (To-Be)
 
-## 7. Conditional Detailed Modules
+### 3-1. 목표 구조
 
-Expand only applicable `CHG-*` rows and title each subsection with its ids.
-Omit non-applicable detailed modules; the Impact Assessment still remains
-complete.
+컴포넌트 책임, 동기 API, 비동기 이벤트, 외부 연동, 데이터 소유권을 설명한다.
+필요한 경우에만 Mermaid를 사용한다.
 
-### API/Contract - <CHG-NN>
+### 3-2. 설계 결정
 
-Cover request/response/events, compatibility, consumers, errors, permissions,
-and versioning as applicable.
+| D ID | 결정 | 고려한 대안 | 선택 이유 | 영향/후속 |
+| --- | --- | --- | --- | --- |
+| D-01 | | | | |
 
-### DB/Data - <CHG-NN>
+### 3-3. 구현 변경 연결
 
-Detailed DB/data design is conditional, but the DB/data impact assessment is
-always required. When applicable, cover:
-
-- affected stores and source of truth;
-- current and target shape plus read/write paths;
-- schema, index, and constraint changes;
-- transaction, concurrency, and idempotency behavior;
-- data-backfill and reconciliation;
-- lock/load risk;
-- old/new reader-writer compatibility;
-- expand, compatible deploy, backfill, validate, switch, and contract phases;
-- rollback/restore or roll-forward-only behavior;
-- privacy, retention, and deletion;
-- production validation and telemetry.
-
-### Business Logic/State - <CHG-NN>
-
-Cover rules, state transitions, invariants, failure handling, and idempotency.
-
-### UI/UX - <CHG-NN>
-
-Cover states, transitions, errors, accessibility, and API dependencies.
-
-### Jobs/Events And External Integrations - <CHG-NN>
-
-Cover producers/consumers, ordering, retries, deduplication, timeouts, contracts,
-and operational ownership.
-
-### Security/Permissions And Observability - <CHG-NN>
-
-Cover authorization, sensitive data, auditability, metrics, logs, alerts, and
-release signals.
-
-## 8. Delivery Safety
-
-| CHG ID | Rollout/dependency order | Compatibility phase | Data safety | Rollback or roll-forward | Release signal |
+| CHG ID | 변경 경계 | As-Is → To-Be | 책임/저장소 | 호환성 | 규칙·시나리오 |
 | --- | --- | --- | --- | --- | --- |
+| CHG-01 | | | | | R-01 / US-01-S01 |
 
-Include migration/backfill sequencing, reversible boundaries, production
-validation, and explicit stop conditions where applicable.
+필요할 때만 여러 경계의 호출 순서, 비동기 처리, 트랜잭션, 재시도, 보상 흐름을
+Mermaid로 작성한다. 단순 CRUD에는 표와 짧은 설명을 사용한다.
 
-## 9. Verification and Traceability
+## 4. 인터페이스와 데이터 설계
 
-Every `CHG-*` row maps to at least one `VER-*` row. Every request rule and stable
-story scenario maps to verification or an explicit evidence gap.
+### 4-1. API·화면·이벤트 계약
 
-| VER ID | Rule/scenario | CHG IDs | Test level | Expected evidence | Exact command or evidence gap |
-| --- | --- | --- | --- | --- | --- |
-| VER-01 | R-01 / US-01-S01 | CHG-01 | integration | <observable result> | `<command>` |
+| CHG ID | 계약 | 변경 | 호환성 | 근거 |
+| --- | --- | --- | --- | --- |
 
-Use stable ids `VER-NN`. Commands must be exact and runnable when known; do not
-invent commands when evidence is missing.
+### 4-2. 데이터 소유권·상태·일관성
 
-## 10. Risks, Open Decisions, Evidence Appendix, and Self Review
+| CHG ID | 대상 | 변경/전이 | 동시성·실패 처리 | 근거 |
+| --- | --- | --- | --- | --- |
 
-### Risks And Open Decisions
+### 4-3. 작업·이벤트·외부 연동
 
-Use stable decision ids `D-NN`. Risk acceptance is a separate product/technical
-decision, not a side effect of approving the design. It must be confirmed before
-the new design revision is presented for approval.
-
-| ID | Type | Risk/decision | Affected ids | Owner | Rationale and bounded scope | Revisit condition | Confirmation |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| D-01 | risk_acceptance | <implicated unknown> | <R/US/CHG/evidence ids> | <owner> | <why and exact boundary> | <observable trigger/date> | <acceptedBy / acceptedAt> |
-
-### Evidence Appendix
-
-Reference `impact.md` dossier entry ids and bounded source references. Do not
-copy the dossier matrix, complete snippets, or search transcript.
-
-| Design claim / CHG | Dossier evidence id | Repo/commit/path/symbol | Confidence / limit |
+| CHG ID | 생산자/소비자 또는 연동 | 순서·재시도·타임아웃 | 운영 책임 |
 | --- | --- | --- | --- |
 
-### Self Review
+## 5. 핵심 흐름과 실패 처리
 
-Apply `design-review-rubric.md` as the single readiness owner and record:
+중요한 정상/예외 경로에서만 sequence Mermaid를 사용한다. 재시도, 중복 실행,
+보상, 부분 실패, 타임아웃의 소유자와 관찰 신호를 명시한다.
 
-```yaml
-verdict: PASS | NEEDS_WORK
-readiness: ready | partial | blocked
-blockingFindings: []
-warnings: []
-requirementCoverage: {}
-productInputAudit: {}
-impactAssessmentAudit: {}
-changeCoverage: {}
-verificationCoverage: {}
-sourceParityAudit: {}
-taskGate: "<blocked and NEEDS_WORK are not approval-eligible; otherwise open only after explicit approval of this current design revision>"
+| 흐름 | 트리거 | 일관성/멱등성 | 실패·복구 | 관찰 신호 |
+| --- | --- | --- | --- | --- |
+
+## 6. 비기능·운영 설계
+
+| 영역 | 요구/결정 | 구현 또는 운영 책임 | 검증 신호 |
+| --- | --- | --- | --- |
+| 권한·개인정보 | | | |
+| 성능·용량 | | | |
+| 관측성·알림 | | | |
+
+## 7. 마이그레이션·배포·롤백
+
+| 변경 | 순서 | 호환성/데이터 안전 | 롤백 또는 전진 복구 | 출시 신호 |
+| --- | --- | --- | --- | --- |
+
+## 8. 구현 연결과 미결정 사항
+
+### 8-1. 코드 컨벤션과 구현 원칙
+
+| 항목 | 확인한 기존 패턴 | 이번 적용 또는 예외 | 근거 |
+| --- | --- | --- | --- |
+| 모듈·파일 배치 | | | |
+| 이름·타입·DTO | | | |
+| 검증·오류 처리 | | | |
+| 트랜잭션·외부 호출 | | | |
+| 테스트 위치·스타일 | | | |
+
+### 8-2. 검증 연결
+
+| VER ID | 규칙/시나리오 | CHG ID | 검증 수준 | 기대 결과 | 명령 또는 근거 공백 |
+| --- | --- | --- | --- | --- | --- |
+| VER-01 | R-01 / US-01-S01 | CHG-01 | 통합 | | |
+
+### 8-3. 위험과 미결정 사항
+
+| ID | 위험 또는 결정 | 영향 | 소유자 | 다음 확인 또는 재검토 조건 |
+| --- | --- | --- | --- | --- |
+
+---
+
+**근거와 한계**: [impact.md](impact.md) — <evidence id 또는 한 줄 요약>.
 ```
+
+## 작성 규칙
+
+- `document_resolve`로 연결된 문서 근거, `graph_trace` 후보, 정확한 원문 읽기
+  범위는 `impact.md`를 SSOT로 삼는다.
+- design에는 구현에 필요한 경로 지도와 근거 ID만 싣고, 매트릭스·도구 로그·
+  freshness 표를 복사하지 않는다.
+- `확인됨`, `후보`, `위험`을 구분한다. candidate-only 또는 빈 graph 결과는
+  영향 없음의 근거가 아니다.
+- 승인·fingerprint·readiness 판단은 frontmatter의 `review`와 review rubric으로 수행하며
+  별도 독자용 섹션으로 만들지 않는다.

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/tasks-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-design/references/tasks-shape.md
@@ -1,310 +1,90 @@
+# MCP SDD 작업 계획 형식
+
+`tasks.md`는 승인된 `design.md`를 구현 작업으로 나눈 한국어 문서다. 상세
+fingerprint와 readiness는 frontmatter로 검증하고, 본문은 실행 순서와 검증에 집중한다.
+
+## Frontmatter
+
+```yaml
 ---
 id: "SPEC-<slug>-<YYYY-MM>"
 type: "sdd-tasks"
 status: "planned"
-executionReadiness: "partial"
+executionReadiness: "partial | ready"
 projectId: "<projectId>"
 outputLanguage: "ko"
 designApprovedAt: "<approved design approvedAt>"
 designApprovedBy: "<approved design approvedBy>"
-designRevision: "<approved design designRevision>"
-approvedRevision: "<approved design approvedRevision; must equal designRevision>"
-productInputFingerprint: "<approved design productInputFingerprint>"
-evidenceFingerprint: "<approved design evidenceFingerprint>"
+designRevision: "sha256:<hex>"
+approvedRevision: "sha256:<hex>"
+productInputFingerprint: "sha256:<hex>"
+evidenceFingerprint: "sha256:<hex>"
 impactStatus: "<seeded | investigated | partial>"
 sourceParity: "<confirmed | partial | unavailable>"
-sourceCommits: {}
-impactRetrievedAt: "<ISO timestamp or unknown>"
-evidenceBoundary: "<MCP evidence surfaces used>"
-contextStatus: "<fresh | stale | unknown>"
-coverageLimits: []
+impactCoverageLimits: []
 derivedFrom: ["request.md", "stories.md", "impact.md", "design.md"]
-generatedAt: "<ISO timestamp>"
 ---
-
-# Tasks - <Spec title>
-
-> Generated only after explicit approval of the current `design.md`. If the
-> design approval metadata no longer matches, this task plan is stale and must
-> not be executed.
-
-`status: planned` describes artifact lifecycle only. Production implementation
-is allowed only when `executionReadiness: ready`, revision/fingerprint equality
-holds, and the current design remains approved. When
-`executionReadiness: partial`, only the bounded Evidence-Resolution tasks in
-this artifact may run; Ready implementation tasks must not run.
-
-## Execution Preflight
-
-Before executing any existing `tasks.md`, the executor must reread the selected
-`request.md`, `stories.md`, `impact.md`, `design.md`, and `tasks.md`. Recompute
-`requestRevision`, `storiesRevision`, `productInputFingerprint`,
-`impactRevision`, `evidenceFingerprint`, and `designRevision`; verify both
-product inputs remain approved and require all task/design approval metadata to
-match. A missing or mismatched value makes the task artifact stale. Do not run
-implementation work. If either product input status is not approved, stop and
-do not create a design revision. When both product inputs remain approved but a
-revision or fingerprint differs, create a new unapproved design revision, stop
-for later explicit approval, and regenerate tasks.
-
-## Goal, Architecture, and Tech Stack
-
-**Goal:** <one sentence describing the completed behavior>
-
-**Architecture:** <two or three sentences copied from the approved design boundary>
-
-**Tech Stack:** <source-confirmed languages, frameworks, libraries, and test tools>
-
-## Global Constraints
-
-- <approved request/design constraint with exact value>
-- <compatibility, migration, security, or rollout constraint>
-- <impact coverage limit that every task must preserve>
-
-## Requirement And Change Coverage
-
-| Requirement | Scenario | Disposition | Design change or rationale | Impact evidence | Implementation task | Verification or resolution |
-| --- | --- | --- | --- | --- | --- | --- |
-| R-01 | US-01-S01 | implemented | CHG-01 | impact.md §<n> / <entry id> | TASK-01 | VER-01 / E2E-01 |
-| R-02 | US-02-S01 | non-goal | D-01 / <approved rationale> | impact.md §<n> / <entry id> | N/A | approved non-goal review |
-
-Every request rule and stable story scenario in a generated `tasks.md` must have
-exactly one disposition: `implemented` or `non-goal`. `implemented` rows map to
-at least one approved `CHG-*`, implementation `TASK-*`, and automated `VER-*` or
-E2E scenario. `non-goal` rows map to an approved rationale or decision id and do
-not require implementation or test work. A `blocked` requirement or scenario
-prevents design approval and must be resolved through MCP evidence or a revised
-design before generating `tasks.md`. An incomplete or contradictory disposition
-makes the design blocked rather than merely lowering task readiness.
-
-## File Structure
-
-### New files
-
-- `<exact path>`: <single responsibility and owning task>
-
-### Modified files
-
-- `<exact path>`: <specific responsibility and owning task>
-
-Use only source-confirmed paths. Put an unresolved path in `coverageLimits` with
-its `nextExactRead`; never invent a plausible path. When a required path or
-command is unresolved, use the Evidence-Resolution Task shape below instead of
-an implementation task with fabricated slots.
-
-## Task Template
-
-Use the Ready Implementation Task shape only when the task's paths, interfaces,
-test content, and commands are source-confirmed. Use the Evidence-Resolution
-Task shape only for approval-eligible partial areas. A blocked design produces
-no `tasks.md`; resolve the blocking finding and create a new design revision
-first. Order tasks by dependency, not by a generic technical-layer checklist.
-
-For data-changing designs, preserve the approved rollout dependency:
-
-```text
-expand schema or contract
--> compatible deploy
--> backfill or reconcile
--> validate
--> switch behavior
--> observe
--> contract old structure
 ```
 
-Use only the phases that apply to the approved `CHG-*` rows.
+## 본문
 
-### Ready TASK-NN: <independently testable outcome>
+```markdown
+# 구현 작업 — <요청 제목>
 
-**Task ID:** `TASK-NN`
+> 승인된 설계 기준: [design.md](design.md). 근거 상세: [impact.md](impact.md).
 
-**Change:** `CHG-NN`
+## 0. 작업 연결표
 
-**Phase:** `<expand | compatible-deploy | backfill | validate | switch | observe | contract>`
+| 작업 | 설계 결정/변경 | 규칙·시나리오 | 근거 | 준비 상태 |
+| --- | --- | --- | --- | --- |
+| TASK-01 | CHG-01 | R-01 / US-01-S01 | impact.md <id> | ready |
 
-**Verification:** `VER-NN`
+## 1. 구현 작업
 
-**Readiness:** `ready`
+### TASK-01. <독립적으로 검증 가능한 결과>
 
-**Files:**
-- Create: `<exact test or source path>`
-- Modify: `<exact source path and bounded region or symbol>`
-- Test: `<exact test path>`
+- **설계 결정/변경**: `D-01` / `CHG-01`
+- **대상**: <확인된 파일·심볼 또는 Evidence-Resolution>
+- **구현**: <무엇을 바꾸는지>
+- **완료 조건**: <관찰 가능한 결과>
+- **검증**: `VER-01`
+- **근거**: <impact evidence id / source reference>
 
-**Interfaces:**
-- Consumes: `<exact earlier contract, type, function, or artifact>`
-- Produces: `<exact contract, type, function, field, or artifact used later>`
+확인된 파일·심볼·명령이 없으면 구현 경로를 추측하지 않는다. 아래처럼 조사 작업으로 분리한다.
 
-**Evidence:**
-- Requirements: `R-NN`
-- Scenarios: `US-NN-SNN`
-- Design: `CHG-NN` / `design.md §<n>`
-- Impact: `impact.md §<n>` / `<evidence entry id>`
-- Source: `<repoId>@<commit>:<file>:<lineStart>-<lineEnd>`
+### Evidence-Resolution TASK-02. <확인할 사실>
 
-- [ ] **Step 1: Write the failing test - RED**
+- **필요한 MCP 도구**: `document_resolve` → `graph_trace` → `code_search` → `readonly_workspace_shell`
+- **다음 확인**: <좁은 대상과 질문>
+- **완료 조건**: <새 설계 revision에서 CHG/VER로 확정할 수 있는 근거>
+- **후속 처리**: impact owner가 `impact.md`를 갱신하고 새 design 승인 후 tasks를 재생성한다.
 
-```text
-<complete test code or exact structural assertion>
-```
+## 2. 자동화 검증
 
-- [ ] **Step 2: Run test to verify it fails**
+| VER ID | 작업 | 자동화 수준 | 명령 또는 검증 방식 | 기대 결과 |
+| --- | --- | --- | --- | --- |
 
-Run: `<exact focused test command>`
+## 3. E2E 시나리오
 
-Expected: FAIL because `<missing behavior asserted by this task>`, not because
-of syntax, configuration, fixture, or environment errors.
+| 시나리오 | Given | When | Then | 연결 |
+| --- | --- | --- | --- | --- |
 
-- [ ] **Step 3: Write minimal implementation - GREEN**
+## 4. 수동 검증
 
-```text
-<complete minimal implementation or exact skill/template content>
-```
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `<same focused test command>`
-
-Expected: PASS with `<exact test count or observable result>`.
-
-- [ ] **Step 5: Refactor while staying green**
-
-Apply only `<named duplication, boundary, or naming improvement>` without adding
-untested behavior. Re-run the focused command and preserve PASS.
-
-- [ ] **Step 6: Run regression verification**
-
-Run: `<exact affected-suite command>`
-
-Expected: all affected tests PASS with no new warnings or errors.
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add <exact task-owned paths>
-git diff --cached --check
-git commit -m "<type>: <specific task outcome>"
-```
-
-### Evidence-Resolution TASK-NN: <missing implementation fact>
-
-**Task ID:** `TASK-NN`
-
-**Change:** `CHG-NN`
-
-**Verification:** `VER-NN` or `<verification gap>`
-
-**Readiness:** `partial`
-
-**Missing evidence:** <exact unknown path, command, symbol, interface, or behavior>
-
-**Required MCP surface:** <workspace_repo_list, readonly_workspace_shell,
-graph_trace, code_search, or exact spec read>
-
-**Next exact query/read:** <bounded query and expected repository/spec scope>
-
-**Owner:** <task or human decision owner>
-
-**Resolution criterion:** <observable evidence that permits a new design
-revision to replace the gap with a source-backed decision or Ready Task>
-
-**Prohibited:** Do not add speculative implementation paths, commands, symbols,
-or test code to this task.
-
-#### Completion Sequence
-
-- [ ] **Step 1: Execute the required MCP read/query through the impact owner**
-
-Route the bounded `Next exact query/read` through
-`platty-mcp-impact-analysis`. Do not substitute a local fallback or broaden the
-scope without recording why.
-
-- [ ] **Step 2: Record the result in impact.md**
-
-The impact owner records the returned evidence, repository/spec scope, and any
-remaining unknown in `impact.md`. The design/task route does not edit dossier
-entries.
-
-- [ ] **Step 3: Recompute revisions and stale the current task artifact**
-
-Reread `impact.md`, recompute `impactRevision` and `evidenceFingerprint`, and
-mark this task artifact stale when the evidence snapshot changed. The existing
-task artifact must not promote itself in place.
-
-- [ ] **Step 4: Create a new unapproved design revision**
-
-Refresh the affected assumptions, decisions, `CHG-*`, and `VER-*` rows from the
-new impact evidence. Recompute `productInputFingerprint`, `designRevision`, and
-`evidenceFingerprint`; clear approval metadata.
-
-- [ ] **Step 5: Stop for later explicit reapproval**
-
-Persist and verify the new design, present its path and revision, and stop. A
-same-request or prior approval does not approve the new revision.
-
-- [ ] **Step 6: Regenerate tasks after reapproval**
-
-After later explicit reapproval, regenerate `tasks.md` from the new design and
-current evidence. Never promote the existing task artifact in place; unresolved
-evidence produces another bounded Evidence-Resolution task.
-
-## E2E Scenarios
-
-| ID | Given | When | Then | Maps to | Command/evidence |
-| --- | --- | --- | --- | --- | --- |
-| E2E-01 | <state> | <action> | <observable result> | R-01 / US-01-S01 | <exact command or harness> |
-
-## Manual-Only Verification
-
-Include only behavior that cannot reasonably be automated. Every row must say
-why automation is unavailable.
-
-| Check | Why manual | Expected evidence |
+| 확인 항목 | 자동화하지 않는 이유 | 기대 결과 |
 | --- | --- | --- |
-| <check> | <automation limit> | <screenshot, log, or observation> |
 
-## Rollback Checklist
+## 5. 배포와 롤백
 
-- [ ] <exact rollback action and verification command>
-
-## Plan Self-Review
-
-- [ ] Every request rule and stable story scenario has exactly one `implemented` or `non-goal` disposition.
-- [ ] Every `implemented` row maps to implementation and automated test or E2E evidence.
-- [ ] Every `non-goal` row maps to an approved rationale or decision id without speculative work.
-- [ ] No generated `tasks.md` contains a `blocked` requirement disposition.
-- [ ] Every `CHG-*` maps to at least one `TASK-*` and `VER-*` or an explicit evidence-resolution task.
-- [ ] Task order follows approved dependency and rollout phases rather than a generic technology-layer order.
-- [ ] Every task observes RED before production or skill behavior changes.
-- [ ] Every RED failure reason is the missing behavior, not a test error.
-- [ ] Every file, symbol, command, and source commit is evidence-backed.
-- [ ] Task interfaces use consistent type, function, and field names.
-- [ ] Automated checks are not duplicated as manual verification.
-- [ ] Remaining non-critical source or impact gaps on an approval-eligible design set `executionReadiness: partial`; critical gaps keep the design blocked and prevent task generation.
-- [ ] `tasks.md` exists only for an explicitly approved current design.
-- [ ] Approval metadata in `tasks.md` matches the current `design.md`.
-- [ ] `tasks.md.designRevision` matches the current approved design revision.
-- [ ] `designRevision == approvedRevision == tasks.md.designRevision`.
-- [ ] `tasks.md.evidenceFingerprint` matches the approved design evidence snapshot.
-- [ ] `tasks.md.productInputFingerprint` matches freshly read approved request/story inputs and the current design.
-- [ ] The executor reruns Execution Preflight immediately before executing an existing task artifact; generation-time checks are not sufficient.
-- [ ] Every task has its own readiness; global `partial` identifies which tasks remain blocked or partial.
-- [ ] Every evidence-resolution task routes its bounded read through the impact owner, records it in `impact.md`, creates a new unapproved design revision when evidence changes, stops for reapproval, and regenerates tasks instead of promoting the old artifact in place.
-
-`TBD`, `TODO`, `implement later`, `fill in details`, `Similar to Task N`,
-generic "add validation/error handling", and test steps without complete test
-content are plan failures. Replace every template slot before persisting the
-generated `tasks.md`; template markers must never survive in the artifact.
-
-Readiness assignment is deterministic:
-
-```text
-design unapproved -> do not create or overwrite tasks.md
-design Self Review blocked or NEEDS_WORK -> reject approval; do not create or overwrite tasks.md
-design approval metadata missing/mismatched -> existing tasks.md is stale; do not execute
-designRevision missing/mismatched -> existing tasks.md is stale; do not execute
-productInputFingerprint missing/mismatched -> existing tasks.md is stale; reread product inputs and create a new unapproved design revision
-evidenceFingerprint changed after approval -> create new unapproved design revision; do not create tasks
-approval-eligible design approved + any non-critical impact/source/command/path gap -> partial
-design approved + required evidence confirmed + coverage complete -> ready
+| 순서 | 변경 | 확인 신호 | 실패 시 조치 |
+| --- | --- | --- | --- |
 ```
+
+## 작성 규칙
+
+- 승인 전에는 `tasks.md`를 만들거나 덮어쓰지 않는다.
+- `ready` 작업은 관련 코드 경로가 `confirmed-path`이고 파일·심볼·인터페이스·검증
+  방식이 근거로 확인된 경우에만 쓴다.
+- 근거가 부족하면 Evidence-Resolution 작업으로 남기고, `impact.md` 갱신 → 새
+  design revision → 재승인 → tasks 재생성 순서를 따른다.
+- 테스트 코드나 파일 경로를 템플릿에 미리 생성하지 않는다.

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/SKILL.md
@@ -13,6 +13,9 @@ evidence through `platty-mcp-retrieval`, drafts `request.md` and `stories.md`,
 then uses `platty-mcp-impact-analysis` to persist the impact snapshot under
 `~/.platty/specs/<projectId>/...`.
 
+All reader-facing output is Korean. Keep code identifiers, API paths, file
+paths, status values, and quoted evidence in their original form.
+
 ## Required Sub-Skills
 
 1. Use `using-platty-mcp` for MCP capability and project context.
@@ -46,7 +49,8 @@ local Platty specs directory.
 4. Require the retrieval full-cycle ladder before SDD product claims.
 5. Stop if minimum retrieval or a selected branch's required evidence surface is
    missing.
-6. Build an SDD packet from direct evidence, inference boundaries,
+6. Require the retrieval packet to distinguish document-map evidence resolved
+   with `document_resolve` from candidates, then build an SDD packet from direct evidence, inference boundaries,
    coverage limits, assumptions, confirmed decisions, and open questions.
 7. Draft `request.md` content through §8 by applying the request template.
 8. Always draft `stories.md` with `request.md` by applying the stories template.
@@ -58,17 +62,18 @@ local Platty specs directory.
    `impact.md` and returns `impactDossier`, `impactStatus`, `sourceParity`, and
    the verified `impactArtifactPath`. Missing workspace parity creates partial
    impact without erasing the product drafts.
-10. Append the compact Engineering Discovery Handoff to `request.md` after §8,
-    using the impact result; then complete §9 Self Review.
+10. Add only a compact `impact.md` status link to `request.md`; detailed
+    discovery, freshness, graph, and source evidence remain in `impact.md`.
 11. Run Self Review across the raw idea, all available requirement inputs, MCP
    evidence, `request.md`, `stories.md`, and the impact result.
-12. Run `review -> revise -> review`; record the final Requirement Coverage,
-    Search Route Audit, and cross-document findings in the drafts.
+12. Run `review -> revise -> review`; retain the final Requirement Coverage,
+    Search Route Audit, and cross-document findings in the review result and
+    `impact.md`, not in planner-facing document bodies.
 13. Persist the revised `request.md` and `stories.md` under the same SDD
     directory. SDD spec must not format or write impact.md.
 14. Verify all three files are readable. Confirm that the three artifacts share
-    `projectId` and `contextStatus`; use `impact.md`'s `sourceCommits` and the
-    handoff's Source commits for source metadata, and use its `retrievedAt` for
+    `projectId` and `contextStatus`; use `impact.md`'s `sourceCommits` for
+    source metadata and its `retrievedAt` for
     impact freshness. Derive the spec identity from the verified
     `impactArtifactPath` and confirm that `impact.md`, `request.md`, and
     `stories.md` are in the same shared SDD directory before returning the final
@@ -87,10 +92,9 @@ Persist durable workflow metadata needed by later SDD stages in frontmatter:
 `localPersistenceTarget`, raw MCP tool payloads, and transient candidate lists in
 the SDD packet, not in the drafted file frontmatter.
 
-Append `## Engineering Discovery Handoff` immediately after §8 in `request.md`.
-Use the compact shape in `references/request-shape.md`; do not include the full
-impact matrix, raw MCP payload, shell transcript, or source bodies in the
-request.
+Do not include an evidence table, self-review checklist, raw MCP payload, shell
+transcript, or source bodies in planner-facing documents. `impact.md` owns those
+details; the request only links to it with status and known limits.
 
 `request.md` uses `references/request-shape.md` and includes these sections in
 order:
@@ -105,13 +109,12 @@ order:
 §6 Confirmed Decisions
 §7 Open Questions
 §8 Validation Hypotheses
-Engineering Discovery Handoff
-§9 Self Review
+Impact reference
 ```
 
-`stories.md` uses `references/stories-shape.md`, starts with `# User Stories`,
-uses `US-NN` story blocks with Given/When/Then scenarios, and ends with
-Traceability followed by Self Review.
+`stories.md` uses `references/stories-shape.md`, starts with `# 사용자 스토리`,
+uses `US-NN` story blocks with Given/When/Then scenarios, and ends with the
+Korean rule-to-scenario connection table.
 
 ## Local Persistence
 
@@ -232,7 +235,7 @@ Read `references/stories-shape.md` before drafting stories content. If
 
 ## Self Review Gate
 
-Self Review is mandatory after the request handoff and both drafts exist. It
+Self Review is mandatory after the compact impact link and both drafts exist. It
 must not move either file to `approved`; explicit user approval remains the only
 approval gate.
 
@@ -249,17 +252,17 @@ Apply this review sequence:
    contradictions or unsupported promotion from inference to decision.
 4. Check request-to-story coverage without treating rule-to-scenario coverage
    as total input-requirement coverage.
-5. Check that the compact handoff agrees with `impactArtifactPath`,
-   `impactStatus`, `sourceParity`, seed EPICs/specs, freshness, source commits,
-   and coverage limits without copying impact evidence into the request.
+5. Check that the compact impact link agrees with `impactArtifactPath`,
+   `impactStatus`, freshness, and coverage limits without copying impact
+   evidence into the request.
 6. Revise both drafts for every fixable blocking finding, then review the
    revised pair again.
 
 Set the final verdict to `NEEDS_WORK` when blocking findings remain. A required
 input that cannot be read inside the MCP boundary is a requirement-coverage gap,
-not permission to claim completeness. Preserve it in §9 and keep both files
-draft. `PASS` means the authored pair is internally reviewable; it does not mean
-user approval.
+not permission to claim completeness. Preserve it in the review result and keep
+both files draft. `PASS` means the authored pair is internally reviewable; it
+does not mean user approval.
 
 ## Answer Contract
 

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/pressure-scenarios.md
@@ -42,7 +42,7 @@ Expected route:
 draft request.md and stories.md
 -> build/reuse impactSeedPacket
 -> platty-mcp-impact-analysis writes partial impact.md
--> append the compact handoff with sourceParity = partial
+-> add a compact impact.md link with partial status and the coverage limit
 -> carry source impact as coverage limit
 draft only product/spec claims supported by MCP evidence
 ```
@@ -240,8 +240,8 @@ Expected route:
 
 ```text
 keep assumptions in §7 and stories draft
--> append only the compact Engineering Discovery Handoff after §8
--> point to impact.md with status, source parity, seed ids, freshness, commits, and limits
+-> keep detailed discovery in impact.md and add only its compact status link to request.md
+-> point to impact.md with status and the user-relevant coverage limit
 -> keep Self Review verdict and approval state honest
 ```
 

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/request-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/request-shape.md
@@ -1,8 +1,8 @@
-# MCP SDD Request Shape
+# MCP SDD 요청서 형식
 
-Use this template reference when `platty-mcp-sdd-spec` drafts `request.md`.
-Preserve this section order. Fill unknowns as open questions or assumptions
-instead of changing the template.
+`request.md`는 기획자·디자이너·QA가 읽는 한국어 문서다. MCP 조사 상세,
+최신성, source parity, 도구 호출, Self Review는 `impact.md`와 frontmatter에
+남기고 본문에 복사하지 않는다.
 
 ## Frontmatter
 
@@ -10,7 +10,7 @@ instead of changing the template.
 ---
 id: "SPEC-<slug>-<YYYY-MM>"
 type: "sdd-request"
-status: "draft"       # draft -> approved
+status: "draft"
 projectId: "<projectId>"
 outputLanguage: "ko"
 sourceCommit: "<source commit or unknown>"
@@ -22,173 +22,80 @@ created: "<YYYY-MM-DD>"
 ---
 ```
 
-## Required Sections
+## 본문
 
 ```markdown
-# <Request Title>
+# <요청 제목>
 
-> <One-paragraph product intent, grounded in MCP evidence and clearly marked assumptions.>
+> <무엇을, 왜 바꾸는지 2~4문장>
 
-## §0 Impact
+## 0. 변경 한눈에 보기
 
-- **영향 유저**
-  - <Affected users or actors>
-- **검색 기준**
-  - Raw terms: <raw user terms>
-  - Korean candidate terms: <Korean terms searched>
-  - English candidate terms: <English terms searched>
-- **영향 EPIC**
-  - <EPIC>: <affected product area>
-- **영향 화면**
-  - <screen/flow/API if known>
-- **관련 SOT**
-  - <MCP document/spec ids read>
-- **관련 코드 참조**
-  - <source confirmations or "추가 확인 필요">
+| 항목 | 내용 |
+| --- | --- |
+| 대상 사용자 | |
+| 바꾸는 경험/정책 | |
+| 영향 영역 | |
+| 이번에 하지 않는 것 | |
 
-## §1 Customer Task
+## 1. 사용자 과업과 현재 문제
 
-> 유저와 제품팀이 해결하려는 일
+### 사용자 과업
 
-- **<actor>**: "<job-to-be-done>"
+> **<사용자>**는 <목표>를 위해 <행동>할 수 있어야 한다.
 
-## §2 Current Situation
+### 현재 문제
 
-### 2-1. 관측된 문제
+- <관찰된 문제 또는 정책 충돌>
+- <현재 흐름의 한계>
 
-- <Observed problem, metric, workflow gap, or policy conflict>
+## 2. 범위
 
-### 2-2. 문제가 아닌 것으로 본 영역
+| 포함 | 제외 |
+| --- | --- |
+| | |
 
-- <Non-goal or area not treated as the bottleneck>
+## 3. 제안하는 해결 방향
 
-### 2-3. 데이터 해석 주의
+### <해결 영역>
 
-- <Data caveat, freshness caveat, source parity limit, or MCP coverage limit>
+- <사용자에게 보이는 변경>
 
-## §3 Limits
+## 4. 제품 규칙
 
-> 기존 해결책의 한계와 이번 변경의 범위
+| ID | 규칙 |
+| --- | --- |
+| R-01 | WHEN <조건>, 시스템은 <관찰 가능한 결과>를 제공한다. |
 
-- <Why existing behavior or workaround is insufficient>
+## 5. 확정 결정과 미결 질문
 
-### In Scope
-
-- <Behavior, actor, flow, or policy included in this request>
-
-### Out of Scope
-
-- <Adjacent behavior explicitly excluded from this request>
-
-### Non-Goals
-
-- <Outcome this request intentionally does not optimize or redesign>
-
-## §4 Solution
-
-> 제안하는 변경 내용
-
-### 4-1. <solution area>
-
-- <Requested product behavior>
-
-## §5 Rules
-
-> EARS 패턴 비즈니스 규칙
-
-| ID | EARS 텍스트 | 비고 |
-|----|------------|------|
-| R-01 | WHEN <trigger>, 시스템은 <observable behavior>. | <evidence or assumption> |
-
-## §6 Confirmed Decisions
-
-> 대화 중 확정된 의사결정
+### 확정 결정
 
 | ID | 결정 | 근거 |
-|----|------|------|
-| D1 | <Only user-approved or exact MCP evidence-backed decision> | <basis> |
+| --- | --- | --- |
+| D-01 | | |
 
-## §7 Open Questions
+### 미결 질문
 
-> 미결 사항 — design/tasks 단계 전 확인 필요
+| ID | 질문 | 영향 | 추천안 |
+| --- | --- | --- | --- |
+| O-01 | | | |
 
-| ID | 질문 | Owner | Affected ids | Status | Scenario-shaping assumption | 추천안 |
-|----|------|-------|--------------|--------|-----------------------------|--------|
-| O1 | <Question> | <decision owner> | <R-NN / US-NN-SNN> | <open or resolved> | <assumption carried into scenarios> | <Recommended default and implication> |
+## 6. 성공 검증
 
-## §8 Validation Hypotheses
+| ID | 확인할 결과 | 측정 또는 관찰 방법 |
+| --- | --- | --- |
+| H-01 | | |
 
-> 성공 검증 방법
+---
 
-| ID | 가설 | 측정 기준 | 목표 방향 |
-|----|------|----------|----------|
-| H1 | <Hypothesis> | <Metric or validation signal> | <Target direction> |
-
-## Engineering Discovery Handoff
-
-- **Impact artifact**: `impact.md`
-- **Impact status**: <seeded | investigated | partial>
-- **Source parity**: <confirmed | partial | unavailable>
-- **Seed EPICs**: <ids and names>
-- **Seed specs**: <ids and kinds>
-- **Context freshness**: <fresh | stale | unknown>
-- **Source commits**: <repo id -> commit>
-- **Coverage limits**: <short summary or none>
-
-## §9 Self Review
-
-- **Verdict**: <PASS | NEEDS_WORK>
-- **Blocking findings**: <count>
-- **Warnings**: <count>
-
-### Requirement Coverage
-
-| Input source or requirement | Result | Evidence or gap |
-|----|----|----|
-| <raw idea, provided requirement, confirmed answer, or MCP evidence> | <covered|partial|missing|conflict> | <request/story location or finding> |
-
-### Search Route Audit
-
-| Check | Result | Evidence or gap |
-|----|----|----|
-| Search Brief preserves raw, Korean, English, alias, and attempted-query fields | <PASS|FAIL|N/A> | |
-| Project overview, candidate EPIC map, and relevant Memory overlay were checked | <PASS|FAIL> | |
-| BR/DD/DESIGN/UCL maps and exact items were read for the selected branch | <PASS|FAIL> | |
-| `document_get`/`document_item_get` and `document_resolve` completed where required | <PASS|FAIL> | |
-| Selected specs received `spec_get` and `spec_resolve` | <PASS|FAIL|N/A> | |
-| Exact source claims use bounded `readonly_workspace_shell` evidence | <PASS|FAIL|N/A> | |
-| Direct evidence, inference, unread surfaces, freshness, and missing MCP surfaces are separated | <PASS|FAIL> | |
-| Final Route Audit completed before drafting factual claims | <PASS|FAIL> | |
-
-### Findings
-
-| Severity | Finding | Required action |
-|----|----|----|
-| <blocking|warning> | | |
+**조사 근거**: [impact.md](impact.md) — 상태: <investigated | partial>, 한계: <한 줄 또는 없음>.
 ```
 
-## MCP Grounding Slots
+## 작성 규칙
 
-- Put exact MCP reads in §0 `관련 SOT` and §6 decision bases.
-- Put source parity gaps, stale evidence, and data caveats in §2-3.
-- Put unresolved assumptions in §7, not in §6.
-- Append the compact Engineering Discovery Handoff after §8 from the verified
-  impact result. Do not include the full Impact Evidence Matrix, raw MCP
-  payload, shell transcript, or source bodies in `request.md`.
-- Keep MCP-only metadata such as project id, output language, evidence boundary,
-  context status, derived evidence ids, and local persistence target outside the
-  markdown draft in the SDD Handoff Packet.
-
-## Rules
-
-- Explain internal names before listing ids, symbols, APIs, or document keys.
-- Keep raw user terms, Korean candidate terms, English candidate terms, and
-  matched glossary terms visible when retrieval normalized vocabulary.
-- Do not promote open questions or assumptions into confirmed decisions.
-- Mark source-level impact as a coverage limit when source parity is missing.
-- Keep the handoff to its eight summary fields; `impact.md` owns the complete
-  impact dossier and evidence matrix.
-- Every §5 rule must be observable or testable.
-- Self Review `PASS` does not change frontmatter status to `approved`.
-- Missing required input or a required retrieval rung makes the verdict
-  `NEEDS_WORK`; preserve the gap instead of claiming completeness.
+- `document_resolve`로 연결한 제품 문서와 `graph_trace` 결과의 상세는
+  `impact.md`에 남긴다.
+- 확인되지 않은 구현 경로를 제품 결정처럼 쓰지 않는다.
+- 미결 가정은 `미결 질문`에 남기고 확정 결정으로 승격하지 않는다.
+- `impact.md`가 partial이면 본문의 범위 또는 검증에서 그 한계를 짧게 알린다.

--- a/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/stories-shape.md
+++ b/plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/stories-shape.md
@@ -1,8 +1,7 @@
-# MCP SDD Stories Shape
+# MCP SDD 사용자 스토리 형식
 
-Use this template reference whenever `platty-mcp-sdd-spec` drafts
-`stories.md`. Preserve this story/scenario/traceability shape so designers,
-planners, and implementation agents can review the same product behavior.
+`stories.md`는 한국어 사용자 시나리오 문서다. 구현 근거와 내부 검토 기록은
+`impact.md` 및 frontmatter에 둔다.
 
 ## Frontmatter
 
@@ -10,7 +9,7 @@ planners, and implementation agents can review the same product behavior.
 ---
 id: "SPEC-<slug>-<YYYY-MM>"
 type: "sdd-stories"
-status: "draft"       # draft -> approved
+status: "draft"
 projectId: "<projectId>"
 outputLanguage: "ko"
 sourceCommit: "<source commit or unknown>"
@@ -21,77 +20,40 @@ derivedFrom: "request.md"
 ---
 ```
 
-## Required Sections
+## 본문
 
 ```markdown
-# User Stories — <Request Title>
+# 사용자 스토리 — <요청 제목>
 
-> request.md의 §1 Customer Task + §5 Rules에서 파생.
-> 디자이너·기획자가 사용자 관점에서 시나리오를 검토할 수 있도록 Given-When-Then 형식으로 작성.
-> 내부 구현 방식보다 유저가 인지하는 결과와 제품팀이 검증해야 할 행동을 중심으로 기술한다.
+> 사용자 관점의 결과와 검증 가능한 시나리오만 적는다.
 
----
+## US-01. <스토리 제목>
 
-## US-01: <story title>
+**사용자로서** <사용자>는<br>
+**<목표>를 위해** <행동>하고 싶다.<br>
+**그래서** <기대 결과>를 얻는다.
 
-**As a** <actor><br>
-**I want** <goal><br>
-**So that** <outcome>
+### 시나리오 1: 정상 흐름
 
-### Scenario 1: US-01-S01 <scenario title> (정상)
+- **Given** <상태>
+- **When** <행동 또는 트리거>
+- **Then** <사용자/운영자가 확인하는 결과>
 
-- **Given** <user/system state>
-- **When** <user action or system trigger>
-- **Then** <visible or measurable result>
-- **And** <optional additional result>
+### 시나리오 2: 예외 흐름
 
-### Scenario 2: US-01-S02 <scenario title> (엣지)
+- **Given** <예외 상태>
+- **When** <행동 또는 트리거>
+- **Then** <기대 결과>
 
-- **Given** <edge state>
-- **When** <action or trigger>
-- **Then** <expected behavior>
+## 규칙·시나리오 연결
 
----
-
-## Traceability
-
-> 각 User Story가 어떤 Rule(§5)에서 파생됐는지 추적
-
-| User Story | Scenario | 관련 Rules | 비고 |
-|------------|----------|------------|------|
-| US-01 | US-01-S01 <scenario> | R-01 | <note> |
-
-**Rule 커버리지: R-01~R-<N> 전부 1개 이상 시나리오에 매핑 (<N>/<N>, 100%)**
-
-## Self Review
-
-- **Verdict**: <PASS | NEEDS_WORK>
-- **Blocking findings**: <count>
-
-| Check | Result | Evidence or finding |
-|----|----|----|
-| request.md consistency | <PASS|FAIL> | |
-| Rule-to-scenario coverage | <PASS|FAIL> | |
-| Every customer task has a story | <PASS|FAIL> | |
-| Scenarios describe user/operator-visible outcomes | <PASS|FAIL> | |
-| Assumptions and coverage gaps remain explicit | <PASS|FAIL> | |
+| 제품 규칙 | 사용자 스토리 | 시나리오 | 남은 가정 |
+| --- | --- | --- | --- |
+| R-01 | US-01 | US-01-S01 | |
 ```
 
-## Rules
+## 작성 규칙
 
-- Every story must map to a request rule or open assumption.
-- Give each new scenario an immutable `US-NN-SNN` id. Do not renumber an
-  existing id when stories or scenarios are reordered; allocate a new id only
-  for a genuinely new scenario.
-- Do not invent implementation detail that the request did not establish.
-- Preserve unresolved assumptions instead of silently closing them.
-- For every open question that shaped a scenario, retain its owner, affected ids,
-  status, and scenario-shaping assumption in the story or Traceability note.
-- If `request.md` is still draft, keep `stories.md` draft and include the
-  assumptions that were used to split stories.
-- Keep runtime-only metadata outside the markdown draft in the SDD packet.
-- If a request rule has no scenario, keep the coverage line below 100% and call
-  out the missing rule in Traceability.
-- Rule coverage measures authored rules only; do not present it as total
-  user-input or evidence coverage.
-- Self Review `PASS` does not approve the document.
+- 각 스토리는 규칙 또는 명시된 가정과 연결한다.
+- `US-NN-SNN` 식별자는 한 번 부여하면 순서 변경으로 다시 번호를 매기지 않는다.
+- 내부 구현 방식, MCP 도구 호출, 근거 매트릭스, Self Review는 본문에 넣지 않는다.


### PR DESCRIPTION
## Summary
- Release Platty agent plugin v0.0.4 build 202607131033.

## Release metadata
- Version: `0.0.4`
- Build: `202607131033`
- Branch: `release/platty-plugin-v0.0.4-build-202607131033`
- Source commit: `4d81cd2e466345318b896f3f6ff8aa3645b69834`

## Exported managed paths
- `.agents`
- `.claude-plugin`
- `plugins/platty`
- `plugins/platty-mcp`
- `guide`
- `README.md`
- `README.ko.md`
- `GETTING_STARTED.md`
- `LICENSE.md`

## Changed files
- `plugins/platty-mcp/skills/platty-mcp-impact-analysis/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/impact-dossier.md`
- `plugins/platty-mcp/skills/platty-mcp-impact-analysis/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-review-rubric.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/references/design-shape.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-design/references/tasks-shape.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/request-shape.md`
- `plugins/platty-mcp/skills/platty-mcp-sdd-spec/references/stories-shape.md`

## Safety gate result
- `public_plugin_release_safety: passed`

## Verification
- `npm run check:agent-skills`
- `npm run check:agent-marketplace`
- `node --test tests/export-public-plugin-repo.test.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 영향 분석, 시스템 설계, 작업 계획 문서 템플릿을 간결한 표준 형식으로 개편했습니다.
  * 한국어 기반의 요청서와 사용자 스토리 작성 형식을 제공합니다.
  * 영향 근거와 코드 경로의 확인 상태를 명확히 표시하도록 개선했습니다.
  * 근거가 불충분한 경우 확정된 내용과 미확인 사항을 구분하고, 후속 확인 작업으로 관리할 수 있습니다.
  * 요청 문서에는 상세 조사 내용 대신 영향 문서로 연결되는 간결한 참조를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->