### PR TITLE
Release Platty agent plugin v0.0.6 build 202607140352

### DIFF
--- a/plugins/platty-mcp/.claude-plugin/plugin.json
+++ b/plugins/platty-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platty-mcp",
   "description": "Platty MCP read-only retrieval, impact analysis, memory, and approval-gated local SDD design/task draft skills for configured remote context servers; no server or unrelated write capability.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": {
     "name": "Paradigm Shift Labs"
   },

--- a/plugins/platty-mcp/.codex-plugin/plugin.json
+++ b/plugins/platty-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platty-mcp",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Platty MCP retrieval, impact, memory, and SDD handoff skills for configured remote context servers.",
   "author": {
     "name": "Paradigm Shift Labs"


### PR DESCRIPTION
## Summary
- Release Platty agent plugin v0.0.6 build 202607140352.

## Release metadata
- Version: `0.0.6`
- Build: `202607140352`
- Branch: `release/platty-plugin-v0.0.6-build-202607140352`
- Source commit: `697bf4598309d2a5b3ab3c219b88faf4fe757d3a`

## Exported managed paths
- `.agents`
- `.claude-plugin`
- `plugins/platty`
- `plugins/platty-mcp`
- `guide`
- `README.md`
- `README.ko.md`
- `GETTING_STARTED.md`
- `LICENSE.md`

## Changed files
- `plugins/platty-mcp/.claude-plugin/plugin.json`
- `plugins/platty-mcp/.codex-plugin/plugin.json`

## Safety gate result
- `public_plugin_release_safety: passed`

## Verification
- `npm run check:agent-skills`
- `npm run check:agent-marketplace`
- `node --test tests/export-public-plugin-repo.test.mjs`
