### PR TITLE
Release Platty agent plugin v0.0.13 build 202607150211

### DIFF
--- a/plugins/platty-mcp/.claude-plugin/plugin.json
+++ b/plugins/platty-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platty-mcp",
   "description": "Platty MCP read-only retrieval, impact analysis, memory, and approval-gated local SDD design/task draft skills for configured remote context servers; no server or unrelated write capability.",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "author": {
     "name": "Paradigm Shift Labs"
   },

--- a/plugins/platty-mcp/.codex-plugin/plugin.json
+++ b/plugins/platty-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platty-mcp",
-  "version": "0.0.12+codex.20260714165323",
+  "version": "0.0.13+codex.20260715020655",
   "description": "Platty MCP retrieval, impact, memory, and SDD handoff skills for configured remote context servers.",
   "author": {
     "name": "Paradigm Shift Labs"

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md
@@ -22,14 +22,24 @@ Do not call `document_search`, `ssot_search`, `spec_search`, `code_search`, or
 and selected BR/DD/DESIGN/UCL map first. Search narrows candidates after maps;
 it cannot replace exact `epic_get`, `document_list`, `document_item_get`,
 `document_resolve`, `spec_get`, or `readonly_workspace_shell` reads.
+
+Use `spec_list` for a complete API, screen, event, or schedule inventory. Apply
+`specKind` and `scopeId` filters when known and follow every `nextCursor` until
+`hasNextPage` is false. Use `spec_search` only for targeted discovery when the
+exact spec id is unknown, then confirm selected hits with `spec_get` and
+`spec_resolve`.
 </HARD-GATE>
 
-The MCP profile is read-only. Use configured MCP tools only. Do not read local
-files, use local shell/CLI as a fallback, read local SOT, mutate projects,
-generate documents, or write memory. MCP-provided source tools such as
-`readonly_workspace_shell` are allowed when exposed and required by the evidence
-gate; they are not local fallback. Stored SOT files are available only through
-MCP artifact tools and need exact evidence reads before behavior claims.
+## MCP Tool Boundary
+
+| Case | Required behavior |
+| --- | --- |
+| Allowed | Use configured MCP tools. MCP `readonly_workspace_shell` is the bounded source-read tool when exposed. |
+| Prohibited | Do not use host/local files, host/local shell or CLI, local SOT, project mutation, generation, or memory writes. |
+| Missing MCP surface | Report the capability gap and weaken or stop the claim; never substitute a host/local surface. |
+
+Stored SOT files are available only through MCP artifact tools and need exact
+evidence reads before behavior claims.
 
 Memory overlay reads are a first-class retrieval rung. At every selected
 overview, epic, document, item, and spec read, inspect returned memory summary
@@ -107,9 +117,7 @@ generation, report a boundary gap.
 
 | Do | Don't |
 | --- | --- |
-| Use configured MCP tools only, including MCP `readonly_workspace_shell` when exposed for bounded source confirmation. | Read local files, use local shell/CLI fallback, local SOT, DB tables, or caches. |
 | Build project, epic, BR/DD/DESIGN/UCL, spec, and source maps in order. | Treat one search hit, snippet, or score as proof. |
-| Read attached memory overlays on every selected overview/epic/document/item/spec surface, and use `memory_get` for relevant cards. | Treat memory as generated SOT or source-confirmed behavior. |
 | On every table/field route, inspect parent `data_dictionary` document memories before item-level conclusions; use `memory_list(documentId)` if attached cards are unavailable. | Read only the `dd_field` item and skip a parent DD fallback memory. |
 | Normalize vocabulary when terms may not line up. | Treat glossary normalization as behavior evidence. |
 | Read exact item/spec/source evidence before implementation claims. | Claim response shape, permissions, writes, emits, or absence without the required evidence tier. |

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md
@@ -11,7 +11,6 @@ detail second.
 - Canonical Ladder
 - Runtime Evidence Checklist
 - Business Document To Source-Near Spec Descent
-- Retrieval Order
 - Final Route Audit
 
 ## Exact Item Fast Path
@@ -103,142 +102,47 @@ capability gap instead of replacing the rung with search.
 
 ## Runtime Evidence Checklist
 
-Before answering, keep this checklist in runtime context and complete the rungs
-required by the selected question branch. Do not print a long checklist in the
-final answer unless the user asks for the route audit.
+Use this only for branch-level completion state; do not restate the Canonical
+Ladder in runtime context or the final answer.
 
-```text
-[ ] Select project with project_list or project_get.
-[ ] Check context_status and project_overview_get.
-[ ] Inspect memory summary cards returned by every selected overview, epic,
-    document, item, and spec read before discarding candidates or finalizing
-    claims.
-[ ] If any memory title/contentPreview/kind/level/trust/alias is relevant to
-    the question, ambiguity, correction, constraint, why, naming, deprecated
-    behavior, or operational caveat, call memory_get for the exact body.
-[ ] Identify relevant EPICs with epic_list and epic_get.
-[ ] Normalize ambiguous Korean/domain terms with glossary_translate or
-    glossary_list when needed.
-[ ] If this is a pure service overview/user-type explanation with no concrete
-    implementation, API, screen, event, schedule, state, or operational-data
-    claim, stop at overview/epic/SSOT depth and state the boundary.
-[ ] For product/business flow: use ssot_search -> ssot_get when SSOT evidence is
-    the selected surface.
-[ ] For authored docs or business rules: use document_list/search/get and exact
-    document_item_get when item evidence is needed.
-[ ] If any exact BR/DD/DESIGN/UCL item was used, run document_resolve(itemId)
-    before source-near search, or state why the answer remains purely
-    conceptual.
-[ ] For product flow, capability, journey, admin workflow, data flow,
-    integration, architecture, or implementation-facing questions, include
-    DESIGN as a near-mandatory business map before descending to specs.
-[ ] For API/screen/event/schedule/source-near behavior: use
-    document_resolve(itemId) first after exact item reads, and prefer explicitly
-    linked api_spec/screen_spec/event_spec/schedule_spec ids when available.
-    Use spec_search only as fallback when explicit links are absent, incomplete,
-    stale, too broad, or unresolved.
-[ ] Run spec_resolve after selected spec reads when connected docs/items, graph
-    seeds, or code seeds matter.
-[ ] If implementation behavior is important or still ambiguous:
-    [ ] use code_search to find filePath/functionName candidates when the source
-        address is incomplete.
-    [ ] use workspace_repo_list if repoId is unknown.
-    [ ] actively use bounded readonly_workspace_shell to read only the relevant
-        file/function range before making code behavior claims. There is no
-        code_snippet tool; do not ask for or claim one.
-[ ] If operational data is claimed:
-    [ ] only do this when a data MCP is exposed for the environment.
-    [ ] read data_analysis_guide/domain_guide when exposed by that data MCP.
-    [ ] use read-only RDS/Athena SELECT and state sample/cohort limits.
-[ ] If no operational data MCP is exposed for a funnel/conversion/bottleneck
-    question, limit the answer to SSOT-derived funnel steps, instrumentation
-    points, and hypotheses. Do not claim observed conversion drops or causes.
-[ ] Do not treat search snippets, scores, overview text, or glossary output as
-    proof.
-[ ] State freshness, coverage, missing MCP surfaces, and any unresolved
-    ambiguity.
-```
+- Record the evidence depth selected from the table above and whether the route
+  ended conceptually, reached source confirmation, or stopped at a missing MCP
+  surface.
+- When operational data is claimed, require an exposed data MCP, read
+  `data_analysis_guide`/`domain_guide` when available, use read-only RDS/Athena
+  `SELECT`, and state sample/cohort limits. Without that surface, limit funnel
+  or conversion answers to SSOT-derived steps, instrumentation points, and
+  hypotheses.
+- When `spec_search` selects a candidate, follow it with `spec_get` and
+  `spec_resolve` in the same route.
+- Run the Final Route Audit and expose only failures that change confidence or
+  scope.
 
-When `spec_search` is used, every selected spec candidate must be followed by `spec_get` and `spec_resolve` in the same route. Do not treat a spec search hit as complete evidence or defer resolve to a later optional step.
+For a complete API inventory, or a complete screen, event, or schedule
+inventory, use `spec_list` with the narrowest known `specKind` and `scopeId`.
+Follow `nextCursor` until `hasNextPage` is false. Do not use ranked
+`spec_search` results as proof that the inventory is complete.
 
 ## Business Document To Source-Near Spec Descent
 
-When the question starts from SOT business context, treat BR/DD/DESIGN/UCL
-documents and items as the map, not as source-near proof:
+When the question starts from exact BR/DD/DESIGN/UCL evidence, use the selected
+item as the bridge rather than rebuilding the whole ladder:
 
 ```text
-business question
--> document_list/document_get/document_item_list
-   [MUST] include DESIGN for product flow, capability, journey, admin workflow,
-   data flow, integration, architecture, or implementation-facing questions
--> document_item_get for exact business item
--> document_resolve(itemId) to follow explicit item links and collect linked
-   api_spec, screen_spec, event_spec, and schedule_spec ids when returned
--> rank linked source-near spec candidates and keep selected spec ids visible
--> spec_list/spec_search only if document_resolve returns no usable link, an
-   incomplete/stale/too-broad linked set, or the exact spec id is unknown
--> when spec_search is used, select candidate specs before making claims
--> spec_get for selected api_spec/screen_spec/event_spec/schedule_spec details
--> spec_resolve to expand selected specs to related docs/items, graph seeds, and code seeds
+document_item_get
+-> document_resolve(itemId)
+-> rank linked api_spec/screen_spec/event_spec/schedule_spec candidates
+-> spec_get for selected exact specs
+-> spec_resolve for reverse anchors and graph/code seeds
 ```
 
-`document_resolve(itemId)` is the first bridge from an exact business item to
-linked source-near specs. Use `document_resolve(documentId)` only when doing
-document-wide inventory before an exact item is selected. `spec_resolve` is not
-the first bridge from business docs to specs; use it after selecting a spec to
-collect reverse anchors, related items/documents, and source seed expansion.
+Use `document_resolve(documentId)` only for document-wide inventory. Prefer
+explicit links and rank by direct link, same epic, entity/field, target, and
+branch intent. Use `spec_search` only when links are absent, incomplete, stale,
+too broad, or leave the exact spec unknown; then read the selected exact specs
+before making source-near claims.
 
-Business document items are routing evidence. For exact API, screen, event, or
-schedule behavior, rank connected `api_spec`, `screen_spec`, `event_spec`, and
-`schedule_spec` candidates before opening details. Direct document/spec links,
-same epic, same entity/field, same route/screen/API/event/schedule target, and
-same branch intent rank first.
-
-Always use explicit links first. `document_resolve(itemId)` is the MCP
-equivalent of following traced business-doc item context into linked specs/items;
-it is the first bridge from exact business evidence to source-near evidence. If
-the selected DESIGN/BR/DD/UCL document or item does not return enough linked
-source-near specs, or returns stale/too-broad candidates, widen with
-`spec_search` using the business terms, route/screen names, table/model names,
-status names, and API/action names discovered from the document. Then read
-`spec_get` and `spec_resolve` for the selected specs before source-near claims.
-Do not open every connected spec up front; rank first, then read the strongest
-candidates.
-
-Memory overlays are correction/constraint/why/context notes attached to the
-overview, epics, documents, items, or specs. They are a required
-selected-surface read, not an optional afterthought. Inspect attached memory
-summary cards at each selected surface: `project_overview_get.overview.memories`,
-`epic_get.memories`, `document_get.memories`, item memories, and spec memories
-when those surfaces return them. If any memory card is relevant to the user
-question, ambiguity, correction, constraint, why, naming, deprecated behavior,
-or operational caveat, call `memory_get` for the exact body before finalizing.
-If the exact body is not read, name the memory as an unread coverage limit. Do
-not treat memory as generated SOT or source proof.
-
-## Retrieval Order
-
-```text
-project context
--> context status
--> capability check
--> Search Clarification Gate when triggers fire
--> project overview with attached overview memory cards inspected
--> glossary_list for broad inventory, comparison, ambiguity, all-alias requests, or blank/conflicting translation; traverse every page when completeness is required
--> glossary_translate for the raw phrase and Korean/English candidates; record matched terms and alias candidates
--> candidate epic
--> candidate BR/DD/DESIGN/UCL document map
--> question branch
--> relevant business document items or exact source-near anchor
--> connected api_spec/screen_spec/event_spec/schedule_spec evidence through
-   document_resolve(itemId) after exact item reads, with spec_search fallback
-   only when explicit links are absent, incomplete, stale, too broad, or unresolved
--> exact spec evidence
--> spec_resolve for connected context and graph/code seeds
--> source-level confirmation only when required
--> Final Route Audit
--> answer with boundary
-```
+Apply the retrieval skill's memory-overlay invariant throughout this descent.
 
 ## Final Route Audit
 

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.md
@@ -16,6 +16,7 @@ expected route.
 - Scenarios 13-15: coupon ambiguity, complete glossary inventory, older server
   exact-spec route
 - Scenario 17: managed-worktree Git history and deployment-boundary labeling
+- Scenarios 18-19: complete spec inventory versus exact targeted lookup
 
 ## Scenario 1: Korean Domain Term
 
@@ -642,4 +643,52 @@ capability gate
 -> preserve networkChecked=false and productionDeploymentObserved=false
 -> if git_metadata_unavailable, report the linked Git metadata gap without local fallback
 -> state that actual production deployment requires separate CI/CD/deployment evidence
+```
+
+## Scenario 18: Complete Survey API Inventory Uses Spec List
+
+User asks:
+
+```text
+Survey EPIC에 연결된 API를 빠짐없이 보여줘.
+```
+
+Failure to prevent:
+
+- treating one relevance-ranked `spec_search` page as a complete inventory;
+- failing to follow `nextCursor` when `hasNextPage` is true;
+- widening outside the selected Survey EPIC without reporting the scope change.
+
+Expected route:
+
+```text
+establish project and Survey EPIC scope
+-> spec_list(projectId, specKind=api_spec, scopeId=<survey-epic-id>)
+-> follow nextCursor until hasNextPage=false
+-> spec_get selected ids
+-> spec_resolve when connected evidence matters
+```
+
+## Scenario 19: Exact Tally Webhook Uses Targeted Search
+
+User asks:
+
+```text
+POST /api/v2/surveys/tally/webhook 스펙을 찾아서 동작을 확인해줘.
+```
+
+Failure to prevent:
+
+- treating `/api/` as a request for every API;
+- starting with a complete `spec_list` traversal when one exact target is known;
+- stopping at a search hit without exact spec and connected-context reads.
+
+Expected route:
+
+```text
+after project overview and the relevant EPIC/document map are established
+-> spec_search(projectId, query="POST /api/v2/surveys/tally/webhook")
+-> select the exact route candidate
+-> spec_get(projectId, id=<selected-spec-id>)
+-> spec_resolve(projectId, id=<selected-spec-id>)
 ```

--- a/plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md
+++ b/plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md
@@ -25,14 +25,9 @@ chosen branch. The branch route may refine `Question branch`, `Candidate MCP
 route`, and `User decision needed`, but it must preserve the raw question and
 the ambiguity trigger that caused the gate to fire.
 
-Read attached memory summary cards on every selected
-`project_overview_get.overview.memories`, `epic_get.memories`,
-`document_get.memories`, document item, and spec result before discarding
-candidates or finalizing semantic answers. If a memory title/contentPreview,
-kind, level, trust, or alias relates to the user question, ambiguity,
-correction, constraint, why, naming, deprecated behavior, or operational caveat,
-call `memory_get` before the final answer. Keep memory separate from SOT/spec/
-source proof, but treat unread relevant memory as an incomplete route.
+Apply the retrieval skill's memory-overlay invariant and the canonical ladder's
+Final Route Audit to every branch below. Branch sections add only their extra
+document families and completion conditions.
 
 Document family names such as BR, DD, DESIGN, and UCL are semantic labels in
 this guide. When passing them to `document_list.documentType`, use the MCP
@@ -159,8 +154,10 @@ Completion:
 ## Exact API, Screen, Event, Schedule
 
 Use the exact source-near branch of the Full-Cycle Retrieval Ladder. Start from
-`spec_get` when the exact spec id is known; use `spec_list/spec_search` only
-when the exact spec id is unknown. Follow selected specs with `spec_resolve`.
+`spec_get` when the exact spec id is known. When an exact route, title, symbol,
+or trace is known but the spec id is unknown, use `spec_search`, then
+`spec_get`, then `spec_resolve` for selected hits. Use `spec_list` only for a
+complete inventory and follow every page.
 
 Completion:
 

--- a/plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.md
@@ -41,43 +41,12 @@ question
 | Impact, dependency, implementation location | `document_resolve(itemId)` or `spec_resolve` -> `graph_trace` / `code_search` -> `readonly_workspace_shell` | graph/code candidates plus bounded source reads when exact source confirmation is required; state missing-tool caveats |
 | Original stored SOT file request | `sot_file_get` | file content only; not proof for behavior unless paired with structured evidence |
 
-## Full Ladder
+## Canonical Execution Order
 
-For broad product, policy, data, design, journey, or impact questions, use the
-map-first ladder:
-
-```text
-project_list / project_get / context_status
--> project_overview_get
--> glossary_list first for inventory, comparison, ambiguity, or every-alias routes; after blank/conflicting exact translation, use it before translating additional candidates
--> glossary_translate for the exact/raw phrase and Korean/English candidates
--> epic_list / epic_get
--> memory_list / memory_get overlay when relevant and available
--> document_list by type and epic
--> document_get
--> document_item_list / document_item_get
--> document_resolve(itemId) after exact item reads; use document_resolve(documentId)
-   only for document-wide inventory
--> rank linked api_spec and screen_spec candidates
--> spec_list or spec_search when connected source-near specs are incomplete or unknown
--> spec_get before exact source-near behavior claims
--> spec_resolve to expand selected specs to related documents, items, graph seeds, and code seeds
--> graph_trace / code_search / readonly_workspace_shell for impact, location, or source confirmation
-```
-
-For targeted candidate discovery, stop `glossary_list` pagination once the
-needed candidate set is clear. For complete inventory, follow
-`pageInfo.nextCursor` until `pageInfo.hasNextPage` is false. Preserve
-`aliases` for query expansion, `generatedAliases` as generated vocabulary
-routing evidence, and `memoryAliases` as memory overlays. Continue to exact
-document/spec/source evidence before behavior claims.
-
-`document_resolve(itemId)`, `spec_list`, `spec_search`, `spec_get`, and `spec_resolve`
-are part of the search path when the answer needs source-near anchors. Do not
-skip from a business document search result directly to a claim about API shape,
-screen behavior, event behavior, schedule behavior, or implementation.
-
-Treat `spec_search` as paired discovery: after it selects a candidate, immediately run `spec_get` and `spec_resolve` before making source-near, impact, graph, code, or implementation claims.
+The executable map-first order, evidence-depth rules, and completion audit live
+only in `platty-mcp-retrieval/references/full-cycle-retrieval.md`. This
+architecture reference explains tool and storage roles; it does not redefine
+that order.
 
 ## Why These Tools Exist
 

--- a/plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md
+++ b/plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md
@@ -42,8 +42,8 @@ This is the MCP-only intent-to-tool map. It does not list local CLI equivalents.
 | Business document items | `document_item_list` | `projectId`, `documentId`; optional `itemType`, `limit`, `cursor` |
 | Business document item detail | `document_item_get` | `projectId`, `itemId` |
 | Document/item connected context | `document_resolve` | `projectId` plus `documentId` or `itemId` |
-| Spec list | `spec_list` | `projectId`; optional `specKind`, `scopeId`, `status`, `filters`, `limit`, `cursor` |
-| Spec search | `spec_search` | `projectId`, `query` |
+| Spec list (complete inventory) | `spec_list` | `projectId`; optional `specKind`, `scopeId`, `status`, `filters`, `limit`, `cursor`; follow `nextCursor` until `hasNextPage` is false |
+| Spec search (targeted discovery; not a completeness surface) | `spec_search` | `projectId`, `query`; follow selected hits with `spec_get` and `spec_resolve` |
 | Spec detail | `spec_get` | `projectId`, `id` |
 | Spec connected context | `spec_resolve` | `projectId`, `id` |
 | Stored SOT file content | `sot_file_get` | `projectId`, `path` |


### PR DESCRIPTION
## Summary
- Release Platty agent plugin v0.0.13 build 202607150211.

## Release metadata
- Version: `0.0.13`
- Build: `202607150211`
- Branch: `release/platty-plugin-v0.0.13-build-202607150211`
- Source commit: `67ff39076c139acb8179feca65fa63486a3bca8b`

## Exported managed paths
- `.agents`
- `.claude-plugin`
- `plugins/platty`
- `plugins/platty-mcp`
- `guide`
- `README.md`
- `README.ko.md`
- `GETTING_STARTED.md`
- `LICENSE.md`

## Changed files
- `plugins/platty-mcp/.claude-plugin/plugin.json`
- `plugins/platty-mcp/.codex-plugin/plugin.json`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/SKILL.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/full-cycle-retrieval.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/pressure-scenarios.md`
- `plugins/platty-mcp/skills/platty-mcp-retrieval/references/question-routes.md`
- `plugins/platty-mcp/skills/using-platty-mcp/references/retrieval-architecture.md`
- `plugins/platty-mcp/skills/using-platty-mcp/references/tool-mapping.md`

## Safety gate result
- `public_plugin_release_safety: passed`

## Verification
- `npm run check:agent-skills`
- `npm run check:agent-marketplace`
- `node --test tests/export-public-plugin-repo.test.mjs`
