### PR TITLE
Restore local platty-retrieval skill and add adaptive SDD product interview

### DIFF
--- a/plugins/platty/skills/platty-cli-router/SKILL.md
+++ b/plugins/platty/skills/platty-cli-router/SKILL.md
@@ -19,13 +19,19 @@ must be registered inside that selected project.
 
 ## Root Commands
 
-Remote read-only MCP retrieval belongs to the separate `platty-mcp` plugin. Do
-not route MCP workflows through this operator router. Context-backend server
-setup, host/port exposure, and `/api/mcp` validation stay in
-`platty-mcp-server-setup`.
+Local, MCP-free retrieval and search over the exported SOT projection belongs to
+`platty-retrieval`: reading `~/.platty/sot/<projectId>/`, `platty sot
+resolve/glossary search`, `platty graph trace`, and `platty code search/snippet`.
+Route "find/what/where/how does it work/search the codebase" questions there.
+
+Remote read-only MCP retrieval is different: it belongs to the separate
+`platty-mcp` plugin. Do not route MCP workflows through this operator router.
+Context-backend server setup, host/port exposure, and `/api/mcp` validation stay
+in `platty-mcp-server-setup`.
 
 | Need | Command or skill |
 | --- | --- |
+| Answer a question about the analyzed codebase locally (domain terms, epics, docs, specs, code locations, source confirmation) | `platty-retrieval` (read SOT projection + `platty sot resolve/glossary search`, `graph trace`, `code search/snippet`) |
 | Install ordinary Platty agent skills (non-MCP agent plugin) | `platty install --json`; MCP installation stays separate |
 | Installed first end-to-end project journey through repositories, analysis, LLM approval, and SOT output | `platty-onboarding` |
 | Initialize global Platty home (`~/.platty` or `PLATTY_HOME`) | `platty init` via `platty-setup` |

--- a/plugins/platty/skills/platty-retrieval/SKILL.md
+++ b/plugins/platty/skills/platty-retrieval/SKILL.md
@@ -1,0 +1,867 @@
+---
+name: platty-retrieval
+description: Use when searching local Platty SOT outputs, generated docs, graph traces, code search, or source-grounded project evidence through the full Platty operator plugin.
+---
+
+# Platty Retrieval
+
+Use this skill when a user asks a question that should be answered from local
+Platty evidence through the full `platty` operator plugin.
+
+Remote read-only MCP retrieval is handled by the separate
+`platty-mcp:platty-mcp-retrieval` skill. Do not use this local retrieval skill
+as the MCP transport entry point.
+
+Platty projects a single source of truth (the DB) into a read-only Markdown tree at
+`~/.platty/sot/<projectId>/`. **Discovery and static relations live in that folder
+(grep/read). Computation, cross-layer traversal, and writes escalate to the CLI.**
+The split is not "MD vs CLI" — it is **enumerable/static (MD wins) vs computed/traversed/mutated (CLI wins)**:
+
+```text
+question
+-> resolve projectId -> ~/.platty/sot/<projectId>/   (folder is the map)
+-> read overview.md + catalog/*.md                   (orient; solve unknown-unknowns)
+-> use project overview/personas + catalog/epics.md  (choose candidate EPIC + purpose doc)
+-> read epics/<id>/overview.md when it exists         (compact epic routing context)
+-> choose BR / DD / DESIGN / UCL by question intent  (business-doc routing)
+-> list connected source-near specs before opening details
+-> read the source-near detail before code search     (API/screen/event/schedule)
+-> stay on the EPIC spine: use epic ids/docs as the semantic route map before final synthesis
+-> use `sot resolve` when holding an id              (epic/doc/item/model -> specs/models/trace seeds)
+-> grep catalog/*.md by name/summary                 (discover candidates — ids are opaque)
+-> read epics/<id>/*.md and specs/<kind>/<fileId>.md (detail)
+-> follow frontmatter ids to the next MD             (static relations, no CLI hop)
+-> escalate to CLI ONLY for:                         (graph trace / code search / memory write)
+-> pass the Completeness Gate (3 axes) before STOP   (depth / width / macro — not a partial answer)
+-> answer with validity (freshness)
+```
+
+When the evidence at a step is enough, STOP there; when it is not, go one step deeper.
+But before any STOP, run the **Completeness Gate (3 Axes)** (see Stop Conditions) so a plausible
+partial answer doesn't pass for the authoritative one — go down to code where the answer lives
+(depth), expose a split question instead of silently picking one branch (width), and for a
+multi-target question build the spec/BR map first and let code only verify it (macro). A pure
+definition / naming question is exempt.
+
+If the SOT folder does not exist yet, use the **advanced recovery CLI graph
+walk** below only when local CLI access is appropriate. For MCP retrieval, route
+to `platty-mcp:platty-mcp-retrieval` instead of falling back to local files or
+CLI.
+
+## Boundary
+
+`platty-retrieval` is the local operator retrieval skill:
+
+```text
+using-platty -> platty-retrieval
+using-platty-mcp -> platty-mcp-retrieval
+```
+
+Discovery starts from the local SOT Markdown projection at
+`~/.platty/sot/<projectId>/`, and computed traversal or writes escalate to
+Platty CLI commands such as `platty sot resolve`, `platty graph trace`,
+`platty code search`, `platty code snippet`, or `platty memory add`.
+
+Do not silently switch from MCP questions to local SOT files or local CLI. Route
+remote MCP questions to `platty-mcp:using-platty-mcp`.
+
+## Case Guides
+
+Keep this file as the router and common evidence rules. For case-specific depth,
+read the linked reference before answering:
+
+| Question shape | Required reference |
+| --- | --- |
+| concept, term meaning, ambiguous Korean/English term, "how are these different?" | `references/concept-search.md` |
+| exact endpoint, response shape, params, API side effects, "what does this API do/return?" | `references/exact-api.md` |
+| screen, page, route, UI entry point, screen spec | `references/screen-search.md` |
+| screen-to-api, api-to-screen, DB impact, event flow, external integration, batch, blast radius | `references/impact-tracing.md` |
+| source file, symbol, snippet, code location, concrete implementation | `references/code-search.md` |
+| business rule, policy, permission, eligibility, documented constraint | `references/business-policy.md` |
+| "what must change", "what breaks", "where do we patch this", add/change a field/type/status/category/classification | `references/design-change.md` |
+| bug, incident, root-cause investigation, regression suspicion | `references/bug-diagnosis.md` |
+| negative evidence, "does this exist?", graph gap, missing docs, coverage boundary | `references/negative-evidence.md` |
+| cross-epic, cross-product-area, multi-area flow | `references/cross-epic-flow.md` |
+
+If a reference applies, load it. Do not rely on memory of its checklist. If no
+reference clearly applies, use this SKILL.md's common State Gate, Query Class
+Routing, Completeness Gate, and Answer Contract. When the same uncovered shape
+causes repeated misses, promote it into a new reference file and add a row here.
+
+## SOT Resolve Gate (Local transport CLI or MCP equivalent)
+
+The commands below are local-transport-only. In MCP mode, use configured
+resolver/read tools such as `ssot_resolve`, `document_get`, `spec_get`, or the
+closest server-provided equivalent. If the MCP server cannot expose an
+equivalent resolver/read path, stop with a configuration/boundary gap. Do not
+read `~/.platty/sot/` or run local `platty` commands from MCP mode.
+
+When you already have an EPIC id, document id, item key, or model id/name and
+need connected APIs, screens, events, schedules, models, or graph-trace seeds,
+use the resolver before graph traversal:
+
+```bash
+platty sot resolve --project <project> --epic <epicId> --json
+platty sot resolve --project <project> --document <documentId> --json
+platty sot resolve --project <project> --item <documentId#stableKey> --json
+platty sot resolve --project <project> --model <modelId-or-name> --json
+```
+
+Resolver output is a machine-readable routing layer. It does not prove business
+claims; it chooses connected specs, models, and safe next hops. After resolve,
+assert exact behavior only from source-near specs and, when needed, graph
+trace/source code. Treat source-near API/screen/event/schedule `traceId`s as
+the normal first trace seeds. Treat model `db:<table>` traces as broad impact
+tools, not as the default next hop for business/concept retrieval.
+
+Use the default resolver output first. It is intentionally compact for agents.
+For shared models such as `User`, `Workspace`, `Channel`, `Order`, or `Project`,
+model-only resolve may be too broad. If the question already has an EPIC or
+document context, scope the model resolve:
+
+```bash
+platty sot resolve --project <project> --model <modelId-or-name> --within-epic <epicId> --json
+```
+
+Use `--detail full` only when you truly need the complete machine inventory.
+Do not use full detail as the default search path.
+
+If a model-only resolve returns a shared-model warning, do not jump straight to
+`graph trace --from db:<table>`. First scope the model with `--within-epic`, read
+the connected source-near specs, then trace from the returned API/screen/event/
+schedule ids. Use `--detail full` or a DB-anchored trace only for explicit global
+table/field impact questions.
+
+## State Gate: Choose the Retrieval Mode (Local SOT flow or MCP equivalent)
+
+The numbered flow below is the local-transport SOT projection path. In MCP
+mode, mirror the same judgment through configured MCP tools such as
+`context_status`, `ssot_search`, `ssot_get`, `ssot_resolve`, `document_get`,
+and `spec_get`. If the MCP server cannot expose the required overview, catalog,
+document, or resolver surfaces, stop with a configuration/boundary gap instead
+of reading local files or running local CLI commands.
+
+Before choosing a retrieval strategy, classify the project state from generic SOT structure.
+
+1. Resolve `projectId` and locate `~/.platty/sot/<projectId>/`.
+2. Read project `overview.md` when present and `catalog/epics.md` to choose the
+   candidate EPIC route. Do not use `README.md` as retrieval evidence; it is
+   layout/freshness audit only.
+3. Extract domain terms from the user question, preserving the raw phrase. For
+   raw user terms, aliases, synonyms, abbreviations, Korean/English variants, or
+   domain slang, call
+   `platty sot glossary search --project <project> --query "<raw term>" --json`
+   instead of expecting a glossary Markdown file. Do not guess English terms before glossary search.
+4. If live EPIC rows have `documentCount > 0` and generated files exist under `epics/<epicId>/` such as `overview.md`, `br.md`, `design.md`, `data_dictionary.md`, or `usecases/ucl.md` (`usecases/ucs.md` only when exported), use **Business Index Mode** for business, planning, policy/rules, journey, and concept questions. Project `overview.md` / `personas.md` when present and epic `overview.md` docs are coarse route maps: they choose an EPIC and purpose docs, not exhaustive API/screen/event/schedule evidence.
+5. If business docs are absent, incomplete, or not exported, use **Static Analysis Mode** for static catalogs and graph/code primitives.
+6. If the state is mixed, use Business Index Mode for valid business-doc evidence and explicitly state coverage or freshness gaps before drilling into static evidence.
+7. For development/design-impact questions ("where do I add/change this", "what breaks", code location, precise screen/api/table impact), load `references/design-change.md` even when business docs exist: start with targeted static catalog grep + graph traces when the question is already anchored to an implementation entity or asks for code/impact, then use business docs for semantic scope and constraints when available.
+
+Never use fixture names, repository names, source paths, EPIC titles, or domain-specific terms as activation conditions. The mode decision must be based on the generic SOT layout and catalog fields.
+
+## Alias Overlay Gate
+
+Before glossary routing, preserve the raw user phrase and check memory overlays for
+user-confirmed aliases. This handles domain slang, abbreviations, Korean/English
+mixes, and team-specific words that generated docs may never contain.
+
+1. Read alias memories when present:
+   - `epics/<epicId>/memory.md` after candidate EPICs are known.
+   - spec frontmatter `memories` when already on a source-near spec.
+   - document/item memories when a candidate document is already known.
+2. Treat alias memories only as query-normalization hints, not source-grounded
+   business facts. They may help search for `친구` when the user says `응원친구`,
+   but they do not prove a business rule.
+3. Search both raw and normalized terms. Example: if memory says
+   `alias: 응원친구 -> canonical: 친구`, grep/search `응원친구`, `친구`,
+   and likely code-language equivalents from glossary hits.
+4. If the raw term has no glossary/spec/code hit and fuzzy candidates are tied,
+   ask one clarifying question before answering.
+5. When the user confirms a new alias, recommend recording it with
+   `platty memory alias add --project <project> --epic <epicId> --term "<raw>" --canonical "<canonical>" --json`.
+   If no EPIC is known, ask one clarifying question and find the candidate EPIC
+   before recording. In MCP mode, do not recommend a local alias write; stop and
+   report a configuration/boundary gap, and route the user to the full `platty`
+   operator plugin for alias recording. Alias memory is query normalization, not
+   business proof.
+
+## Boundary Declaration
+
+Before answering, decide and state the evidence boundary in one or two sentences:
+
+- **Project evidence state:** business docs available, static-only, mixed, stale, or unavailable.
+- **Allowed answer scope:** what this evidence can answer.
+- **Stop boundary:** what must not be asserted from this evidence.
+
+This is not citation polish; it prevents false product claims. If business docs are absent,
+a product/planning question can still get an implementation-structure answer, but it cannot get
+retrieved business intent, policy, priority, or a complete journey. If graph trace returns no
+confirmed edge, say there is no confirmed graph evidence for that anchor/depth/kind set, not that
+there is no impact.
+
+## Source Confirmation Guard
+
+For exact behavior, permissions, response shape, DB writes, event emits, external calls, policy/rule enforcement, and negative source-absence claims, generated business docs are only the route map. Confirm through the connected source-near spec first (`specs/api`, `specs/screen`, `specs/event`, or `specs/schedule`), then inspect original source code using the spec path, `graph trace`, `code search`, `docs show` code evidence, or direct worktree reads. Assert from the source-near spec/code; cite business docs only as the index that located it.
+
+Before declaring that a handler, source file, permission check, response field, write, emit, or external call is absent, confirm the intended project repository id/path from the SOT catalog row, spec frontmatter, graph/code evidence, or `docs show` evidence. Do not search a sibling repo, tutorial variant, generated example, or adjacent monorepo package and conclude the project lacks the behavior.
+
+## Business Docs As Routers, With Bypass Gate
+
+Use business docs as detailed routers when the question is business-contextual,
+ambiguous, or asks about a capability, rule, data area, user journey, or design
+area. They narrow the search inside an EPIC:
+
+- **Project overview/personas:** pick the candidate EPIC and purpose docs
+  (`rules`, `design`, `data`, `terms`). They intentionally do not enumerate
+  every API/screen/event/schedule; use catalogs or the EPIC Technical Index for that.
+- **epic.md Technical Index:** lists that EPIC's source-near API, screen, event,
+  and schedule spec files with `traceId`. This is the preferred bridge from
+  business context to source-near detail.
+- **UCL:** user action / capability router.
+- **BR:** rule, permission, policy, and constraint router.
+- **DD:** data, model, table, and field router.
+- **Design:** component, API, DB, event, and service connection router.
+
+Business-doc ladder for ambiguous or domain-term questions:
+
+1. Project `overview.md` plus `catalog/epics.md` candidate EPIC rows.
+2. `epics/<epicId>/overview.md` routing context.
+3. Intent doc: BR business rules, DD data dictionary, DESIGN system design, or
+   UCL feature list.
+4. List connected source-near specs before opening details.
+5. Read the source-near detail before code search when exact behavior, screen,
+   response, DB/state, side effect, or absence is being asserted.
+
+When using these docs, prefer item-level `docLinks`, `items[].docLinks`,
+`source_mapping[].documentId`, the EPIC Technical Index, and linked catalog rows
+to choose the relevant `api_spec`, `screen_spec`, `event_spec`, `schedule_spec`,
+and source files. Business-doc prose is routing evidence, not final truth.
+
+Bypass business docs when the question is already anchored to a specific endpoint,
+specific file, specific symbol, specific model field, screen, event, schedule,
+trace id, or exact implementation fact. In those cases, go directly to the
+relevant catalog/spec and source code. In short: go directly to the relevant catalog/spec and source code when the question is already source-near, then use business docs only if semantic scope or cross-feature context is still needed.
+
+## Query Class Routing
+
+After the State Gate, route by question shape before reading details. This keeps retrieval
+bounded and prevents the "CLI is available, so trace first" failure mode.
+
+| Question shape | First hop | Drilldown gate | Stop rule |
+| --- | --- | --- | --- |
+| concept / term meaning | `sot glossary search`, then `catalog/epics.md` | candidate `epic.md` / `design.md` | stop before graph unless implementation is asked |
+| planning / product direction | `catalog/epics.md` | `design.md`, `br.md`, `usecases/ucl.md` | stop after business docs when supported |
+| policy / business rules | `catalog/epics.md` | `br.md`, `usecases/ucs.md`, `data_dictionary.md` | do not infer policy from code alone |
+| user journey / screen flow | `catalog/epics.md` plus `catalog/screens.md` | `design.md`, `usecases/ucl.md`, screen specs | separate journey from implementation |
+| precise API / screen / table impact | static catalog row (`apis.md`, `screens.md`, `tables.md`) | `graph trace` from `traceId` / `serviceMapNodes`, then source snippet | state graph limits and candidates |
+| data field / carrier impact | `catalog/tables.md` or field docs | DB-anchored upstream trace with `accesses_db,calls_api`, then source grep | check read carriers as well as writes |
+| code location | glossary search `codeTerm` or static catalog | `code search` -> nodeId -> optional trace/snippet | never pass `codeTerm` directly to `graph trace` |
+| ambiguous domain term | `sot glossary search` and `catalog/epics.md` | read 2-3 candidate epic folders | qualify or ask if candidates remain tied |
+| negative evidence / missing graph links | static catalog anchor | targeted graph trace returning 0 confirmed | say "no confirmed graph evidence"; never say "no impact" |
+| business docs absent | static catalogs only | graph/code only for static structure | explicitly stop before business policy, journey, or intent |
+
+## Boundary
+
+- **Local transport only:** The SOT Markdown is a read-only projection (`[regen]`).
+  Never edit a file under `~/.platty/sot/`. To change knowledge in local mode,
+  write to the DB with the CLI (`platty memory add ...`) and re-run
+  `platty sot export`. The next export regenerates the MD. In MCP mode, do not
+  touch local projection files or attempt memory writes; use only server-exposed
+  read tools, or stop with a configuration/boundary gap when the needed surface
+  is unavailable.
+- The CLI does not understand natural language and must not be treated like an LLM.
+  Do not use or invent `docs ask` / `docs investigate`, and do not pass a natural-language
+  question to a legacy term-search command.
+- **Discovery is on `name`/`summary`, never on ids.** Frontmatter `id` values are opaque/large
+  (`doc:<projectId>:<type>:<hash16>`, `doc:<nanoid>`, nanoid epic ids). grep readable text;
+  follow ids only after you have the file.
+
+You, the agent, read the catalog, grep terms, follow frontmatter links, choose escalations, and synthesize the answer.
+
+## Red Flags
+
+STOP if you catch yourself thinking any of these:
+
+| Excuse | Reality |
+| --- | --- |
+| "I'll just use a legacy term-search command/`LIKE` for the term and answer from the hit" | The SOT folder is right there. `grep` `catalog/*.md` for the concept (name/summary), then read the detail MD. A term-match hit is not evidence; answering from titles and a score is fabrication. |
+| "I can't read the catalog (folder missing / read failed), so I'll guess from memory" | Do not fabricate. In local mode, either run `platty sot export --project <project>` to (re)create the folder, or fall back to the local advanced recovery CLI graph walk. In MCP mode, stop and report a configuration/boundary gap; do not fall back to local files or CLI. |
+| "The question terms are clear, skip glossary search" | The user may ask in Korean while docs use English, Japanese, or code identifiers. `sot glossary search` maps raw terms and aliases to candidate EPICs and code terms — skipping it is how you pick the wrong EPIC. |
+| "There are hundreds of MD files, I'll open them all to be safe" | Don't brute-force the tree. Use `catalog/*.md` to narrow, read only the named detail files, and for cross-layer reach use `graph trace` — high-cardinality code nodes are intentionally NOT in the MD (use `code search`). |
+| "The doc is stale/orphaned but probably still right — present it as fact" | State `validity` from frontmatter. In local mode, recommend `sync` + `sot export`. In MCP mode, stop and report a configuration/boundary gap, and route refresh work to the full `platty` operator plugin. Do not hide stale evidence. |
+| "I'll edit the MD file to fix the wrong value" | The MD is a `[regen]` projection. Edits are lost on next export. In local mode, write via `platty memory add` then `platty sot export`. In MCP mode, retrieval is read-only: do not edit local MD or attempt memory writes. |
+| "I found the `codeTerm` in glossary search, I'll pass it straight to `graph trace --from`" | A `codeTerm` is a code identifier, NOT a service-map node id. `graph trace --from` needs a node id — first `code search --symbol <codeTerm>` to get the nodeId, then trace from that. Passing the raw `codeTerm` is a dangling-input error. |
+| "I have an epicId/BR id/model id, so I'll pass it directly to graph trace" | EPIC ids, business document ids, item keys, and model ids are not necessarily graph node ids. Run `platty sot resolve` first. Prefer returned source-near `traceId`s. Use model `db:<table>` traces only after explicit scope/full-detail or when the question is a global table/field impact question. |
+| "The query is Korean but I know the English word, I'll skip glossary and trace from my guess" | Cross the language bridge through `sot glossary search` first. Guessing the English/code term skips the canonical/`codeTerm` mapping and traces the wrong (or non-existent) node. |
+| "Business docs exist, but graph trace feels faster, so I'll start there" | Wrong mode for business/planning/policy/journey/concept questions. When valid business docs exist, treat them as the semantic index first for those questions. For development/design-impact questions already anchored to implementation or asking code/impact, use the 4-axis path: targeted static catalog grep + graph traces first, with business docs as semantic scope/constraints. |
+| "The business doc says it, so I'll assert it as fact" | Business docs are an **index, not ground truth**. LLM-generated business docs (`usecases/ucs.md`, `design.md`, `br.md`) can overclaim — an `authenticated user` written up as `owner`/`member-only`/`participant-only`, a minimal `"ok"` response written up as a returned/created record — or lag the source. Before asserting a behavior, actor/permission, response shape, or rule from a business doc, drill into the **connected** `specs/api/<id>.md` / `specs/screen/<id>.md` (via `relatedDocs`/`serviceMapNodes`/`traceId`, **only the related ones**) — and code via `graph trace`/`code search` when the spec is thin — and confirm it there. Assert from the source-near spec/code; cite the business doc as the index that located it. If they disagree, surface the gap. |
+| "The connected spec says the handler persists/broadcasts/returns X, so I don't need to inspect the source" | Specs are source-near but still LLM-authored. If the source handler body is empty, only logs values, returns no value, or is a stub/TODO/not implemented shell, **source code wins**: report that the implementation is not confirmed. Do not trust a spec claim that a stub delegates to a service, persists data, emits events, enforces permissions, or returns a business result unless the code or included shared-module evidence shows it. |
+| "I grepped nearby repos and did not find it, so the project lacks it" | Wrong boundary. Before any absence claim, verify the repo id/path from SOT catalog/spec/code evidence and search only the intended project repository or explicitly state which repo scope was searched. Sibling examples or alternate implementations are not negative evidence for this project. |
+| "Business docs are missing, so retrieval cannot answer anything" | Wrong mode. Static catalogs, graph trace, and code search still answer static-analysis questions; just avoid inventing business rules. |
+| "This domain term means business-doc mode should be active" | Wrong mode. Mode selection comes from generic SOT structure and catalog fields, never domain, fixture, repository, source-path, or EPIC-title terms. |
+| "The glossary/BR already lists them, so that's the complete set — STOP" | **Depth gap.** An enumeration / "what types/values exist" question answered from a glossary or BR list is an *abstraction or partial list*, not the authoritative set. The authoritative enum/constant usually lives in code. Verify against the code enum/constant once (`code search --symbol <EnumOrConstant>`) before STOP. |
+| "The question is clear enough, I'll answer the most likely reading and STOP" | **Width gap.** If a core noun is polysemous, or the intent level is undecided, or a cross-cutting flow spans several targets, the question reads two+ ways. **Expose the split first** ("this reads N ways: (a)… (b)…"); never silently pick one interpretation. For a cross-cutting flow, **count the applicable targets** (enum/grep) before answering. If the answer makes the discarded alternatives invisible, that is a width violation. |
+| "It's a multi-target question but one grep hit covers it, so STOP" | **Macro gap.** A single code grep matches *one mechanism* and misses the set boundary (missing pages, hidden call sites, other mechanisms). For "all / every / which screens / across / each / list of …" questions, build the full map from spec (`relations.navigation` / `relations.api_calls`) / BR **first**, then use code only to verify and fill that map. Going straight to code for a multi-target question is how you deep-dive one mechanism and falsely report "I saw everything". |
+
+## Stop Conditions
+
+- **SOT folder missing AND no EPIC catalog entries exist**: docs/EPICs have not been generated. Route to the generation skills; do not answer from guesses.
+- **A frontmatter `id` you followed does not resolve** to any catalog entry or MD file (dangling link): stop, do not invent the target. Report the mismatch. In local mode, recommend `platty sot export` because the projection may be stale relative to the DB. In MCP mode, stop and report a configuration/boundary gap, and route export/recovery to the full `platty` operator plugin.
+- **The same `id` appears in more than one document** (catalog or frontmatter): stop and report the ambiguity instead of picking one — the projection or DB is inconsistent.
+- **Every candidate document reports `validity: orphaned`** (or `status: deleted`): stop treating their content as evidence; report that the docs no longer map to analyzed sources. In local mode, recommend regeneration + re-export. In MCP mode, stop and report a configuration/boundary gap, and route regeneration/export recovery to the full `platty` operator plugin.
+- **Two full discovery passes** (catalog grep -> detail read -> frontmatter follow) surface no evidence for a subquestion: answer "no evidence found", list what you grepped/read, and stop — do not widen indefinitely or fabricate.
+- **Completeness gate not yet passed**: do NOT STOP on a glossary/BR list, a single interpretation, or a single grep hit until you have run the **Completeness Gate (3 Axes)** below. A plausible partial answer is not an authoritative one. Only a pure definition / naming question ("what does X mean") may STOP at the glossary without the gate.
+
+## Completeness Gate (3 Axes) — Before STOP
+
+The core rule is: **when the evidence is enough, STOP; when it is not, go one step deeper.** But before any STOP, pass these three checks so a plausible partial answer doesn't pass for an authoritative one. The axes are **depth** (did you go down to code where the answer lives), **width** (did the question split and you answered only one branch), and **macro** (is it multi-target but you saw only part of the set). A pure definition / naming question is exempt from all three.
+
+1. **Depth — enumeration / exact-value / structure questions go to code.**
+   - "what types/values exist", "kinds of", "all of", "the list of": a glossary/BR list is an abstraction or partial list. The authoritative enum/constant lives in code — verify it **once** (`platty code search --project <project> --symbol "<EnumOrConstant>"` or worktree grep) before STOP.
+   - "how does it differ / exactly / by what criterion / where": don't STOP at a glossary definition — confirm the actual routing/branch/numeric value in code.
+   - structure / mapping ("tab↔section", "screen↔component"): a glossary's structural description may be abstracted or stale — cross-check the structure against code.
+
+2. **Width — expose ambiguity before answering (do not silently pick one).** A question is ambiguous if any of these hold:
+   - the core noun is polysemous (one word, two domains/meanings),
+   - the intent level is undecided ("tell me about X" = definition vs page/API vs code branch),
+   - a cross-cutting flow spans several targets (one "A→B flow" applies to several types/screens at once).
+
+   When ambiguous, in this fixed order: (a) **expose the split in one line first** ("this reads N ways: (a)… (b)…"); (b) for a cross-cutting flow, **count the applicable targets before answering** (enum/grep: is it one target or several?); (c) then either answer both briefly (if cheap) or answer the most likely reading while naming why it was chosen, naming the discarded reading, and offering to switch. **Forbidden:** silently choosing one branch and finishing. If the discarded interpretation is invisible in the answer, the width axis failed.
+
+3. **Macro — multi-target questions build the spec/BR map first, code verifies.** Triggers (any one ⇒ multi-target): "all / every / which screens / across / each / list of / the whole flow / categorize / …" — if the target set is **not exactly one**, it is multi-target. Mandatory order:
+   1. **Before** any code grep, build the full map from spec (`relations.navigation` / `relations.api_calls`) or BR — fix that as the expected target list.
+   2. Use code **only to verify and fill** that map (grep/snippet each listed item). That is: **spec/BR = map, code = verification.**
+   3. If spec/BR is missing or abstracted/stale, cross-reinforce with code — but never treat "one symbol grep = the whole set" (one grep catches one mechanism only).
+   - **Self-check before STOP:** "Did I check this answer's target set against the spec/BR map? Did I finish on a single grep? Are there other mechanisms / types / screens I haven't accounted for?" — a single page or single symbol is exempt.
+   - **MCP mode:** the macro gate maps to split-tool inventory calls, not shell grep: use `glossary_translate`, then `spec_list`/`spec_search` with `specKind` and scope filters, and then exact `*_get` calls.
+
+## Required Inputs
+
+Resolve these before retrieval:
+
+- Local transport: project selector, then **projectId** via
+  `platty project list --json` (or `platty project use <project>`). The SOT
+  path is `~/.platty/sot/<projectId>/`.
+- MCP transport: the configured project/context identifier from MCP tools such
+  as `project_list` or `context_status`. Do not resolve it by reading local SOT
+  paths or running local CLI commands.
+- User question, classified: `business`, `data`, `development`, `design`, or `mixed`.
+
+## Discovery Flow (Local SOT Markdown)
+
+This section is local-transport-only. In MCP mode, use the configured MCP
+search/get/resolve tools that expose equivalent SSOT, document, spec, glossary,
+and status surfaces. If the server lacks an equivalent surface for a required
+step, stop with a configuration/boundary gap instead of reading local files or
+running local CLI commands.
+
+### 1. Resolve project and locate the SOT folder
+
+```bash
+platty project list --json     # or: platty project use <selector>
+```
+
+Build the absolute path `~/.platty/sot/<projectId>/`. If it does not exist, run:
+
+```bash
+platty sot export --project <project> --json
+```
+
+`sot export` writes the whole tree atomically (temp + rename) and prints
+`{ outDir, lastExportAt, sourceCommit, counts, skipped }`. If `sync` reports the
+DB is stale, run `sync` first; a failed `sync` means the existing MD stays — treat
+its `validity` as the freshness signal.
+
+### 2. Orient with project overview + catalog
+
+Read these first to get the map and solve unknown-unknowns (you don't need to know the term yet):
+
+```text
+~/.platty/sot/<projectId>/overview.md         # project-level business/context map when present
+~/.platty/sot/<projectId>/catalog/epics.md    # epicId | name | summary | documentCount | memories | path
+~/.platty/sot/<projectId>/catalog/apis.md     # apiId | traceId | name | repo | epicIds | validity | status | memories | detailPath | source
+~/.platty/sot/<projectId>/catalog/screens.md  catalog/events.md  catalog/schedules.md  # 동일 스키마 (screenId/eventId/scheduleId | traceId | …)
+~/.platty/sot/<projectId>/catalog/tables.md   # modelId | name | validity | repoId | traceId
+~/.platty/sot/<projectId>/catalog/external-services.md
+~/.platty/sot/<projectId>/project/glossary.index.json # machine glossary index used by CLI/fallback only
+~/.platty/sot/<projectId>/README.md           # layout/freshness audit only, not retrieval evidence
+```
+
+`README.md` is layout/freshness audit only. Do not use `README.md` as retrieval
+evidence for product meaning, EPIC selection, business rules, APIs, screens,
+models, or code behavior.
+
+- **api/screen/event/schedule rows are static** — built from service-map nodes, so they appear **even with no generated docs**. `source=static` means node-only; `source=doc` means an LLM spec enriched the row (then `detailPath`, `epicIds`, `validity`/`status` are filled). apiId is empty for static-only rows.
+- **`traceId` is the `graph trace --from` seed.** grep a row by `name`/`repo`, then trace its cross-layer/cross-repo connections (callers, DB) with `platty graph trace --from <traceId>`. To read the actual source code, go traceId → graph trace (source location), NOT the catalog row.
+- `detailPath` points straight at the detail MD file when a doc exists (empty for static-only) — read it directly, don't reconstruct the hashed filename. The `memories` column flags entities with human knowledge worth reading before you assert.
+
+### 3. Discover candidates with grep (name/summary)
+
+grep the catalog for the user's concept, and use glossary search for raw terms or aliases:
+
+```bash
+grep -in "환불\|refund" ~/.platty/sot/<projectId>/catalog/*.md
+platty sot glossary search --project <project> --query "환불" --json
+```
+
+Pick 1-3 candidate epics/specs by the readable `name`/`summary` columns — not by a single matching word, and never by id (ids are opaque). The catalog is the table of contents; the `Excluded (orphaned/deleted)` section lists audit-only entries you must not treat as live.
+
+#### Glossary cross-lingual search protocol (run at search start)
+
+Before expanding or guessing terms, extract domain terms from the user question
+and cross the language bridge through deterministic glossary search. Include the
+raw term, obvious aliases/synonyms, and Korean/English variants when asking the
+CLI, but treat all glossary hits as routing hints only. Do not guess English terms before glossary search.
+
+1. **Run `sot glossary search` for the raw query term first.** Its matches map the
+   raw term to candidate EPICs, aliases, `canonicalTerm`, and **`codeTerm`** when
+   the generated glossary exposed a code identifier bridge:
+
+   ```bash
+   platty sot glossary search --project <project> --query "<raw term>" --json
+   platty sot glossary search --project <project> --query "환불" --json
+   ```
+
+2. **If the match has a `codeTerm`, do NOT pass it to `graph trace --from`.** A `codeTerm`
+   is a code identifier, **not a service-map node id** — `graph trace --from` expects a
+   node id. Resolve the node id first, then trace:
+
+   ```bash
+   platty code search --project <project> --symbol "<codeTerm>" --json   # -> get the nodeId
+   platty graph trace --project <project> --from <nodeId> --direction upstream|downstream --json
+   ```
+
+3. **If there is no `codeTerm`, use aliases/canonical terms from the matches to expand `docs`/`code search`
+   candidates only — do not assert.** The aliases/synonyms widen discovery; they are not
+   themselves evidence and do not bridge to a code node.
+
+### 4. Read the detail Markdown
+
+Open the named files. Business docs nest under the epic; technical specs are pooled under `specs/`:
+
+```text
+epics/<epicId>/epic.md                         # epic body + relatedDocs (id + role + path)
+epics/<epicId>/br.md  design.md  data_dictionary.md
+epics/<epicId>/usecases/ucl.md  epics/<epicId>/usecases/ucs.md
+epics/<epicId>/memory.md                        # human memories anchored here ([regen])
+specs/api/<fileId>.md  screen/<fileId>.md  event/<fileId>.md  schedule/<fileId>.md
+specs/memory/<fileId>.md                        # spec-anchored memories ([regen])
+```
+
+Each file's frontmatter carries `id`, `name`, `type`, `scope`, `scopeId`, `validity`, `status`, `sourceCommit`, `items[]`, `relatedDocs[]`, and `serviceMapNodes[]`.
+
+### 5. Follow static relations via frontmatter (no CLI hop)
+
+Static doc↔doc, item↔item, and item↔model relations are encoded in frontmatter — follow them by reading the next MD, not by calling the graph CLI:
+
+```text
+epic.md relatedDocs[]      -> {id, role, path}; read `path` directly (the spec filename is a hash)
+items[].docLinks           -> <docId>#<stableKey>
+items[].modelLinks         -> <modelId> (see catalog/tables.md) or <modelId>#<field>
+```
+
+`relatedDocs[].path` and the catalog `path` column give a direct file to read —
+the filename is a hash of the id you cannot recompute, so use the supplied path.
+The destination's frontmatter `id` confirms identity. If a supplied `path` (or a
+followed id) resolves to no file, that is a **Stop Condition** (dangling link) —
+do not invent it; re-run `platty sot export`.
+
+### 6. Escalate to the CLI (computation / cross-layer / writes)
+
+Only these need the CLI; everything static stays in MD:
+
+```bash
+# Cross-layer / multi-repo service-map traversal. --from is any service-map node id:
+# a spec frontmatter `serviceMapNodes` id, OR a catalog id you can grep directly —
+# external-services.md `serviceId` (e.g. external_service:azure_blob) or tables.md `traceId`
+# (the db:<table> id). No spec is needed to start an upstream trace from an external service.
+platty graph trace --project <project> --from <node-id> --direction downstream|upstream --depth <n> --json
+
+# High-cardinality code symbols (intentionally omitted from MD). Matches return
+# filePath / lineStart / lineEnd / signature (the field is `filePath`, not `file`).
+platty code search --project <project> --symbol "<identifier>" --json
+platty code snippet --project <project> --repo <repo-id> --file <path> --lines <start>-<end> --json
+
+# Record human knowledge, then re-project so the MD reflects it.
+platty memory add --project <project> --document <doc-id> [--item-type <item-type> --item-key <stable-key>] --content "<text>" --kind why|correction|constraint|context --json
+platty sot export --project <project> --json
+```
+
+`graph trace` is **known static service-map impact, not complete impact**: it returns
+`omittedEdgeClasses` (ORM includes, indirect writes, event side effects, dynamic URLs) and
+`candidates` (unresolved edges). Assert only `confirmed` edges; treat `candidates` as
+leads to cross-check with `code search`; skip `omitted`. With `--depth N` it accumulates
+per hop and reports `truncated`/`truncatedBy` — never report a trace as an exhaustive blast radius.
+
+`relationCandidates` are separate non-traversable recall hints from business/docs or
+unresolved relation gaps. They are not confirmed impact. Use them after confirmed edges
+for missing-evidence investigations, ambiguous implementation follow-up, or candidate
+code searches. Prefer compact trace output; use `--verbose-candidates` only when the
+candidate evidence text is needed in the final answer.
+
+Graph evidence tiers:
+
+- exact impact answers: answer from `.data.confirmed`; mention `relationCandidates` only as follow-up checks.
+- missing-evidence investigations: inspect `relationCandidates` after confirmed edges.
+- business/planning/policy questions: use the business index first; use graph candidates only for implementation follow-up.
+- never turn `relationCandidates` into confirmed impact without source/code validation.
+
+### Field Addition / Schema Change Design Flow
+
+For requests like "add a field", "change response field", "DB column impact",
+or "design the implementation impact", do not stop at the first screen/API hit:
+
+1. Anchor the user-facing surface from `catalog/screens.md`, the API from
+   `catalog/apis.md`, or the table/model from `catalog/tables.md`.
+2. Read 1-3 relevant business docs (`design.md`, `br.md`,
+   `data_dictionary.md`) to capture semantic constraints and product wording.
+3. Run `graph trace` from the screen/API for confirmed screen -> API flow.
+4. If a persisted field/table is involved, also run a DB/table upstream trace
+   for read carriers. Do this even when the write path is already found.
+5. If the DB/table trace returns no confirmed edges, say "no confirmed graph
+   evidence for this table anchor" and continue through
+   `catalog/relation-candidates.md` plus targeted code search. Do not conclude
+   "no impact" from an empty table trace.
+6. Inspect `relationCandidates` for side-effect classes: `analytics_event`,
+   `cache_access`, `navigation`, `external_service`, `notification`,
+   `event_publish`, and `db_access`. Report them as "candidate checks", not
+   confirmed impact.
+7. Read source snippets only for confirmed nodes or high-value candidates after
+   graph/catalog narrowing.
+
+Default candidate output should be grouped and capped. Use the CLI default
+candidate limit (`20`) for normal impact answers, lower it only for explicitly
+brief summaries (`--candidate-limit 10`), and raise it for side-effect
+completeness checks (`--candidate-limit 50` or a purpose-specific higher cap).
+Group by `kind` and a normalized target label, report
+`relationCandidatesReturned` / `relationCandidatesTotal`, mention
+`relationCandidatesTruncated` when true, and use `--verbose-candidates` only
+when the final answer needs candidate evidence text. If candidates duplicate
+confirmed edges or each other, summarize them as corroborating hints instead of
+separate impacts.
+
+Read **`.data.confirmed`** (flattened across all hops), not `.data.hops[0]` alone — the
+first hop only holds direct neighbors, so reading it alone undercounts multi-hop entry
+points (e.g. a controller two layers above an external-service call). Each confirmed edge
+also carries **`sourceFile` / `sourceLineStart` / `sourceLineEnd`** (the source handler's
+location, joined read-time), so you get the entry point's `file:line` from the trace itself
+— no separate `code search` per entry point.
+
+**Invariant:** the `serviceMapNodes` id in a spec's frontmatter is exactly the `--from`
+input `graph trace` expects. If they disagree, the projection is stale — re-export.
+
+### 7. Freshness
+
+Trust the frontmatter `validity` (`fresh` | `stale` | `orphaned`) and `status`:
+
+- `fresh`: assert normally, cite the file path + frontmatter `id`.
+- `stale`: usable as a clue; state it may not reflect the latest source. In local mode, recommend `sync` + `sot export`. In MCP mode, stop and report a configuration/boundary gap, and route refresh work to the full `platty` operator plugin.
+- `orphaned` / `status: deleted`: do not assert; these are excluded from the body tree and live only in catalog audit sections. In local mode, recommend regeneration. In MCP mode, stop and report a configuration/boundary gap, and route regeneration to the full `platty` operator plugin.
+
+## Business Index Mode
+
+Use this when the State Gate finds live EPIC rows with generated business documents and the question is about business meaning, planning, policy/rules, user journeys, or concepts. Business docs are the semantic index: they define intent, scope, constraints, journeys, rules, and field meaning. Technical specs and graph/code are drill-down surfaces for implementation detail, impact analysis, or gaps.
+
+**Verify business-index claims against the connected spec (index ≠ ground truth).** A business doc routes you to the right entity; it does not certify its own wording. LLM-generated business docs can overclaim — an authentication-only guard written up as `owner`/`member-only`/`participant-only`, a minimal `"ok"` response written up as a returned/created record — or lag the source. So **do not assert a behavior, actor/permission, response shape, or rule from a business doc alone.** For each such claim, follow item-level links first: `items[].docLinks`, `items[].content.source_mapping[].documentId`, `items[].content.detailPath`, then document-level `relatedDocs`/`serviceMapNodes`/`traceId`. Read only the connected `specs/api/<fileId>.md` or `specs/screen/<fileId>.md` for that item — never open specs in bulk — and confirm it there; drill to code via `graph trace`/`code search` when the spec itself is thin. If item-level links are empty for the relevant claim, treat the business doc as an unverified index clue: say the item has no direct source link, use catalog/spec grep to find the nearest source-near evidence, and do not assert the business-doc wording as fact. Assert from the source-near spec/code, citing the business doc as the index that located it. If the connected spec contradicts the business doc, surface the gap and route a `correction` (see Memory Rule); never assert the index's wording over the source.
+
+For development/design-impact questions ("where do I add/change this", "what breaks", code location, precise screen/api/table impact), do not override **Development Design Questions (4-Axis)**. If the question is already anchored to an implementation entity or asks for code/impact, start with targeted static catalog grep + graph traces as that section requires, then read available business docs for semantic scope and constraints.
+
+Discovery order:
+
+1. Start from the user question.
+2. Cross the glossary bridge with `sot glossary search` when raw terms, aliases, or translated concepts may affect EPIC selection.
+3. Use `catalog/epics.md` to identify candidate rows by readable terms, summaries, and `documentCount`.
+4. Read only 1-3 candidate `epics/<epicId>/epic.md` files on the first pass.
+5. Read purpose-selected business docs from those candidate EPIC folders.
+6. Follow item-level links before document-level links: `items[].docLinks`, `items[].content.source_mapping[].documentId`, `items[].content.detailPath`, then `relatedDocs`, `serviceMapNodes`, or `traceId`, only when technical detail is required.
+7. Use graph/code only for implementation, impact radius, or unresolved coverage/freshness gaps.
+
+Purpose-to-document routing:
+
+| Purpose | Read first |
+| --- | --- |
+| concept | `sot glossary search`, `epic.md`, `design.md` |
+| planning | `design.md`, `br.md`, `usecases/ucl.md`, `usecases/ucs.md` |
+| policy/rules | `br.md`, `usecases/ucs.md` |
+| user journey | `design.md`, `usecases/ucl.md` |
+| data/fields | `data_dictionary.md`, `catalog/tables.md`, `catalog/model-links.md` |
+| code location/implementation | when anchored to code/API/screen/table, use the 4-axis path first; otherwise read business docs for intent and constraints, then specs -> graph trace -> code search/snippet |
+| impact radius | when asking precise screen/API/table impact, use the 4-axis path first; otherwise read business docs for semantic scope, then graph trace and code search for graph-invisible leads |
+
+Token/speed budget:
+
+- Catalogs first; do not open EPIC folders until candidate rows are narrowed.
+- Read at most 3 candidate EPIC folders on the first pass.
+- Open only docs matching the question intent.
+- For Business Index Mode answers, name the actual index path used before any
+  source/spec drill-down: glossary search or alias terms checked,
+  `catalog/epics.md` candidate rows, chosen `epics/<epicId>/`, and the selected
+  business docs (`br.md`, `design.md`, `usecases/*`, `data_dictionary.md`)
+  that support the answer.
+- Read technical specs only after scope selection.
+- Run graph/code only when implementation, impact, or unresolved gaps require it.
+- Do not call graph/code just because the CLI is available. For business-only planning, policy, or journey answers, stop after the business docs once the answer is supported.
+- For business-index questions, graph/code is an escalation, not a validation ritual. Escalate only
+  when the answer needs source location, confirmed implementation edges, graph-negative evidence, or
+  a code-level bridge from a `codeTerm`.
+- For static impact or DB questions, graph trace is worth the extra time/tokens only when it adds evidence grep cannot supply: confirmed DB/API/screen edges, source locations, candidates, or negative trace evidence.
+- If a graph/code call does not materially change the answer, treat that as a skill failure in later evals and tighten the routing rule rather than widening searches.
+
+## Static Analysis Mode
+
+Use this when business docs are unavailable, incomplete, or not exported. Do not stall looking for business docs. Static catalogs, graph trace, and code search still support retrieval over observed screens, APIs, tables, external services, schedules, events, and code primitives.
+
+Discovery order:
+
+1. Start from the user question.
+2. Use `sot glossary search` when raw terms, aliases, or translated concepts may affect candidate selection.
+3. Search static catalogs: `catalog/screens.md`, `catalog/apis.md`, `catalog/tables.md`, and `catalog/external-services.md` plus relevant static `events`/`schedules`.
+4. Pick candidate rows by readable `name`/`summary`/`repo` fields, not ids alone.
+5. Trace from `traceId` or `serviceMapNodes` when cross-layer relationships are needed.
+6. Use code search/snippet for high-cardinality symbols, source locations, and graph-invisible leads.
+
+Static-only answers must not invent business rules. Distinguish observed static evidence from product inference, and say when a conclusion is only an implementation or structural observation.
+
+For product/planning questions in Static Analysis Mode, use this exact boundary:
+
+1. Say business docs are absent, incomplete, or unavailable from the SOT state you checked.
+2. List the static surfaces you can inspect (`catalog/apis.md`, `catalog/screens.md`,
+   `catalog/tables.md`, static specs when present, graph trace, code search/snippet).
+3. Answer only the observed implementation structure: APIs, tables, handlers, screens, source
+   locations, and confirmed graph edges.
+4. Stop before product intent, business policy, prioritization, or complete user journeys unless
+   the user explicitly wants a proposal. If proposing, label it as a proposal, not retrieved fact.
+5. If static catalogs are also missing, report the missing projection. In local mode, recommend
+   `sync`/`sot export` or generation. In MCP mode, stop and report a configuration/boundary gap,
+   and route refresh/generation work to the full `platty` operator plugin. Do not widen into
+   unrelated source reads to fabricate a business answer.
+
+## Memory Rule (Local writes only; MCP retrieval is read-only)
+
+Memories are human-recorded knowledge (why, corrections, constraints), projected to
+`epics/<id>/memory.md` and `specs/memory/<fileId>.md` as `[regen]` files:
+
+- Quote them as human-recorded, e.g. "사람이 기록한 메모리에 따르면 …". Do not present memory content as system-derived fact.
+- When a memory contradicts SOT content, present both and flag the conflict. In local mode, recommend `sync`/regeneration. In MCP mode, stop and report a configuration/boundary gap if resolving the conflict requires refresh, regeneration, or memory mutation. Never silently prefer either side.
+- A memory entry with `anchorStale: true` is anchored to an item that no longer exists (renamed/dropped on regen) even though its parent doc may read `fresh` — do **not** assert it as current; surface it. In local mode, recommend re-anchoring (`memory update`/re-add). In MCP mode, stop and report a configuration/boundary gap, and route re-anchoring to the full `platty` operator plugin.
+- If `README.md` reports a `memory/unrouted.md` count (memories whose epic/doc anchor was deleted or regenerated), **read that file** — its memories are NOT reachable from any epic/spec `memory.md`. Surface them. In local mode, recommend re-anchoring. In MCP mode, stop and report a configuration/boundary gap, and route re-anchoring to the full `platty` operator plugin; do not assume the rest of the tree covers them.
+- Local transport only: the MD is a projection, so a `memory add` is invisible here until the next `sot export`. If you just wrote memory, treat `memory.md` as behind until you re-export. To record, use `platty memory add` (with `--export-sot`) then never edit `memory.md` directly. See `platty-memory`.
+- In MCP mode, memory is read-only. You may quote server-exposed memory evidence, but do not attempt local memory writes, project mutation, sync, or export. If the answer requires recording a correction/constraint or re-anchoring memory, stop and report that as a configuration/boundary gap for the MCP profile.
+
+## Development Design Questions (4-Axis)
+
+For "where do I add this", "how do I change this", or "what breaks if I touch this", a single
+read is not enough. **Start cheap and targeted**: grep the catalog (`apis.md`/`screens.md`/`tables.md`)
+to fix entry points + `traceId`s first, then run a *few targeted* graph traces. Spawn subagents only
+when grep + targeted trace genuinely cannot cover it — fanning out one subagent per repo is the main
+cause of slow, token-heavy runs (it does not improve recall over the checklist below). **This whole protocol runs on static-analysis output alone — `catalog/*.md` + the service-map graph + `code search` — so it works even when no business/technical docs have been generated.** Investigate four axes:
+
+1. **Current state** — `specs/<kind>/<fileId>.md` + `epics/<id>/*.md` when those exist; **otherwise `catalog/{apis,screens,tables}.md` + `code search`** (static-only projects have no generated docs).
+2. **Constraints / background** — `epics/<id>/memory.md` / `specs/memory/<fileId>.md` (`constraint`/`correction`/`why`).
+3. **Existing patterns** — `platty code search --symbol` for similar handlers/utilities to reuse.
+4. **Impact / blast radius — BOTH directions.** From the changed entity's node: `platty graph trace --from <serviceMapNodes-id> --direction upstream --depth <n>` (who calls/depends on it). **AND, for a changed table/column, anchor on the db node and trace the READ path too:** `platty graph trace --from db:<table> --direction upstream --kinds accesses_db` — this surfaces the **data carriers**: read handlers that SELECT the entity and map it into a response for a frontend. **To enumerate the affected screens cross-repo in ONE trace, extend that same db-anchored trace with `calls_api` and a depth:** `platty graph trace --from db:<table> --direction upstream --kinds accesses_db,calls_api --depth <n>` returns, in a single call, both the backend handlers that read the entity *and* the frontend screens that call those handlers — across every repo. This is the graph's headline value: do **not** grep each frontend repo for endpoint strings by hand when the trace already joins DB→API→screen for you. (The screen hops can include weaker `suffix_match`/`navigates` edges — those are medium-confidence; keep `calls_api` as the backbone and verify the medium hits.) Fixing only the write path while missing the read carrier means the new field is stored but **never reaches the frontend** (the screen component can be edited but the response payload still lacks the field). Read **all** `.data.confirmed` (not `.hops[0]`); each edge's `sourceFile`/`sourceLineStart`/`sourceLineEnd` gives the entry-point location directly. Carry `omittedEdgeClasses` + `candidates` forward.
+
+**Graph-invisible leaks (hybrid check).** A refactor scope is not complete from the graph alone. `graph trace` only sees nodes joined by a service-map edge; code that bypasses DI has **no edge** and never appears in the trace — a bootstrap/singleton SDK client, a service imported across a module boundary, a `process.env.<X>` read inside a usecase, a polluted/wrong import. This is exactly what `omittedEdgeClasses` warns about. So after the trace, also: `platty code search --symbol "<SDK client / class>"` to surface direct call sites, and — when the analyzed source tree is reachable — grep its imports and `process.env.<PREFIX>_` directly. A trace with zero leaks is not proof there are none; it is the half of the picture the graph can see. Label trace findings (connected impact) vs grep findings (graph-invisible) separately.
+
+**Completeness checklist (run before synthesizing — apply whichever items fit the change).** Recurring blind spots a write-path-only trace misses:
+- **Data carriers (read path):** every read handler that SELECTs the changed entity and returns it to a frontend must also carry the new field (axis 4 read-direction) — otherwise it is stored but the screen shows nothing. Include not just screen queries but **export / report / batch consumers**; when the change's goal is collecting or analyzing data, an export/report path is usually a required carrier. The graph trace surfaces screen carriers cheaply, but **an empty or short trace is NOT proof there are no backend carriers** — a consumer the engine failed to link (no `accesses_db` edge) is graph-invisible (see the hybrid-check rule above). Cross-check with a keyword grep for the change's intent (export / report / download / stats / batch) so a carrier the graph missed still surfaces; never conclude "no export/report path" from the trace alone.
+- **Naming collision (text search, NOT the graph — the graph only sees call/access edges, never identifier reuse):** grep the new identifier — **including the very field name you are about to introduce** — across **all repos and all layers, not just the DB schema**: prisma/SQL models, backend DTOs, **and frontend models/types/components**. If the same name already exists on a *different* path, model, or domain (even a frontend-only type), warn against reuse so data isn't routed to — or rendered from — the wrong place. A DB-schema-only grep misses a name that lives only in a frontend model.
+- **Conditional scope:** if a path is gated (a type/enum branch, a feature flag, a role check), state that scope — never present a one-branch path as if it applies to all.
+- **Derived artifacts:** a schema/contract change usually forces a regen of generated code (DB client, types, API SDK, schema docs). Flag it or downstream builds break.
+
+Then synthesize: concrete **change points** (repo + file + node + layer), the **reusable pattern** (axis 3), an **impact map** labeled known-static-not-complete (axis 4), a **constraint check** against axis-2 memories, and a clear separation of **observed structure (evidence)** vs **recommended design (proposal)**.
+
+## Answer Contract
+
+- Start with the evidence boundary when the project is static-only, mixed, stale, or docs are missing.
+- State the normalized terms used (and the alias bridge from `sot glossary search` when used).
+- Cite MD file paths and frontmatter `id`s; for code, cite repo + file + line.
+- Separate direct evidence from inference.
+- For docs-absent projects, explicitly say "business docs are absent/unavailable" and "static catalogs/graph/code can only support implementation structure." Do not merely imply this by saying "no SOT path."
+- Keep verdicts internally consistent: a summary table's ✅ / "필요" must not contradict the body's confidence label for the same item (don't assert "required" in a table while hedging it as low-confidence in the prose). Pick one and align both.
+- State `validity` for any stale/orphaned evidence.
+- If evidence is weak, name the next step. In local mode, that may be `sot export`, `sync`, `code search`, or regeneration. In MCP mode, name only configured MCP read tools; if the answer instead requires refresh, export, generation, or memory writes, stop and report a configuration/boundary gap, and route to the full `platty` operator plugin.
+
+End with the `Platty handoff` card. `Evidence` lists the MD paths / ids / commands used.
+`Recommended next` is one of: a sharper follow-up from the same evidence surface; in local mode,
+`sync` + `sot export` to refresh or `platty-generated-docs` if outputs need (re)generation; in
+MCP mode, stop and report a configuration/boundary gap, and route refresh/generation work to the
+full `platty` operator plugin.
+
+## Advanced Recovery Fallback: CLI Graph Walk (Local transport only; never MCP)
+
+When `~/.platty/sot/<projectId>/` does not exist and you cannot/should not export it
+in the local transport profile, retrieve directly from the CLI (this is the
+legacy EPIC-centered graph walk). In MCP mode, stop and report a
+configuration/boundary gap instead of falling back to local CLI or local files:
+
+Advanced recovery commands:
+
+```bash
+platty docs glossary digest --project <project> --json     # term unification (aliases)
+platty epics list --project <project> --compact --json      # EPIC catalog (table of contents)
+platty epics show --project <project> --epic <id> --include-docs --json
+platty docs show --project <project> --document <id> --json
+platty docs related --project <project> --document <id> --json
+platty docs targets show --project <project> --id <entry-point-id> --json
+```
+
+The same Red Flags, Stop Conditions, Freshness, and Memory rules apply. Legacy term-search
+commands are hints only — read the catalog before trusting them; answering from a score is fabrication.
+Prefer running `platty sot export` and using the Markdown discovery flow above when possible in
+local transport only. In MCP mode, stop and report a configuration/boundary gap, and route export
+work to the full `platty` operator plugin instead of suggesting local CLI recovery.
+
+## Baseline Pressure Scenarios
+
+Behavioral checks for this skill. `npm run check:*` only verifies file structure — these
+scenarios verify the skill actually changes behavior under pressure. Each scenario names the
+PASS path and the Red (failure) paths it must prevent.
+
+### Scenario: Korean query → code location via glossary bridge
+
+**Input:** A Korean query (e.g. "환불") asking where the corresponding logic lives in code.
+
+**PASS path:**
+
+1. Run `platty sot glossary search --project <project> --query "환불" --json`.
+2. Read the top match's `codeTerm` when present (e.g. `refund`) and candidate EPIC path.
+3. `platty code search --project <project> --symbol refund --json` → obtain the `nodeId`
+   (with `filePath`/`lineStart`/`lineEnd`).
+4. `platty graph trace --project <project> --from <nodeId> ... --json` using that node id.
+
+**Red (any of these is a failure):**
+
+- Putting the `codeTerm` directly into `graph trace --from` (e.g. `--from refund`) — a
+  `codeTerm` is not a service-map node id.
+- Skipping `sot glossary search` entirely and guessing an English term to search/trace.
+- The term has **no** `codeTerm`, yet the answer asserts a code location anyway instead of
+  using aliases/canonical terms only to widen `docs`/`code search` candidates without asserting.
+
+### Scenario: Product question but business docs are absent
+
+**Input:** A product/planning question for a project whose SOT state has static catalogs but no
+generated business docs under `epics/<epicId>/`.
+
+**PASS path:**
+
+1. State that business docs are absent/unavailable from the checked SOT state.
+2. Answer only from static catalogs, graph trace, and source snippets when those are relevant.
+3. Label any product direction as a proposal, or stop before policy/journey/intent if the user asked
+   for retrieved facts.
+4. Mention that graph trace can support static implementation structure but not a complete business
+   journey.
+
+**Red (any of these is a failure):**
+
+- Inventing business rules, prioritization, or complete user journeys from source names.
+- Saying retrieval cannot answer anything even though static catalogs/graph/code can answer
+  implementation structure.
+- Reporting only "SOT path missing" without naming the business-doc absence boundary and the static
+  surfaces that remain available.
+
+### Scenario: "what types/values exist" STOPped at the glossary list (Depth axis)
+
+**Input:** An enumeration question ("what kinds of X are there / list all X") for a project that
+has both a glossary/BR list of X and an authoritative enum/constant in code.
+
+**Trap:** The glossary or BR shows a readable list, so the answer STOPs there and reports that list
+as the complete set. The glossary list is an abstraction / partial list; the authoritative set lives
+in the code enum/constant, and the two can disagree.
+
+**PASS path:**
+
+1. Read the glossary/BR list as the candidate set.
+2. Before STOP, verify against the authoritative enum/constant once:
+   `platty code search --project <project> --symbol "<EnumOrConstant>"` (or worktree grep).
+3. Reconcile: report the code-authoritative set, flagging any item the glossary list missed or added.
+
+**Red (any of these is a failure):**
+
+- Presenting the glossary/BR list as the complete set without checking the code enum/constant.
+- Treating a partial list as authoritative because it "looked complete".
+
+### Scenario: polysemous core noun answered with one silent interpretation (Width axis)
+
+**Input:** A question whose core noun is polysemous (one word, two domains), or whose intent level is
+undecided, or whose flow is cross-cutting across several targets.
+
+**Trap:** The answer silently picks the single most likely reading and finishes, so the discarded
+interpretation never surfaces and the user can't tell a choice was made.
+
+**PASS path:**
+
+1. Expose the split in one line first: "this reads N ways: (a)… (b)…".
+2. For a cross-cutting flow, count the applicable targets (enum/grep) before answering — is it one
+   target or several?
+3. Either answer both briefly, or answer the most likely reading while naming why it was chosen,
+   naming the discarded reading, and offering to switch.
+
+**Red (any of these is a failure):**
+
+- Choosing one branch silently and finishing — the answer makes the discarded reading invisible.
+- For a cross-cutting flow, answering as if it applies to one target without counting the set.
+
+### Scenario: multi-target question answered by a single grep (Macro axis)
+
+**Input:** A multi-target question ("all / every / which screens / across / each / list of …") whose
+target set is spread across several pages / call sites / mechanisms.
+
+**Trap:** A single `code search` / grep matches one mechanism, returns hits, and the answer concludes
+"that's all" — missing the other pages, hidden call sites, and other mechanisms that make up the set.
+
+**PASS path:**
+
+1. Before any code grep, build the full map from spec (`relations.navigation` / `relations.api_calls`)
+   or BR — fix it as the expected target list.
+2. Use code only to verify and fill that map (grep/snippet each listed item): spec/BR = map,
+   code = verification.
+3. If spec/BR is absent or abstracted/stale, cross-reinforce with code, but do not treat one symbol
+   grep as the whole set.
+
+**Red (any of these is a failure):**
+
+- Going straight to code for a multi-target question and reporting the single grep's hits as the set.
+- Deep-diving one mechanism/type/screen and claiming the full set was covered.
+- Concluding "there are no others" from one grep without checking the spec/BR map for the boundary.
+
+### Scenario: business-doc claim asserted without checking the connected spec
+
+**Input:** A business question whose answer touches a behavior, actor/permission, or response shape
+that a business doc (`usecases/ucs.md` / `design.md` / `br.md`) states more strongly than the source
+supports — e.g. the doc reads "only the workspace owner can manage members" while the connected API
+spec shows the route only checks an authentication guard, or the doc says an upload "returns the
+created record" while the endpoint returns `"ok"`.
+
+**Trap:** The business doc reads cleanly, so the answer asserts its wording verbatim as fact and STOPs,
+never opening the connected `specs/api|screen/<id>.md` the doc points to. Business docs are an index;
+their claims are LLM-generated and can overclaim or lag.
+
+**PASS path:**
+
+1. Use the business doc as the index to locate the relevant entity (`relatedDocs` / `serviceMapNodes` / `traceId`).
+2. Read the **connected** `specs/api/<fileId>.md` or `specs/screen/<fileId>.md` (only the related one), and when it is thin, drill to code via `graph trace` / `code search`.
+3. Assert the behavior / actor-permission / response shape from the source-near spec/code, citing the business doc only as the index that found it. If the spec and the business doc disagree, surface the gap and route a `correction` (Memory Rule).
+
+**Red (any of these is a failure):**
+
+- Asserting a behavior, actor/permission, or response shape from a business doc without confirming it in the connected spec/code.
+- Opening unrelated specs in bulk instead of only the connected one(s) the business doc points to.
+- Presenting the business doc's wording as ground truth when the connected spec shows a weaker reality.
+
+### Scenario: connected spec overclaims an empty handler
+
+**Input:** A question about an API whose connected `specs/api/<fileId>.md` claims implemented behavior, but the source handler body is empty, only logs, returns nothing, or is a stub/TODO/not implemented shell.
+
+**PASS path:**
+
+1. Use the spec to locate the handler/source path.
+2. Inspect the handler source when the claim matters.
+3. If the source handler is empty or stub-like, **source code wins**: answer that the implementation is not confirmed, and name the spec/source mismatch.
+4. Continue with another source-backed implementation of the same capability only if the catalog/spec map shows one; keep the stub variant separate.
+
+**Red (any of these is a failure):**
+
+- Treating the spec's prose as authoritative when the handler body is empty.
+- Claiming a stub delegates to a service, persists data, emits events, checks permissions, or returns a business result without visible source evidence.
+- Merging a complete implementation from another file/repo variant into the stub route without saying they are different targets.

--- a/plugins/platty/skills/platty-retrieval/references/bug-diagnosis.md
+++ b/plugins/platty/skills/platty-retrieval/references/bug-diagnosis.md
@@ -1,0 +1,22 @@
+# Bug Diagnosis Retrieval Guide
+
+Use for "why is this bug happening?", "user says X failed", incident triage, regression suspicion, and investigation-order questions.
+
+## First Hops
+
+1. Identify the product flow and entry point: screen, API, event, batch, or external service.
+2. Read source-near specs and relevant business rules only to form hypotheses.
+3. Trace the flow across API, DB, events, batches, external services, and read carriers.
+4. Inspect source snippets for the highest-risk branch or guard.
+
+## Required Coverage
+
+- Ordered hypotheses, not a single asserted root cause.
+- Checks from user symptom -> entry point -> state table/log -> side effects -> downstream carrier.
+- Tables/logs/events/batches to inspect.
+- Source anchors for any concrete failure mechanism.
+- Explicit "not confirmed" boundary for unverified causes.
+
+## Stop Rule
+
+Do not claim a definitive root cause without direct evidence. Unsupported root-cause certainty should be treated as a quality failure.

--- a/plugins/platty/skills/platty-retrieval/references/business-policy.md
+++ b/plugins/platty/skills/platty-retrieval/references/business-policy.md
@@ -1,0 +1,21 @@
+# Business Policy / Rule Guide
+
+Use for business rules, policy, permissions, constraints, eligibility, validation, and documented behavior.
+
+## First Hops
+
+1. Use glossary search and `catalog/epics.md` to pick the business area.
+2. Read `br.md`, `usecases/ucl.md`, `usecases/ucs.md` when present, and relevant `design.md`.
+3. Follow only question-relevant item-level links or `sot resolve --item` to connected API/screen/model specs.
+4. Confirm actor, permission, response shape, side effect, table impact, or enforcement in source-near spec/code before asserting it as implementation fact.
+
+## Required Coverage
+
+- Rule/policy text and path.
+- Connected implementation evidence when claiming enforcement or exact behavior.
+- Actor/permission boundary.
+- Difference between business intent, generated doc wording, and source-confirmed behavior.
+
+## Stop Rule
+
+Business docs are an index, not ground truth. If connected source evidence is absent, label the rule as documented intent or generated-doc evidence, not confirmed enforcement.

--- a/plugins/platty/skills/platty-retrieval/references/code-search.md
+++ b/plugins/platty/skills/platty-retrieval/references/code-search.md
@@ -1,0 +1,21 @@
+# Code Search Guide
+
+Use for concrete files, symbols, snippets, implementation locations, handlers, DTOs, models, constants, or source absence.
+
+## First Hops
+
+1. If the user gives business language, run glossary search, `catalog/epics.md`, and the relevant epic context first to find code terms.
+2. If the user gives a source-near term, use `code search --symbol` or targeted worktree grep, then map the result back to its catalog/EPIC context when available.
+3. For a `codeTerm` from glossary, run `code search` first; do not pass it directly to `graph trace`.
+4. Use `code snippet` or direct source read for the exact lines.
+
+## Required Coverage
+
+- Repo, file path, symbol, and line range.
+- Why this symbol/file matches the question.
+- Similar names or false positives distinguished.
+- Absence scope when not found: exact repos/paths searched and terms used.
+
+## Stop Rule
+
+Do not answer code-location questions from SOT titles alone when source access is allowed. Do not claim absence from sibling repos or one grep term.

--- a/plugins/platty/skills/platty-retrieval/references/concept-search.md
+++ b/plugins/platty/skills/platty-retrieval/references/concept-search.md
@@ -1,0 +1,36 @@
+# Concept / Term Search Guide
+
+Use for concept, terminology, ambiguous Korean/English terms, product vocabulary, and "how are these different?" questions.
+
+## First Hops
+
+1. Preserve the raw user phrase.
+2. Run glossary search for each raw term and the combined phrase.
+3. Read `catalog/epics.md` to find product areas by readable name/summary.
+4. Read 1-3 candidate epic `overview.md` / `design.md`; use `br.md` or `usecases/ucl.md` only when the question asks rules or flows.
+5. If the concept has an enum/codeTerm, verify it once with `code search` or source grep before treating the set as complete.
+
+## Ambiguity Rule
+
+If a term can mean a label, menu/list, enum/model value, business concept, or implementation branch, expose the split before answering. Do not silently pick one meaning.
+
+## Required Coverage
+
+- Raw term and normalized/canonical term.
+- Candidate product areas or epics.
+- User-facing labels when relevant.
+- Backend enum/model/source term when relevant.
+- List/scope evidence when a label includes multiple backend types.
+- Adjacent lifecycle/state area when the concept is an action domain: participation, tracking, enrollment, progress, history, log, or join records.
+- Explicit unknowns if the term is only partially evidenced.
+
+For "how are these different?" comparison questions, make a compact concept table:
+
+| Concept / candidate | Product area | Source-near anchor | Scope boundary |
+| --- | --- | --- | --- |
+
+Do not treat participation/tracking as incidental when the compared concepts are campaigns, missions, enrollments, applications, orders, rewards, or workflows. If a separate lifecycle/tracking epic, table, API, or source model exists, include it as its own row or explicitly say it was not found.
+
+## Stop Rule
+
+A pure naming question may stop after glossary + epic catalog. A comparison/difference question must verify the actual product areas and at least one implementation or source-near anchor when claiming how they differ.

--- a/plugins/platty/skills/platty-retrieval/references/cross-epic-flow.md
+++ b/plugins/platty/skills/platty-retrieval/references/cross-epic-flow.md
@@ -1,0 +1,21 @@
+# Cross-Epic / Multi-Area Flow Guide
+
+Use for flows spanning several epics, product areas, actors, screens, APIs, tables, events, or batches.
+
+## First Hops
+
+1. Use glossary search and `catalog/epics.md` to identify all candidate product areas.
+2. Read the overview/design docs for 1-3 relevant epics.
+3. Use catalogs and `sot resolve` to find source-near specs for each area.
+4. Use graph trace only after anchors are fixed.
+
+## Required Coverage
+
+- Primary area and secondary areas.
+- The bridge: API, screen, event, table, schedule, external service, or shared model.
+- Confirmed vs candidate cross-area links.
+- Missing bridge evidence when not confirmed.
+
+## Stop Rule
+
+Do not report a cross-epic flow from one epic's prose alone. A cross-epic answer needs a bridge artifact or an explicit "bridge not confirmed" statement.

--- a/plugins/platty/skills/platty-retrieval/references/design-change.md
+++ b/plugins/platty/skills/platty-retrieval/references/design-change.md
@@ -1,0 +1,87 @@
+# Design / Change Retrieval Guide
+
+Use this reference for questions like:
+
+- "what must change if we add X?"
+- "what breaks if we touch X?"
+- "where do we patch this?"
+- "add a new type/status/category/classification"
+- "this bug exists; where should I investigate?"
+
+## Core Rule
+
+A design/change answer is not a single lookup. It must produce a bounded impact map:
+
+1. **Current state** — source-near specs and business docs when present; otherwise static catalogs, `sot resolve`, graph trace, and code search.
+2. **Constraints / background** — memories, business rules, design docs, stale/unknown boundaries.
+3. **Existing patterns** — similar handlers, DTOs, components, tests, migrations.
+4. **Impact / blast radius** — upstream callers and read carriers, not just write paths.
+
+Start from the EPIC/product area, then descend only through question-relevant purpose docs and connected specs. BR/design/UCL/data docs route the search; source-near specs and source/code prove exact behavior or impact. Start cheap and targeted: grep generated spec catalogs (`apis.md`, `screens.md`) and static catalogs (`tables.md`, `external-services.md`) to fix entry points and `traceId`s before broad code search.
+
+## Type / Status / Category Changes
+
+For requests that add or change a **type, status, category, workflow state, tier, role, channel, or classification**, do not treat it as a single enum edit. Build this mandatory coverage table before final prose:
+
+| Axis | Status | Evidence |
+| --- | --- | --- |
+| Primary entity | covered / not found | table/model/API/screen that owns the value |
+| Grouping / segmentation | covered / not found | group, cohort, segment, bundle, schedule bucket, routing table |
+| Participation / tracking | covered / not found | participation, assignment, enrollment, progress, history, log, audit, state transition |
+| Preset / configuration | covered / not found | preset, template, default setting, seeded constant, rule/mission config |
+| Management surfaces | covered / not found | admin create/edit/list/detail screens and APIs |
+| Consumer surfaces | covered / not found | user/seller/customer screens, read APIs, exports/reports, batches, notifications, events, external integrations |
+| Tests / generated artifacts | covered / not found | enum tests, DTO/API schema, client types, migrations, seed data, fixtures, E2E, generated SDK/docs |
+
+**Evidence requirement:** an axis is not covered just because it is named. Each covered axis needs a concrete anchor: catalog row, spec path, resolver row, graph trace row, source file:line, or test file:line. If no anchor is found, write `not found in checked surfaces` and list the searches/surfaces checked.
+
+## Grouping / Segmentation Search
+
+For grouping/segmentation, check `catalog/tables.md` before source grep.
+
+Generate candidates from the primary entity and glossary/code terms:
+
+- singular/plural forms
+- snake_case forms
+- `<primary>_groups`
+- `<primary>_group`
+- `<primary>_segments`
+- `<primary>_segment`
+- model names ending in `Group` or `Segment`
+
+If `catalog/tables.md` has an exact row, cite that row or its `db:<table>` trace seed before discussing related screens/APIs. A related team/cohort screen is not enough when a concrete group table/model exists.
+
+## Read Carrier / Blast Radius
+
+For a changed table/column, trace both directions:
+
+```bash
+platty graph trace --project <project> --from <serviceMapNodes-id> --direction upstream --depth <n> --json
+platty graph trace --project <project> --from db:<table> --direction upstream --kinds accesses_db,calls_api --depth <n> --json
+```
+
+The DB-anchored trace surfaces read handlers and frontend screens that call those handlers. If it is empty or short, do not conclude "no read carriers"; cross-check with targeted code search for export/report/download/stats/batch terms.
+
+## Graph-Invisible Checks
+
+Graph trace misses code that bypasses service-map edges. After graph/catalog narrowing, run code search for:
+
+- SDK clients or singleton imports
+- direct service/class imports
+- `process.env.<PREFIX>_` reads
+- exports/reports/batches
+- generated DTO/client/type artifacts
+
+Label graph evidence as connected impact and grep/code-search evidence as graph-invisible candidates.
+
+## Final Answer Shape
+
+1. Evidence boundary and freshness.
+2. Coverage table with every applicable axis.
+3. Confirmed change points grouped by axis.
+4. Existing pattern to reuse.
+5. Known-static-not-complete impact map.
+6. Constraints and unknowns.
+7. Proposed implementation order.
+
+Do not STOP after the primary enum/model and one admin screen. A named-but-uncited axis is partial, not covered.

--- a/plugins/platty/skills/platty-retrieval/references/exact-api.md
+++ b/plugins/platty/skills/platty-retrieval/references/exact-api.md
@@ -1,0 +1,26 @@
+# Exact API Retrieval Guide
+
+Use for exact endpoint, response shape, request params, side effects, permissions, or "what does this API return/do?" questions.
+
+## First Hops
+
+1. Grep `catalog/apis.md` for the exact method/path or nearest path fragment.
+2. Keep the row's `epicIds`; read `catalog/epics.md` and the matching epic `overview.md` or directly connected BR/design item only for semantic/product context.
+3. Read only the matching `specs/api/<file>.md`.
+4. Use the spec's source file/handler evidence or `serviceMapNodes` / catalog `traceId` to inspect source when behavior, params, response shape, writes, emits, permissions, or absence matters.
+5. Run graph trace only if the question asks callers, DB, external calls, screens, or side effects.
+
+## Required Coverage
+
+- Exact method and path.
+- Controller/handler/usecase source anchor.
+- Request params/body/query if asked or visible.
+- Response payload shape or explicit "not confirmed".
+- Side effects: DB read/write, event, external service, notification, cache, queue.
+- Permissions/guards if asked or relevant.
+- Epic/product context from the matched API row's `epicIds`.
+- Boundary: spec/source mismatch, missing response envelope, graph omissions.
+
+## Stop Rule
+
+Do not spend broad search time in epics for an exact API, but do keep the matched row's EPIC context. Do not answer from API catalog title alone. If the spec and source disagree, source wins and the mismatch must be stated.

--- a/plugins/platty/skills/platty-retrieval/references/impact-tracing.md
+++ b/plugins/platty/skills/platty-retrieval/references/impact-tracing.md
@@ -1,0 +1,37 @@
+# Impact / Trace Retrieval Guide
+
+Use for screen-to-api, api-to-screen, DB impact, shared table, event flow, external integration, batch, and cross-layer blast-radius questions.
+
+## First Hops
+
+1. Identify the relevant EPIC/product area from `catalog/epics.md`, glossary, or the matched catalog row's `epicIds`; use EPIC docs to route, not to prove exact impact.
+2. Anchor the entity in the right catalog:
+   - API: `catalog/apis.md`
+   - screen: `catalog/screens.md`
+   - table/model: `catalog/tables.md`
+   - event: `catalog/events.md`
+   - schedule/batch: `catalog/schedules.md`
+   - external service: `catalog/external-services.md`
+3. Read the matching source-near spec when present.
+4. Trace from the catalog `traceId`, spec `serviceMapNodes`, `db:<table>`, or external service id.
+
+## Trace Rules
+
+- Use upstream for callers/read carriers.
+- Use downstream for effects/dependencies.
+- For DB impact, run `db:<table>` upstream with `accesses_db,calls_api` when frontend/read carriers matter.
+- Read `.data.confirmed` first; treat `candidates` and `relationCandidates` as leads, not confirmed impact.
+- Carry `flags.omittedEdgeClasses`, truncation, and empty-trace boundaries into the answer.
+
+## Required Coverage
+
+- Anchor and trace seed.
+- EPIC/product-area context.
+- Confirmed edges by kind.
+- Candidate/omitted limitations.
+- Source path when exact code impact is claimed.
+- Shared-table warning when table fanout is broad.
+
+## Stop Rule
+
+Never convert "no confirmed graph evidence" into "no impact". For high-fanout tables, narrow by epic, API, screen, or model before reporting blast radius.

--- a/plugins/platty/skills/platty-retrieval/references/negative-evidence.md
+++ b/plugins/platty/skills/platty-retrieval/references/negative-evidence.md
@@ -1,0 +1,22 @@
+# Negative Evidence / Coverage Boundary Guide
+
+Use for "does this exist?", "is there no impact?", "why can't we find it?", graph gaps, missing docs, and coverage-boundary questions.
+
+## First Hops
+
+1. State the evidence surface checked: SOT freshness, catalogs, specs, graph, code, memories.
+2. Search exact term, aliases, canonical terms, and likely code terms.
+3. Check the right catalog before source grep.
+4. If graph returns no confirmed edges, inspect candidates/omitted/truncation flags.
+
+## Required Coverage
+
+- Search scope and terms.
+- Surfaces checked.
+- Whether absence is "not confirmed" or "not present in checked scope".
+- Next evidence needed to make a stronger absence claim.
+- Stale/orphaned/missing-doc boundary when relevant.
+
+## Stop Rule
+
+Do not say "does not exist" unless the searched scope is complete for the claim. Prefer "not found in checked surfaces" for partial evidence.

--- a/plugins/platty/skills/platty-retrieval/references/screen-search.md
+++ b/plugins/platty/skills/platty-retrieval/references/screen-search.md
@@ -1,0 +1,22 @@
+# Screen / Route Search Guide
+
+Use for screens, pages, routes, UI entry points, navigation, screen specs, or "where is this page?" questions.
+
+## First Hops
+
+1. Grep `catalog/screens.md` for route, title, component, label, or product term.
+2. Read the matching `specs/screen/<file>.md`.
+3. If the question asks behavior, follow screen relations to APIs/navigation from the spec or `graph trace` using the screen `traceId`.
+4. Use source snippets only after the screen/spec route is narrowed.
+
+## Required Coverage
+
+- Screen route/path and source repo/file.
+- Screen spec path.
+- Similar screens distinguished.
+- API calls/navigation/side effects when requested.
+- Source component anchor when exact implementation location is requested.
+
+## Stop Rule
+
+Do not claim all related screens from one route hit. For "which screens/all screens", build the target set from `catalog/screens.md` and relations before source grep.

--- a/plugins/platty/skills/platty-sdd-design/SKILL.md
+++ b/plugins/platty/skills/platty-sdd-design/SKILL.md
@@ -36,6 +36,12 @@ This skill may author files only inside the selected SDD output directory. It mu
 
 Use the Platty CLI convention from `using-platty`. Inside this repository, `AGENTS.md` overrides public plugin examples: run the local build with `node packages/cli/dist/main.js <command> --json`.
 
+Gather SOT-grounded and source evidence through `platty-retrieval` (SOT
+projection, `platty sot resolve/glossary search`, `graph trace`, `code
+search/snippet`). Consume the Design Decision Handoff from
+`../using-platty/references/sdd-question-ownership.md`, and when design evidence
+changes the approved product result, feed feasibility back to `platty-sdd-spec`.
+
 ## Evidence Flow
 
 1. Read `prd.md` and `user_stories.md`. Treat a new-session handoff containing
@@ -112,6 +118,29 @@ lint, or migration convention. Follow an observed convention unless the design
 names an intentional deviation and its reason.
 
 Do not infer a framework, ORM, vendor, or repository layout from another project.
+
+## Design Decision Handoff
+
+The product phase preserves each unresolved implementation choice as a Design
+Decision Handoff (see `../using-platty/references/sdd-question-ownership.md`).
+Consume every handoff item and resolve it into an implementation-ready decision:
+
+- Resolve reversible, source-grounded `DESIGN` items yourself from SOT/source
+  evidence via `platty-retrieval`, and record the selected option, its
+  `invariantUserResult`, and the confirming evidence in `system_design.md`.
+- Escalate to a technical owner only when the choice materially changes cost or
+  operational responsibility, security or privacy, data loss, irreversible
+  migration, or the approved product result — not for ordinary implementation
+  alternatives.
+- Never re-ask a non-developer to choose an API, DB, field, enum, migration,
+  cache, query, tie-breaker, component, file, or test.
+
+Feasibility feedback: if design evidence shows the approved product result is not
+feasible or must change, return a feasibility feedback packet to
+`platty-sdd-spec` instead of silently closing it as a technical decision. The
+design is implementation-ready only when every handoff item is resolved or
+explicitly escalated, and every affected code path is confirmed or named as
+risk.
 
 ## Authoring
 

--- a/plugins/platty/skills/platty-sdd-spec/SKILL.md
+++ b/plugins/platty/skills/platty-sdd-spec/SKILL.md
@@ -57,6 +57,12 @@ Reader boundary:
 
 Use the Platty CLI convention from `using-platty`. Inside this repository, `AGENTS.md` overrides public plugin examples: run the local build with `node packages/cli/dist/main.js <command> --json`.
 
+Gather SOT-grounded evidence through `platty-retrieval` (read the SOT projection,
+`platty sot resolve/glossary search`, `graph trace`, `code search/snippet`).
+Before returning any question, classify every unresolved item with
+`../using-platty/references/sdd-question-ownership.md` as `FACT`, `PRODUCT`, or
+`DESIGN`, and run the Adaptive Product Interview below.
+
 ## Evidence Flow
 
 1. Project and SOT state:
@@ -85,30 +91,51 @@ frontmatter paths. Graph trace accelerates scope discovery; it is not exhaustive
 proof and must not by itself establish a write, permission, transaction, response
 shape, or absence of impact.
 
-## Question Loop
+## Adaptive Product Interview
 
-Ask at most three questions at a time. Prefer one question if the answer changes later questions.
+Do not use a fixed question cap. Ask one question at a time and keep going until
+no material `PRODUCT` decision remains. A specific request over a safe,
+reversible existing product flow may need zero questions; a complex policy may
+need many. Follow `../using-platty/references/sdd-question-ownership.md` and
+maintain the runtime-only `decisionLedger`, `productInterviewRounds`, and
+`remainingProductDecisions` state; stop only when `remainingProductDecisions` is
+empty.
 
-Every question should include:
+Question ownership and the non-developer boundary:
 
-- what SOT evidence suggests;
-- why the answer matters;
-- a recommended default;
-- what the default would imply.
+- `FACT` — source-confirmable existing behavior. Resolve it from SOT/source via
+  `platty-retrieval`; never ask the user (a non-developer) to guess it, and
+  never turn a `code search` miss into a negative fact.
+- `PRODUCT` — a choice that changes the visible user result, target user,
+  policy, money, permission, notification, or irreversible outcome. Apply a safe
+  recommendation when one clearly fits; otherwise ask exactly one plain-language
+  product question.
+- `DESIGN` — API, DB, field, enum, migration, cache, query, tie-breaker,
+  component, file, or test choice that preserves the approved result. Preserve
+  it as a Design Decision Handoff for `platty-sdd-design`; do not ask a
+  non-developer to choose it.
 
-Question categories:
+Each `PRODUCT` question uses product language and shows what SOT evidence
+suggests, why it matters, a recommended default, and what the default would
+imply — never an API/DB/field/implementation choice:
 
-- scope: users, entry points, clients, repos;
-- policy: eligibility, limits, permissions, approvals;
-- journey: normal path, empty states, edge paths, rollback/retry;
-- data: source of truth, fields, retention, migration;
-- compatibility: existing BR/UC conflicts, deprecated flows;
-- success: measurable validation and release criteria.
+```text
+정해야 할 것: <사용자에게 보이는 선택>
+추천: <권장안>
+이유: <현재 제품 근거와 사용자 영향>
+달라지는 점: <다른 선택의 사용자 관점 차이>
+```
 
-Confirmed answers go to `§6 Confirmed Decisions`. Unresolved items stay in `§7 Open Questions`.
-When unresolved items affect stories, write the stories from clearly named
-recommended defaults or assumptions and include an assumptions/impact section in
-`user_stories.md` so later edits know what must change.
+Prioritize `remainingProductDecisions` by material user effect: (1) target user,
+eligibility, surface, journey; (2) money, rewards, permissions, privacy,
+notification, irreversible state; (3) cadence, duplication, limits, exceptions,
+failure; (4) reversible feedback or operator preference.
+
+Confirmed answers go to `§6 Confirmed Decisions`. Unresolved items stay in `§7
+Open Questions`. When unresolved items affect stories, write the stories from
+clearly named recommended defaults or assumptions and include an
+assumptions/impact section in `user_stories.md` so later edits know what must
+change. Final product approval is a separate gate, not an interview round.
 
 ## Output Language
 

--- a/plugins/platty/skills/using-platty/references/sdd-question-ownership.md
+++ b/plugins/platty/skills/using-platty/references/sdd-question-ownership.md
@@ -1,0 +1,242 @@
+# SDD Question Ownership (Local)
+
+Use this contract for local, MCP-free SDD retrieval, product specs, and technical
+design. Its purpose is to preserve evidence and approval safety without asking a
+non-developer to choose implementation details.
+
+Local evidence comes from the exported SOT projection and the local CLI through
+`platty-retrieval`: SOT files under `~/.platty/sot/<projectId>/`, `platty sot
+resolve/glossary search`, `platty graph trace`, and `platty code search/snippet`.
+Wherever this contract needs "existing behavior," that means SOT/source evidence
+gathered locally, never a guess.
+
+## Contents
+
+- Core Rule and Classification Test
+- FACT Handling and Safe PRODUCT Recommendation
+- Adaptive Product Interview
+- PRODUCT Question Shape and DESIGN Handoff
+- Metrics Boundary, Product Draft And Review Gate, and Red Flags
+
+## Core Rule
+
+Classify every unresolved item before asking the user:
+
+| Class | Meaning | Owner | Default action |
+| --- | --- | --- | --- |
+| `FACT` | Existing product or implementation behavior that local SOT/source evidence can confirm | retrieval | Read the required SOT/source evidence; never ask the user to guess it |
+| `PRODUCT` | A choice that changes the visible user result, target user, policy, scope, money, permission, notification promise, or irreversible outcome | SDD spec | Apply a safe recommendation when one clearly fits; otherwise ask one plain-language product question |
+| `DESIGN` | API, DTO, DB, index, migration, cache, query, sort implementation, tie-breaker, component, file, test, deployment, or rollback choice that preserves the approved user result | SDD design | Preserve it in the design handoff; do not ask it during product drafting |
+
+The labels are runtime coordination metadata. Do not add them to persisted
+frontmatter or expose them in the first user-facing review by default.
+
+## Classification Test
+
+Apply these questions in order:
+
+1. Can local SOT document, spec, glossary, graph, or bounded `code snippet`
+   evidence establish the answer as existing behavior? Classify it as `FACT`.
+2. Would different answers change what the user or operator sees, can do, pays,
+   receives, is allowed to do, or cannot undo? Classify it as `PRODUCT`.
+3. Would different answers preserve the approved visible result and differ only
+   in implementation or operation? Classify it as `DESIGN`.
+4. If an item spans classes, split it. Do not promote a technical sub-question
+   into a product decision merely because it is attached to one.
+
+Examples:
+
+| Item | Class | Reason |
+| --- | --- | --- |
+| Whether an active Home Banner is already ordered by priority | `FACT` | Existing behavior is source-confirmable from SOT/code |
+| Whether the highest-ranked eligible notice appears as the first home banner | `PRODUCT` | It defines the promised visible result |
+| Whether notices reuse a table or use a new table | `DESIGN` | Either can preserve that result |
+| How equal ranks are broken | `DESIGN` unless users receive a promised ordering guarantee | Normally an implementation contract |
+| Whether all users or only a segment see the notice | `PRODUCT` | Target experience changes |
+| Which endpoint, DTO, cache, component, or test implements it | `DESIGN` | Implementation detail |
+
+## FACT Handling
+
+- Use local SOT/source evidence before asking the user.
+- Complete only the evidence rungs required to establish the relevant fact and
+  its boundary. Do not use call volume as proof of completeness.
+- If a required SOT surface or source read is unavailable, record the exact
+  coverage limit (for example, missing spec, stale export, or no confirmed
+  graph edge).
+- A missing fact becomes retrieval coverage or a design Evidence-Resolution
+  item. It does not become a request for the non-developer to select an API,
+  field, enum, query, or source path.
+- Never convert a `code search` miss into a negative fact.
+
+## Safe PRODUCT Recommendation
+
+Apply a recommendation to the draft before asking when all are true:
+
+- the user's requested visible result is specific;
+- current product evidence supports one existing host flow or policy;
+- the recommendation is reversible;
+- it does not introduce a materially different money, permission, security,
+  privacy, legal, notification, data-loss, or operational promise;
+- competing choices are primarily implementation alternatives.
+
+Record an adopted recommendation as the current product decision and close its
+matching product question. A future revisit condition does not keep the current
+decision open.
+
+Ask before drafting only when two or more `PRODUCT` choices remain genuinely
+tied and their user-visible consequences are materially different. Technical
+possibility alone is not a tie.
+
+## Adaptive Product Interview
+
+Use one question at a time and no arbitrary question limit. Product discovery
+ends because the product result is complete, not because a numeric budget has
+expired. A specific request with a safe, reversible existing product flow may
+still need zero questions; a complex policy may need five, ten, or more.
+
+Maintain this runtime-only state:
+
+```text
+- decisionLedger: every resolved, recommended, or open PRODUCT decision
+- productInterviewRounds: ordered question, answer, evidence read, and effect
+- remainingProductDecisions: ranked unresolved PRODUCT decisions
+- stopReason: zero unresolved PRODUCT decisions | waiting for product answer |
+  capability gap
+```
+
+Run the loop in this order:
+
+1. Before deep or full-cycle SOT retrieval, ask only when the raw request itself
+   has a materially different user-visible interpretation whose answer changes
+   the evidence branch. The question must not assert an existing-system fact or
+   ask for an implementation choice. A time-based reward with unstated cadence
+   is one such case: once-per-visit/window and repeated-threshold earning are
+   different economic policies.
+2. Narrow the retrieval scope from the answer, read the SOT/source evidence
+   needed for that branch, then reclassify every unresolved item as `FACT`,
+   `PRODUCT`, or `DESIGN`.
+3. Apply safe recommendations and update `decisionLedger`. If
+   `remainingProductDecisions` is non-empty, ask its highest-priority item in
+   plain language, record the answer, research only the newly affected boundary,
+   and reclassify again.
+4. Stop interviewing only when there are zero unresolved `PRODUCT` decisions.
+   Do not ask a filler question. `FACT` work and `DESIGN` handoff items are not
+   reasons to continue the product interview.
+
+The final product approval after the reviewed drafts are saved is a separate
+gate. It is not an interview round and cannot retroactively close an unresolved
+product decision.
+
+### Question Priority
+
+Rank `remainingProductDecisions` by material user effect:
+
+1. target user, eligibility, product surface, and journey continuity;
+2. money, rewards, permissions, privacy, notification, and irreversible state;
+3. cadence, duplication, limits, exceptions, and failure behavior;
+4. reversible feedback or operator preference.
+
+A safe existing limit or policy may be adopted as a recommendation. It must not
+displace an unresolved surface, journey, eligibility, or reward decision merely
+because the existing default is easier to confirm.
+
+## PRODUCT Question Shape
+
+Ask exactly one question at a time and use product language:
+
+```text
+정해야 할 것: <사용자에게 보이는 선택>
+추천: <권장안>
+이유: <현재 제품 근거와 사용자 영향>
+달라지는 점: <다른 선택의 사용자 관점 차이>
+```
+
+Do not put API, DB, field, enum, migration, cache, query, tie-breaker,
+component, file, test, source parity, or internal SDD ids in this question.
+Explain an unavoidable technical constraint through its user or operational
+effect first.
+
+## DESIGN Handoff
+
+Preserve each `DESIGN` item instead of discarding it or turning it into a
+product blocker:
+
+```text
+Design Decision Handoff
+- item:
+- approvedProductIds:
+- invariantUserResult:
+- evidenceKnown:
+- evidenceMissing:
+- candidateOptions:
+- riskClass: reversible | cost | security | privacy | data-loss | irreversible | product-change
+- recommendedNextRead:
+```
+
+The SDD design phase resolves reversible, source-grounded items itself and
+records the selected option as a technical decision. Ask a technical owner only
+when the choice materially changes cost or operational responsibility, security
+or privacy, data loss, irreversible migration, or the approved product result.
+
+If design evidence changes the approved product result, return a feasibility
+feedback packet to SDD spec. Do not close that change as a technical decision.
+
+## Metrics Boundary
+
+- A numeric promise visible to users or required to approve policy is
+  `PRODUCT`.
+- Baseline collection and a later decision rule are not a product blocker when
+  the approved visible result is unchanged; preserve them as design/operations
+  work.
+- Instrumentation, event schema, data pipeline, dashboard, and query details are
+  `DESIGN`.
+- Never ask the user to invent an unknown baseline merely to fill a template.
+
+## Product Draft And Review Gate
+
+When no tied `PRODUCT` choice remains:
+
+1. Resolve `FACT` items or record their evidence boundary.
+2. Apply safe `PRODUCT` recommendations.
+3. Preserve `DESIGN` handoffs.
+4. Draft and review the planning documents before the approval request.
+5. Present one plain-language review:
+
+```text
+이번에 바뀌는 것
+- <사용자 관점 변화 3~5개>
+
+제가 적용한 추천안
+- <평이한 결정과 이유>
+
+확인이 필요한 충돌
+- <없음 또는 진짜 PRODUCT 충돌>
+
+이 방향으로 기획을 승인할까요?
+```
+
+Before sending that review, run a wording audit. Rewrite code-field names and
+implementation vocabulary into the user's product language even when the saved
+draft preserves the exact identifier as evidence. For example, say `가장 우선인
+공지` rather than ``priority``. The first review contains no backticked
+identifier unless the user explicitly needs that exact public name to make a
+product decision. Raw workflow status values remain in the persisted artifacts
+and are shown only on request.
+
+Explicit product approval, revision binding, impact coverage, design approval,
+and task gates remain unchanged. Fewer questions must not weaken those gates.
+
+## Red Flags
+
+- Asking the user to confirm a source-checkable existing fact.
+- Offering "reuse the existing API/table" versus "create a new one" as a
+  product choice when the visible result is the same.
+- Blocking product drafts on ordering implementation, tie-breakers, cache,
+  migrations, file locations, or test commands.
+- Hiding a real money, permission, notification, privacy, or irreversible
+  product choice inside technical design.
+- Dropping technical uncertainty instead of handing it to design.
+- Treating a long SOT investigation or many CLI calls as a reason to expose raw
+  implementation terminology in the first review.
+- Leaving a field name such as ``priority`` in the plain-language approval
+  summary when `가장 우선인` conveys the same product result.


### PR DESCRIPTION
## What

Restore the local `platty-retrieval` skill and bring the SDD skills up to the
adaptive product-interview model — all on the local (MCP-free) transport where
Claude reads the exported SOT Markdown projection directly.

## Changes

- **Restore `platty-retrieval`** (SKILL.md + 10 case references). Discovery is
  grep/read over `~/.platty/sot/<projectId>/`; computation, cross-layer
  traversal, and writes escalate to `platty sot resolve`, `graph trace`, and
  `code search/snippet`. Remote MCP retrieval stays with `platty-mcp`.
- **Add `using-platty/references/sdd-question-ownership.md`** — FACT/PRODUCT/
  DESIGN classification and an adaptive product interview (one question at a
  time, no fixed cap) so non-developers are never asked to pick implementation.
- **`platty-sdd-spec` / `platty-sdd-design`** — wire evidence gathering to
  `platty-retrieval` and the question-ownership contract; replace the fixed
  question cap with the adaptive interview; add a design-decision handoff and
  feasibility-feedback loop.
- **`platty-cli-router`** — route local retrieval/search questions to
  `platty-retrieval`.

## Notes

- Local transport only — no MCP tools. All referenced skills exist in this repo
  (no dangling references).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 로컬 프로젝트 자료를 기반으로 코드, 개념, API, 화면, 영향 범위를 검색하고 추적하는 표준 검색 가이드를 추가했습니다.
  * 버그 원인 분석과 변경 영향 검토에서 근거, 검색 범위, 미확정 사항을 명확히 확인할 수 있습니다.
  * 설계 문서 작성 시 제품 결정과 기술 결정을 구분하고, 필요한 질문을 단계적으로 진행합니다.

* **문서 개선**
  * 로컬 검색과 원격 조회 절차를 분리하고, 부정확한 단정과 근거 없는 결론을 방지하는 검증 규칙을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->