### PR TITLE
Document onboarding language and Codex compatibility

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -182,6 +182,17 @@ Use Platty to analyze this repository. Start with platty:using-platty.
 The agent should use the Platty skills to choose the next workflow and explain
 what it is doing.
 
+## Choose The Onboarding Language
+
+Onboarding uses your current conversation language. To choose a language
+explicitly, append the instruction to the invocation. If the conversation
+language is unclear, onboarding defaults to Korean.
+
+```text
+$platty:platty-onboarding . 한국어로 진행해줘
+$platty:platty-onboarding . Continue in English.
+```
+
 ## Troubleshooting
 
 ### `platty` is not found
@@ -210,6 +221,23 @@ npm install -g @paradigmshift/platty
 ```
 
 Then open a new terminal and try `platty version` again.
+
+### Codex needs an update for plugin installation
+
+If `platty install` reports `AGENT_RUNTIME_UPDATE_REQUIRED` or Codex rejects
+`--json`, update Codex using its supported installation method, then retry:
+
+```bash
+codex update
+platty install --runtime codex --json
+```
+
+If updating is not currently possible, use the manual fallback:
+
+```bash
+codex plugin marketplace add paradigmshift-labs/platty
+codex plugin add platty@platty
+```
 
 ### The agent does not mention Platty skills
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -64,6 +64,14 @@ $platty:platty-onboarding .
 
 `.`은 AI 에이전트의 현재 작업 디렉터리에 있는 저장소를 뜻합니다.
 
+온보딩은 현재 대화 언어로 진행됩니다. 언어를 명시하려면 호출 뒤에 원하는 언어를
+적어 주세요. 대화 언어가 명확하지 않으면 한국어로 진행합니다.
+
+```text
+$platty:platty-onboarding . 한국어로 진행해줘
+$platty:platty-onboarding . Continue in English.
+```
+
 일반 문장으로 요청해도 됩니다:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ $platty:platty-onboarding .
 
 `.` means the repository in your AI assistant's current working directory.
 
+Onboarding uses your current conversation language. To choose a language
+explicitly, append the instruction to the invocation. If the conversation
+language is unclear, onboarding defaults to Korean.
+
+```text
+$platty:platty-onboarding . 한국어로 진행해줘
+$platty:platty-onboarding . Continue in English.
+```
+
 You can also ask in plain language:
 
 ```text

--- a/plugins/platty/skills/platty-onboarding/SKILL.md
+++ b/plugins/platty/skills/platty-onboarding/SKILL.md
@@ -11,14 +11,15 @@ Coordinate the installed first-run journey. This skill does not install the CLI 
 
 ## Conversation Language
 
-Determine the conversation language from the user's request at the start. Use
-Korean when the request is Korean, mixes Korean and English, or is ambiguous
-enough that the language cannot be inferred. Use English when the request is in
-English or the user explicitly asks for English. Keep every user-facing
-progress update, explanation, question, approval card, and completion or
-failure report in that language across all routed owner skills. Preserve
-commands, paths, project and repository names, provider values, ids, and error
-codes verbatim.
+Determine the conversation language from the user's request at the start. An
+explicit language instruction takes precedence. Otherwise use Korean when the
+request is Korean, mixes Korean and English, or is ambiguous enough that the
+language cannot be inferred. Use English when the request is in English. Do not
+infer the response language from the repository's source language. Keep every
+user-facing progress update, explanation, question, approval card, and
+completion or failure report in that language across all routed owner skills.
+Preserve commands, paths, project and repository names, provider values, ids,
+and error codes verbatim.
 
 For the shared Start Notice, Progress Checkpoint, and Handoff Card, translate
 all human-readable labels and headings into the conversation language while


### PR DESCRIPTION
## Summary
- document Korean and English onboarding invocation examples in both READMEs and Getting Started
- default ambiguous onboarding conversations to Korean while honoring explicit language instructions
- document Codex runtime update and manual plugin-install fallback for AGENT_RUNTIME_UPDATE_REQUIRED / rejected --json

## Safety
- limited to README.md, README.ko.md, GETTING_STARTED.md, and platty-onboarding/SKILL.md
- public plugin safety gate passed with no forbidden files or content
- preserved newer public retrieval, SDD, and onboarding guidance outside this change

## Verification
- npm run check:agent-skills
- npm run check:agent-marketplace
- node --test tests/export-public-plugin-repo.test.mjs
- git diff --check