### PR TITLE
docs: explain skill refresh and default branch setup

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -61,6 +61,10 @@ platty install
 Use `platty install --runtime codex` or `platty install --runtime claude` when
 you want to target one runtime explicitly.
 
+Rerun `platty install` whenever you want to update an existing Platty plugin to
+the latest published skills. After installation or refresh, start a new Codex
+or Claude Code session.
+
 ### Codex manual fallback
 
 ```bash
@@ -165,9 +169,11 @@ platty init
 platty project list
 platty project create "My Project" --description "Repository analysis workspace"
 platty project use PROJECT
-platty repo add REPOSITORY_PATH --project PROJECT
+platty repo add REPOSITORY_PATH --project PROJECT --branch main
 platty status --project PROJECT
 ```
+
+Use `master` instead of `main` when `master` is the repository's default branch.
 
 Follow the `Next:` line printed by `platty status` or by the previous command.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -43,7 +43,9 @@ npm install -g @paradigmshift/platty  # CLI 설치
 platty install                        # 에이전트 스킬 등록
 ```
 
-설치가 끝나면 새 AI 에이전트 세션을 시작하세요.
+기존 Platty 플러그인을 갱신하려면 `platty install`을 다시 실행해 최신 게시
+스킬을 받으세요. 설치 또는 갱신 후에는 새 Codex 또는 Claude Code 세션을
+시작하세요.
 
 ### 2. 온보딩 시작
 
@@ -112,6 +114,10 @@ platty install                        # 에이전트 스킬 등록
 `platty@platty` 플러그인을 감지된 모든 런타임에 설치합니다. 특정 런타임만
 선택하려면 `platty install --runtime codex` 또는
 `platty install --runtime claude`를 사용하세요.
+
+기존 Platty 플러그인을 갱신하려면 `platty install`을 다시 실행해 최신 게시
+스킬을 받으세요. 설치 또는 갱신 후에는 새 Codex 또는 Claude Code 세션을
+시작하세요.
 
 Codex 수동 설치 대안:
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ npm install -g @paradigmshift/platty  # Install the CLI
 platty install                        # Register the agent skills
 ```
 
-Start a new AI assistant session after installation.
+Rerun `platty install` whenever you want to update an existing Platty plugin to
+the latest published skills. After installation or refresh, start a new Codex
+or Claude Code session.
 
 ### 2. Start onboarding
 
@@ -117,6 +119,10 @@ platty install                        # Register the agent skills
 ordinary `platty@platty` plugin into every detected runtime. To target one
 runtime explicitly, use `platty install --runtime codex` or
 `platty install --runtime claude`.
+
+Rerun `platty install` whenever you want to refresh an existing Platty plugin
+to the latest published skills. After installation or refresh, start a new
+Codex or Claude Code session.
 
 Manual fallback for Codex:
 

--- a/plugins/platty/skills/platty-cli-router/SKILL.md
+++ b/plugins/platty/skills/platty-cli-router/SKILL.md
@@ -32,7 +32,7 @@ in `platty-mcp-server-setup`.
 | Need | Command or skill |
 | --- | --- |
 | Answer a question about the analyzed codebase locally (domain terms, epics, docs, specs, code locations, source confirmation) | `platty-retrieval` (read SOT projection + `platty sot resolve/glossary search`, `graph trace`, `code search/snippet`) |
-| Install ordinary Platty agent skills (non-MCP agent plugin) | `platty install --json`; MCP installation stays separate |
+| Install or refresh ordinary Platty agent skills (non-MCP agent plugin) | `platty install --json`; restart the agent session after success; MCP installation stays separate |
 | Installed first end-to-end project journey through repositories, analysis, LLM approval, and SOT output | `platty-onboarding` |
 | Initialize global Platty home (`~/.platty` or `PLATTY_HOME`) | `platty init` via `platty-setup` |
 | Create/select a project | `platty project ...` via `platty-setup` |

--- a/plugins/platty/skills/platty-onboarding/SKILL.md
+++ b/plugins/platty/skills/platty-onboarding/SKILL.md
@@ -60,7 +60,12 @@ When the user selects a project, or supplies the project name and short descript
 for a new one, create or select it and run `repo list` before every
 `repo add`. Reuse every verified registration and add only missing repositories
 or source roots. For each new registration collect the repository path, display name, analysis branch, and optional source root. Follow the owner skill's
-default-versus-current branch gate when the branch is omitted.
+default-versus-current branch gate when the branch is omitted: resolve
+`origin/HEAD`, then an existing `main`, then an existing `master`; recommend the
+verified default branch, normally `main` or `master`; present a differing
+current branch second as an explicit alternative instead; wait for confirmation;
+then pass the confirmed value as `--branch <branch>`. Never silently register a
+feature checkout.
 
 Before choosing registrations, inspect the Git root, root manifest, workspace declaration or metadata, and nested app or package manifests. When one Git root has no usable root manifest or workspace declaration but contains multiple independently analyzable nested app manifests, register the same absolute Git repository path once per app with a distinct `--source-root` and unique display names. Do not register application subdirectories as the repository path. Pass an explicit `--branch` on each registration and keep the `repo list`-before-add invariant.
 

--- a/plugins/platty/skills/platty-setup/SKILL.md
+++ b/plugins/platty/skills/platty-setup/SKILL.md
@@ -247,15 +247,12 @@ Branch rule:
 - If the user says analysis should use `main`, the default branch, or any named
   branch, include `--branch <branch>` in `repo add`; do not assume `analyze`
   will move the source checkout.
-- If the user does not name a branch, inspect the repository's current checkout
-  and default-branch candidate before registering it. Prefer `origin/HEAD`,
-  then `main`, then `master` as the default-branch candidate.
-- If the default-branch candidate differs from the current checkout, ask the
-  user which branch Platty should analyze: the default branch, usually `main`,
-  or the current branch. Do not register the repository until the branch choice
-  is explicit.
-- After the user chooses, pass the chosen branch explicitly with
-  `--branch <branch>`.
+- When the user omits the analysis branch, resolve `origin/HEAD`, then an
+  existing `main`, then an existing `master`. Recommend that verified default
+  candidate, normally `main` or `master`. If the current branch differs,
+  present it second as an explicit alternative instead. Wait for confirmation,
+  then pass the confirmed value explicitly as `--branch <branch>`; never
+  silently register the feature checkout.
 - If a repository is already registered on the wrong branch, fix the
   registration before analysis:
 

--- a/plugins/platty/skills/using-platty/SKILL.md
+++ b/plugins/platty/skills/using-platty/SKILL.md
@@ -149,11 +149,13 @@ command, stop and tell the user to reinstall or update the global @paradigmshift
 
 ## Ordinary Agent Plugin Installation
 
-Use `platty install --json` when the user wants to install the ordinary non-MCP
-Platty agent plugin after installing the global CLI. The command detects Codex
-and Claude Code, preserves existing installs, and installs `platty@platty` at
-user scope. Use `--runtime codex`, `--runtime claude`, or `--runtime all` only
-when the user or automation needs an explicit target.
+Use `platty install --json` when the user wants to install or refresh the
+ordinary non-MCP Platty agent plugin after installing the global CLI. The
+command detects Codex and Claude Code, installs a missing `platty@platty`
+plugin, and updates an existing installation from the registered marketplace.
+Use `--runtime codex`, `--runtime claude`, or `--runtime all` only when the user
+or automation needs an explicit target. Start a new agent session after a
+successful install or refresh so the updated skills are loaded.
 
 The separate `platty-mcp` plugin is never installed by `platty install`. Keep
 MCP client registration and MCP-only skill installation on the separate
@@ -182,15 +184,12 @@ Branch rule:
 - If the user names an analysis branch, including `main`, `master`, `develop`,
   or a feature branch, pass it through `--branch`. Do not rely on the source
   checkout being on that branch.
-- If the user does not name a branch, inspect the repository's current checkout
-  and default-branch candidate before `repo add`. Prefer `origin/HEAD`, then
-  `main`, then `master` as the default-branch candidate.
-- If the default-branch candidate differs from the current checkout, ask the
-  user which branch Platty should analyze: the default branch, usually
-  `main`, or the current branch. Do not register the repository until the
-  branch choice is explicit.
-- After the user chooses, include the chosen branch in `repo add` or
-  `repo update` with `--branch <branch>`.
+- When the user omits the analysis branch, resolve `origin/HEAD`, then an
+  existing `main`, then an existing `master`. Recommend that verified default
+  candidate, normally `main` or `master`. If the current branch differs,
+  present it second as an explicit alternative instead. Wait for confirmation,
+  then pass the confirmed value to `repo add` or `repo update` as
+  `--branch <branch>`; never silently register the feature checkout.
 - `platty analyze` uses the repository registration's stored analysis branch
   and prepares an app-managed worktree from that branch. It does not repair an
   omitted branch from `repo add`.


### PR DESCRIPTION
## Summary
- explain that rerunning `platty install` refreshes existing Codex/Claude agent skills
- require a new runtime session after install or refresh in English and Korean docs
- show explicit `--branch main` manual registration with `master` guidance
- teach ordinary Platty skills to recommend verified `origin/HEAD`, then `main`, then `master`, while keeping the current branch as an explicit alternative

## Safety
- narrow forward patch on current public `main`
- changed paths limited to README.md, README.ko.md, GETTING_STARTED.md, and four `plugins/platty/skills/**` files
- public plugin release safety gate: passed, 0 blocking issues
- no npm release or version change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 기존 Platty 플러그인을 최신 스킬로 갱신하려면 `platty install`을 다시 실행하고 새 Codex 또는 Claude Code 세션을 시작하도록 설치 안내를 보강했습니다.
  * 저장소 등록 시 기본 브랜치로 `main`을 우선 안내하고, 저장소 설정에 따라 `master`를 사용할 수 있도록 설명을 추가했습니다.

* **개선 사항**
  * 저장소 브랜치 생략 시 `origin/HEAD`, `main`, `master` 순으로 후보를 확인하고 사용자 승인 후 등록하도록 안내를 명확히 했습니다.
  * 설치 또는 갱신 완료 후 최신 스킬을 적용하려면 새 에이전트 세션을 시작하도록 명시했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->