### PR TITLE
Guide adaptive onboarding document concurrency

### DIFF
--- a/plugins/platty/skills/platty-generated-docs/SKILL.md
+++ b/plugins/platty/skills/platty-generated-docs/SKILL.md
@@ -92,6 +92,48 @@ Keep the selected provider for the whole generated-docs workflow. If
 asked to review EPICs before confirmation. Preserve the same provider flags when
 reconstructing a command.
 
+## Local CLI Technical-Docs Concurrency
+
+Apply the same technical-document LLM concurrency policy to Codex CLI
+(`codex_cli`) and Claude Code CLI (`claude_code`). Start either local CLI
+provider with:
+
+```bash
+platty generate-docs run --project <project> --provider <provider> --docs-llm-concurrency 10 --json
+```
+
+`--docs-llm-concurrency 10` is the total in-flight LLM-call budget for
+`build_docs` compaction and final technical-document generation. It is not the
+repository count, target count, document-worker count, or business-document
+worker count. Keep EPIC and business-document worker defaults unchanged. This
+policy does not apply to `claude_api`; its behavior remains unchanged.
+
+Reduce the current budget only when command output or failed-task evidence
+shows concurrent provider pressure: HTTP `429` or an explicit rate limit,
+provider capacity or concurrency-limit errors, or repeated connection,
+transport, or provider timeout failures across concurrently running tasks. Use
+the exact sequence `10 -> 5 -> 2`. Make at most two automatic concurrency
+reductions in one generated-docs workflow.
+
+Every reduction is same-run recovery, not a fresh generation run. Follow the
+primary active-work or `retry_failed_tasks` action for the existing stage and
+run id, then resume worker-backed generation with the lower
+`--docs-llm-concurrency` value. Preserve `--project`, `--stage`, `--run-id`,
+`--provider`, `--model`, every `--fallback-model`, timeout and progress flags,
+and `--json`. Preserve saved and validated tasks; never use `--full`,
+`--new-run`, or `--force-regenerate` for a concurrency reduction. When a
+returned worker-bearing resume command omits the current execution-only
+concurrency value, reconstruct that command with the current value rather than
+silently returning to the default of `2`.
+
+Do not lower or reduce concurrency for malformed JSON or schema output,
+document validation, grounding or evidence gaps, missing EPIC assignment,
+business-rule coverage, one deterministic task failure, or a status/report
+poll failure. Use the existing repair-first, model-fallback, or polling path
+for those failures. If verified provider pressure remains at `2`, stop after
+the second reduction and report the exact stage, run id, failed tasks, provider
+error evidence, current concurrency, and next recovery action.
+
 ## Public Workflow
 
 Inspect targets before generation:
@@ -103,7 +145,7 @@ platty targets list --project <project> --json
 Start or resume public generated-output work:
 
 ```bash
-platty generate-docs run --project <project> --json
+platty generate-docs run --project <project> --provider <local-provider> --docs-llm-concurrency 10 --json
 ```
 
 With an explicit provider choice:

--- a/plugins/platty/skills/platty-onboarding/SKILL.md
+++ b/plugins/platty/skills/platty-onboarding/SKILL.md
@@ -130,7 +130,12 @@ field labels into the conversation language; keep machine values verbatim.
 - **Provider:** show the resolved CLI provider value.
 - **Availability:** show the verified `command -v` executable path.
 - **Parallel work:** state that independent document tasks can run through
-  multiple workers concurrently.
+  multiple workers concurrently. State that both Codex CLI and Claude Code CLI
+  start technical-document LLM work with `--docs-llm-concurrency 10`, which is
+  a total technical-document LLM-call budget rather than a document-worker
+  count. Explain that verified provider pressure may reduce it through
+  `10 -> 5 -> 2` while leaving EPIC and business-document worker defaults
+  unchanged.
 - **Automatic continuation:** state that technical documents continue through
   EPIC drafting, returned-command EPIC confirmation, and business documents
   without another routine approval.
@@ -156,10 +161,18 @@ Wait for explicit approval. Static-analysis completion is not LLM approval.
 Use `platty-generated-docs`. After approval run:
 
 ```bash
-platty generate-docs run --project <project> --provider <resolved-provider> --json
+platty generate-docs run --project <project> --provider <resolved-provider> --docs-llm-concurrency 10 --json
 ```
 
 The explicit flag satisfies the provider gate; do not ask a duplicate provider question. Preserve `--project`, `--stage`, `--run-id`, `--provider`, model flags, and `--json` in every continuation or recovery command.
+
+For both `codex_cli` and `claude_code`, preserve the current
+`--docs-llm-concurrency` value in every worker-bearing continuation or recovery
+command. Use the owner skill's provider-pressure rule to reduce the same run
+only through `10 -> 5 -> 2`, with at most two automatic reductions. Do not ask
+for another approval when lowering concurrency. Never lower it for JSON/schema,
+document-validation, grounding, EPIC-assignment, deterministic task, or poll
+failures; keep those on the existing repair-first or polling path.
 
 Continue technical docs -> EPIC draft -> EPIC auto-confirm -> business docs without asking the user to select EPICs. A valid returned `confirm-epics` command is automatic unless the user explicitly requested manual review. If EPIC confirmation is required but the confirmation command or run id is missing, stop instead of guessing.
 


### PR DESCRIPTION
## Summary
- start Codex CLI and Claude Code CLI technical-document generation at concurrency 10
- reduce only on verified provider pressure through 10 → 5 → 2 while preserving the same run
- keep validation recovery and EPIC/business worker defaults unchanged

## Verification
- source onboarding contract tests: 21/21
- public export tests: 8/8
- public release library tests: 18/18
- both shipped skills pass quick validation
- live clean-state Slack clone replay: technical docs 14/14, EPIC work 4/4, business-doc work 81/81, failures 0

This replaces closed broad export PR #48; this PR intentionally contains only the two requested skill files.