### PR TITLE
chore: release Platty plugin 0.0.5

### DIFF
--- a/plugins/platty/.claude-plugin/plugin.json
+++ b/plugins/platty/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platty",
   "description": "Shared Platty CLI and documentation workflow skills for Codex and Claude Code.",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": {
     "name": "Paradigm Shift Labs"
   },

--- a/plugins/platty/.codex-plugin/plugin.json
+++ b/plugins/platty/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platty",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Shared Platty CLI and documentation workflow skills for Codex and Claude Code.",
   "author": {
     "name": "Paradigm Shift Labs"


### PR DESCRIPTION
## Summary
- bump the hook-free ordinary Platty plugin to 0.0.5
- allow existing Codex and Claude installations to refresh instead of reusing the 0.0.4 cache

## Verification
- claude plugin validate plugins/platty
- Codex and Claude manifests both report 0.0.5
- hook entrypoint files remain absent